### PR TITLE
Pyomo/bonmin solver for site-preserved CV

### DIFF
--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -216,7 +216,8 @@ def _fill_queue(
 def split_patients_preserved_site(
     patients_dict: Dict[str, Dict],
     n: int,
-    balance: str
+    balance: str,
+    method: str = 'auto'
 ) -> List[List[str]]:
     """Splits a dictionary of patients into n groups,
     balancing according to key "balance" while preserving site.
@@ -226,12 +227,12 @@ def split_patients_preserved_site(
             dict of outcomes: labels
         n (int): Number of splits to generate.
         balance (str): Annotation header to balance splits across.
+        method (str): Solver method. 'auto', 'cplex', or 'bonmin'. If 'auto',
+            will use CPLEX if availabe, otherwise will default to pyomo/bonmin.
 
     Returns:
         List of patient splits
     """
-    if not sf.util.CPLEX_AVAILABLE:
-        raise errors.CPLEXNotFoundError
     patient_list = list(patients_dict.keys())
     shuffle(patient_list)
 
@@ -255,13 +256,7 @@ def split_patients_preserved_site(
         columns=['patient', 'outcome_label', 'site']
     )
     df = cv.generate(
-        df,
-        'outcome_label',
-        unique_labels,
-        crossfolds=n,
-        target_column='CV',
-        patient_column='patient',
-        site_column='site'
+        df, 'outcome_label', k=n, target_column='CV', method=method
     )
     log.info(col.bold("Train/val split with Preserved-Site Cross-Val"))
     log.info(col.bold(

--- a/slideflow/errors.py
+++ b/slideflow/errors.py
@@ -1,12 +1,9 @@
 '''Slideflow module errors.'''
 
 
-# --- CPLEX errors ------------------------------------------------------------
-class CPLEXNotFoundError(Exception):
-    def __init__(self):
-        msg = 'CPLEX not found; unable to perform preserved-site validation.'
-        super().__init__(msg)
-
+# --- CPLEX / bonmin errors ---------------------------------------------------
+class SolverNotFoundError(Exception):
+    pass
 
 # --- DatasetErrors -----------------------------------------------------------
 class DatasetError(Exception):

--- a/slideflow/io/preservedsite/crossfolds.py
+++ b/slideflow/io/preservedsite/crossfolds.py
@@ -1,30 +1,49 @@
-import cvxpy as cp
+from typing import List
+
 import numpy as np
 import pandas as pd
-
 import slideflow as sf
+from slideflow import errors
 from slideflow.util import log
 
 
-def generate(data, category, values, crossfolds=3, target_column='CV3',
-             patient_column='patient', site_column='SITE',
-             timelimit=10):
+def generate(*args, method='auto', **kwargs):
+    if method == 'auto':
+        if not sf.util.CPLEX_AVAILABLE:
+            log.info("CPLEX solver not found; falling back to pyomo/bonmin.")
+            method = 'bonmin'
+        else:
+            method = 'cplex'
+    if method == 'bonmin':
+        return _generate_bonmin(*args, **kwargs)
+    elif method == 'cplex':
+        return _generate_cplex(*args, **kwargs)
+    else:
+        raise ValueError(f'Unrecognized solver {method}')
 
-    """Generates site preserved cross-folds, balanced on a given category.
+
+def _generate_bonmin(
+    df: pd.DataFrame,
+    category: str,
+    k: int = 3,
+    target_column: str = 'CV3',
+    timelimit: int = 10
+) -> pd.DataFrame:
+
+    """Generates site preserved cross-folds, balanced on a given category,
+    using the bonmin solver.
+
+    Bonmin can be installed with:
+
+        conda install -c conda-forge coinbonmin
 
     Args:
         data (pandas.DataFrame): Dataframe with slides that must be split into
             crossfolds.
         category (str): The column in data to stratify by.
-        values (list(str)): A list of possible values within category to
-            include for stratification
-        crossfolds (int): Number of crossfolds for splitting. Defaults to 3.
+        k (int): Number of crossfolds for splitting. Defaults to 3.
         target_column (str): Name for target column to contain the assigned
             crossfolds for each patient in the output dataframe.
-        patient_column (str): Column within dataframe indicating unique
-            identifier for patient
-        site_column (str): Column within dataframe indicating designated site
-            for a patient
         timelimit: maximum time to spend solving
 
     Returns:
@@ -34,49 +53,175 @@ def generate(data, category, values, crossfolds=3, target_column='CV3',
     .. _Preserved-site cross-validation:
         https://doi.org/10.1038/s41467-021-24698-1
     """
+    try:
+        import pyomo.environ as pyo
+        from pyomo.opt import SolverFactory
+    except:
+        raise errors.SolverNotFoundError("Unable to import pyomo solver.")
 
-    submitters = data[patient_column].unique()
-    newData = pd.merge(
-        pd.DataFrame(submitters, columns=[patient_column]),
-        data[[patient_column, category, site_column]],
-        on=patient_column, how='left'
-    )
-    newData.drop_duplicates(inplace=True)
-    uniqueSites = data[site_column].unique()
-    n = len(uniqueSites)
-    listSet = []
-    for v in values:
-        listOrder = []
-        for s in uniqueSites:
-            listOrder += [len(newData[((newData[site_column] == s)
-                                       & (newData[category] == v))])]
-        listSet += [listOrder]
-    gList = []
-    for i in range(crossfolds):
-        gList += [cp.Variable(n, boolean=True)]
-    A = np.ones(n)
-    constraints = [sum(gList) == A]
+    unique_sites = df['site'].unique()
+    unique_labels = df[category].unique()
+    n_sites = len(unique_sites)
+    n_labels = len(unique_labels)
+
+    # Calculate number of labels seen at each site
+    # Outer list is each unique label
+    # Inner list is each unique site
+    n_label_by_site = [
+        [ len(df[((df['site'] == site) & (df[category] == label))])
+          for site in unique_sites ]
+        for label in unique_labels
+    ]
+
+    # Initialize model with pyomo
+    model = pyo.ConcreteModel()
+    model.n_sites = pyo.Param(initialize=n_sites)
+
+    # Create boolean variables that signify whether
+    # a site is included in each crossfold.
+    for si in range(k):
+        var = pyo.Var(pyo.RangeSet(model.n_sites), domain=pyo.Binary)
+        setattr(model, f'cv{si}', var)
+
+    def get_site_var(model, cv_idx):
+        '''Function to return a cross-fold variable set from a model.'''
+        return getattr(model, f'cv{cv_idx}')
+
+    # Set constraints that sites should be assigned to exactly one crossfold.
+    def get_constraint(site_index):
+        def constraint_rule(m):
+            return sum(get_site_var(m, cv)[site_index] for cv in range(k)) == 1
+        return constraint_rule
+
+    # Create objective rule for the optimization problem.
+    def obj_rule(m):
+        return sum(
+            sum(
+                (
+                    sum(
+                        get_site_var(m, cv)[si+1] * n_label_by_site[li][si] * k
+                        for si in range(n_sites)
+                    )
+                    - sum(n_label_by_site[li])
+                )**2
+                for cv in range(k)
+            ) for li in range(n_labels)
+        )
+
+    # Apply the objective.
+    model.obj = pyo.Objective(rule=obj_rule, sense=pyo.minimize)
+
+    # Apply constraints.
+    for si in range(1, n_sites+1):
+        setattr(model, f'const{si}', pyo.Constraint(rule=get_constraint(si)))
+
+    # Get the bonmin solver.
+    try:
+        opt = SolverFactory('bonmin', validate=False)
+    except (ValueError, RuntimeError) as e:
+        raise errors.SolverNotFoundError("Unable to find bonmin solver.")
+
+    if not opt.available():
+        raise errors.SolverNotFoundError("Unable to find bonmin solver.")
+
+    # Solve the equation.
+    results = opt.solve(model)
+    model.solutions.store_to(results)
+
+    # Convert solved variables into chosen sites.
+    chosen_sites = [
+        [ site for site_idx, site in enumerate(unique_sites)
+          if getattr(model, f'cv{cv}')[site_idx+1].value > 0.5 ]
+        for cv in range(k)
+    ]
+
+    # Print results and assign results to new DataFrame column.
+    for i in range(k):
+        log.info(f"Crossfold {i+1} Sites: {chosen_sites[i]}")
+
+        # Assign site results.
+        df.loc[df['site'].isin(chosen_sites[i]), target_column] = str(i+1)
+
+    return df
+
+
+def _generate_cplex(
+    df: pd.DataFrame,
+    category: str,
+    k: int = 3,
+    target_column: str = 'CV3',
+    timelimit: int = 10
+) -> pd.DataFrame:
+
+    """Generates site preserved cross-folds, balanced on a given category,
+    using the CPLEX solver.
+
+    Args:
+        data (pandas.DataFrame): Dataframe with slides that must be split into
+            crossfolds.
+        category (str): The column in data to stratify by.
+        k (int): Number of crossfolds for splitting. Defaults to 3.
+        target_column (str): Name for target column to contain the assigned
+            crossfolds for each patient in the output dataframe.
+        timelimit: maximum time to spend solving
+
+    Returns:
+        dataframe with a new column, 'CV3' that contains values 1 - 3,
+            indicating the assigned crossfold
+
+    .. _Preserved-site cross-validation:
+        https://doi.org/10.1038/s41467-021-24698-1
+    """
+    if not sf.util.CPLEX_AVAILABLE:
+        raise errors.SolverNotFoundError("CPLEX solver not found.")
+
+    import cvxpy as cp
+
+    unique_sites = df['site'].unique()
+    unique_labels = df[category].unique()
+
+    # Calculate number of labels seen at each site
+    # Outer list is each unique label
+    # Inner list is each unique site
+    n_label_by_site = [
+        [ len(df[((df['site'] == site) & (df[category] == label))])
+          for site in unique_sites ]
+        for label in unique_labels
+    ]
+
+    # Optimization variables.
+    variables_by_cv = [
+        cp.Variable(len(unique_sites), boolean=True)
+        for _ in range(k)
+    ]
+    A = np.ones(len(unique_sites))
+    constraints = [sum(variables_by_cv) == A]
+
+    # Create and solve optimization problem.
     error = 0
-    for v in range(len(values)):
-        for i in range(crossfolds):
+    for li in range(len(unique_labels)):
+        for cv in range(k):
             error += cp.square(
-                cp.sum(crossfolds * cp.multiply(gList[i], listSet[v]))
-                - sum(listSet[v])
+                cp.sum(
+                    k * cp.multiply(variables_by_cv[cv],
+                    n_label_by_site[li]))
+                - sum(n_label_by_site[li])
             )
     prob = cp.Problem(cp.Minimize(error), constraints)
     prob.solve(solver='CPLEX', cplex_params={"timelimit": timelimit})
-    gSites = []
-    for i in range(crossfolds):
-        gSites += [[]]
-    for i in range(n):
-        for j in range(crossfolds):
-            if gList[j].value[i] > 0.5:
-                gSites[j] += [uniqueSites[i]]
-    for i in range(crossfolds):
-        str1 = "Crossfold " + str(i+1) + " Sites: "
-        j = 0
-        str1 = str1 + str(gSites[i])
-        log.info(str1)
-    for i in range(crossfolds):
-        data.loc[data[site_column].isin(gSites[i]), target_column] = str(i+1)
-    return data
+
+    # Convert solved variables into chosen sites.
+    chosen_sites = [
+        [ site for site_idx, site in enumerate(unique_sites)
+          if variables_by_cv[cv].value[site_idx] > 0.5 ]
+        for cv in range(k)
+    ]
+
+    # Print results and assign results to new DataFrame column.
+    for i in range(k):
+        log.info(f"Crossfold {i+1} Sites: {chosen_sites[i]}")
+
+        # Assign site results.
+        df.loc[df['site'].isin(chosen_sites[i]), target_column] = str(i+1)
+
+    return df

--- a/slideflow/test/dataset_test.py
+++ b/slideflow/test/dataset_test.py
@@ -4,7 +4,6 @@ import shutil
 import unittest
 
 import pandas as pd
-
 import slideflow as sf
 from slideflow.test.utils import TestConfig
 
@@ -105,27 +104,51 @@ class TestSplits(unittest.TestCase):
         # Assert that sites are not shared between splits
         self.assertTrue(sorted(flattened_sites) == sorted(self.sites))
 
-    def test_site_preserved_split_three_splits(self):
+    def test_site_preserved_cplex_three_splits(self):
         try:
             splits = sf.dataset.split_patients_preserved_site(
-                self.patients_dict, n=3, balance='outcome'
+                self.patients_dict, n=3, balance='outcome', method='cplex'
             )
-            self._test_split(splits)
-        except sf.errors.CPLEXNotFoundError:
+            self._test_site_split(splits)
+        except sf.errors.SolverNotFoundError:
             sf.util.log.error(
                 'CPLEX not installed, unable to test site-preserved'
                 'cross-validation.'
             )
 
-    def test_site_preserved_split_five_splits(self):
+    def test_site_preserved_cplex_five_splits(self):
         try:
             splits = sf.dataset.split_patients_preserved_site(
-                self.patients_dict, n=5, balance='outcome'
+                self.patients_dict, n=5, balance='outcome', method='cplex'
             )
-            self._test_split(splits)
-        except sf.errors.CPLEXNotFoundError:
+            self._test_site_split(splits)
+        except sf.errors.SolverNotFoundError:
             sf.util.log.error(
                 'CPLEX not installed, unable to test site-preserved '
+                'cross-validation.'
+            )
+
+    def test_site_preserved_bonmin_three_splits(self):
+        try:
+            splits = sf.dataset.split_patients_preserved_site(
+                self.patients_dict, n=3, balance='outcome', method='bonmin'
+            )
+            self._test_site_split(splits)
+        except sf.errors.SolverNotFoundError:
+            sf.util.log.error(
+                'Pyomo/bonmin not installed, unable to test site-preserved'
+                'cross-validation.'
+            )
+
+    def test_site_preserved_bonmin_five_splits(self):
+        try:
+            splits = sf.dataset.split_patients_preserved_site(
+                self.patients_dict, n=5, balance='outcome', method='bonmin'
+            )
+            self._test_site_split(splits)
+        except sf.errors.SolverNotFoundError:
+            sf.util.log.error(
+                'Pyomo/bonmin not installed, unable to test site-preserved '
                 'cross-validation.'
             )
 


### PR DESCRIPTION
- Adds pyomo/bonmin solver for calculating site-preserved cross-validation, an open-source alternative to CPLEX
- `sf.dataset.split_patients_preserved_site()` accepts a `method` argument which specifies the solver. Can be `'auto'`, `'cplex'`, or `'bonmin'`. If `'auto'`, will attempt to use CPLEX if available (faster), and if not, will default to bonmin.
- `sf.io.preservedsite.crossfolds.generate()` accepts a new `method` argument with the same logic as above.
- `errors.CPLEXNotFoundError` changed to `errors.SolverNotFoundError`, as this may be raised if attempting to use pyomo/bonmin but it is not installed.
- Includes unit tests for the pyomo/bonmin solver