### PR TITLE
Bayesian HP optimization

### DIFF
--- a/slideflow/__init__.py
+++ b/slideflow/__init__.py
@@ -10,7 +10,7 @@
 
 __author__ = 'James Dolezal'
 __license__ = 'GNU General Public License v3.0'
-__version__ = "1.1.4-dev1"
+__version__ = "1.2.0-dev0"
 
 import os
 

--- a/slideflow/errors.py
+++ b/slideflow/errors.py
@@ -153,3 +153,6 @@ class TileCorruptionError(Exception):
 class ModelParamsNotFoundError(Exception):
     def __init__(self):
         super().__init__('Model parameters file (params.json) not found.')
+
+class SMACError(Exception):
+    pass

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -2274,9 +2274,8 @@ class Project:
                 accept the epoch results dict and return a float value. If
                 a str, must be a valid metric, such as  'tile_auc',
                 'patient_auc', 'r_squared', etc.
-
-        Keyword Args:
-            All keyword arguments used in Project.train() are accepted.
+            train_kwargs (dict):  Dict of keyword arguments used for the
+                Project.train() function call.
 
         Raises:
             errors.SMACError: If training does not return the designated metric.
@@ -2324,7 +2323,8 @@ class Project:
         params: ModelParams,
         smac_configspace: "ConfigurationSpace",
         smac_metric: str = 'tile_auc',
-        **train_kwargs
+        smac_limit: int = 10,
+        **train_kwargs: Any
     ) -> None:
         """Train a model using SMAC3 bayesian hyperparameter optimization.
 
@@ -2333,6 +2333,8 @@ class Project:
             params (ModelParams): Model parameters for training.
             smac_configspace (ConfigurationSpace): ConfigurationSpace to
                 determine the SMAC optimization.
+            smac_limit (int): Max number of function evaluations to perform
+                during optimization. Defaults to 10.
             smac_metric (str, optional): Metric to monitor for optimization.
                 May either be a callable function or a str. If a callable
                 function, must accept the epoch results dict and return a
@@ -2341,7 +2343,8 @@ class Project:
                 Defaults to 'tile_auc'.
 
         Returns:
-            _type_: _description_
+            Configuration: Optimal hyperparameter configuration returned
+            by SMAC4BB.optimize()
         """
 
         from smac.facade.smac_bb_facade import SMAC4BB
@@ -2350,7 +2353,7 @@ class Project:
         # Create SMAC scenario.
         scenario = Scenario({
             'run_obj': 'quality', # Optimize quality (alternatively: runtime)
-            'runcount-limit': 3,  # Max number of function evaluations
+            'runcount-limit': smac_limit,  # Max number of function evaluations
             'cs': smac_configspace
         })
         smac = SMAC4BB(

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -7,8 +7,10 @@ import multiprocessing
 import os
 import pickle
 from os.path import basename, exists, join
+from statistics import mean
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
+                    Union)
 
 import numpy as np
 from tqdm import tqdm
@@ -24,6 +26,7 @@ from slideflow.util import log, path_to_name
 
 if TYPE_CHECKING:
     import pandas as pd
+    from ConfigSpace import ConfigurationSpace
 
     from slideflow.model import DatasetFeatures, Trainer
 
@@ -2252,6 +2255,119 @@ class Project:
     def save(self) -> None:
         """Saves current project configuration as "settings.json"."""
         sf.util.write_json(self._settings, join(self.root, 'settings.json'))
+
+
+    def _get_smac_runner(
+        self,
+        outcomes: Union[str, List[str]],
+        params: sf.ModelParams,
+        metric: Union[str, Callable],
+        train_kwargs: Any
+    ) -> Callable:
+        """Builds a SMAC3 optimization runner.
+
+        Args:
+            outcomes (str, List[str]): Outcome label annotation header(s).
+            params (sf.ModelParams): Model parameters for training.
+            metric (str or Callable): Metric to monitor for optimization.
+                May be callable function or a str. If a callable function, must
+                accept the epoch results dict and return a float value. If
+                a str, must be a valid metric, such as  'tile_auc',
+                'patient_auc', 'r_squared', etc.
+
+        Keyword Args:
+            All keyword arguments used in Project.train() are accepted.
+
+        Raises:
+            errors.SMACError: If training does not return the designated metric.
+
+        Returns:
+            Callable: tae_runner for SMAC optimization.
+        """
+
+        def smac_runner(config):
+            """SMAC tae_runner function."""
+
+            # Load hyperparameters from SMAC configuration and train model.
+            params.load_dict(dict(config))
+            results = self.train(
+                outcomes=outcomes,
+                params=params,
+                **train_kwargs
+            )
+
+            # Interpret results.
+            model_name = list(results.keys())[0]
+            last_epoch = sorted(list(results[model_name]['epochs'].keys()))[-1]
+            if len(results[model_name]['epochs']) > 1:
+                log.warning(f"Ambiguous epoch for SMAC. Using '{last_epoch}'.")
+            epoch_results = results[model_name]['epochs'][last_epoch]
+
+            # Determine metric for optimization.
+            if callable(metric):
+                return metric(epoch_results)
+            elif metric not in epoch_results:
+                raise errors.SMACError(f"Metric '{metric}' not returned from "
+                                       "training, unable to optimize.")
+            else:
+                if outcomes not in epoch_results[metric]:
+                    raise errors.SMACError(
+                        f"Unable to interpret metric {metric} (epoch results: "
+                        f"{epoch_results})")
+                return 1 - mean(epoch_results[metric][outcomes])
+
+        return smac_runner
+
+    def smac_search(
+        self,
+        outcomes: Union[str, List[str]],
+        params: ModelParams,
+        smac_configspace: "ConfigurationSpace",
+        smac_metric: str = 'tile_auc',
+        **train_kwargs
+    ) -> None:
+        """Train a model using SMAC3 bayesian hyperparameter optimization.
+
+        Args:
+            outcomes (str, List[str]): Outcome label annotation header(s).
+            params (ModelParams): Model parameters for training.
+            smac_configspace (ConfigurationSpace): ConfigurationSpace to
+                determine the SMAC optimization.
+            smac_metric (str, optional): Metric to monitor for optimization.
+                May either be a callable function or a str. If a callable
+                function, must accept the epoch results dict and return a
+                float value. If a str, must be a valid metric, such as
+                'tile_auc', 'patient_auc', 'r_squared', etc.
+                Defaults to 'tile_auc'.
+
+        Returns:
+            _type_: _description_
+        """
+
+        from smac.facade.smac_bb_facade import SMAC4BB
+        from smac.scenario.scenario import Scenario
+
+        # Create SMAC scenario.
+        scenario = Scenario({
+            'run_obj': 'quality', # Optimize quality (alternatively: runtime)
+            'runcount-limit': 3,  # Max number of function evaluations
+            'cs': smac_configspace
+        })
+        smac = SMAC4BB(
+            scenario=scenario,
+            tae_runner=self._get_smac_runner(
+                outcomes=outcomes,
+                params=params,
+                metric=smac_metric,
+                train_kwargs=train_kwargs,
+            )
+        )
+
+        # Optimize.
+        best_config = smac.optimize()
+        log.info("Results of SMAC optimization:")
+        print(best_config)
+        return best_config
 
     def train(
         self,


### PR DESCRIPTION
Enables Bayesian hyperparameter searching through SMAC. 

To use, simply replace `P.train()` with `P.smac_search()` and provide the additional argument `smac_configspace`. For example:

```
import slideflow as sf
import ConfigSpace.hyperparameters as cs_hp
from ConfigSpace import ConfigurationSpace

def main(P):
    hp = sf.ModelParams(...)

    cs = ConfigurationSpace()
    cs.add_hyperparameter(cs_hp.UniformIntegerHyperparameter("epochs", 1, 2))
    cs.add_hyperparameter(cs_hp.UniformFloatHyperparameter("dropout", 0, 0.5))

    best_config = P.smac_search(
        ...,
        smac_configspace=cs
    )
```

By default, it will use tile_auc metric for optimization. This can be overriden using the `smac_metric` argument. You can either provide a different metric:

```
P.smac_search(
  ...,
  smac_metric='patient_auc'
)
```

Or, you can provide a callable function that creates a custom metric:

```
def custom_metric(results):
   1 - mean(x['tile_auc']['brs_class']) * 0.5,

P.smac_search(
  ...,
  smac_metric=custom_metric
)
```
Additionally, the hyperparameter validation checks are moved from the initializer to `ModelParams.validate()`