### PR TITLE
Dataset performance improvements (SLID-9)

### DIFF
--- a/slideflow/test/dataset_test.py
+++ b/slideflow/test/dataset_test.py
@@ -4,7 +4,6 @@ import shutil
 import unittest
 
 import pandas as pd
-
 import slideflow as sf
 from slideflow.test.utils import TestConfig
 
@@ -36,7 +35,7 @@ class TestDataset(unittest.TestCase):
         dataset.load_annotations(ann_df)
         self.assertTrue(len(dataset.annotations) == 100)
 
-    def test_load_invalid_annotations(self):
+    def test_load_faulty_annotations_with_duplicates(self):
         dataset = self.PROJECT.dataset()
         ann_df = pd.DataFrame({
             'patient': pd.Series([f'pt{p}' for p in range(100)]),

--- a/slideflow/test/dataset_test.py
+++ b/slideflow/test/dataset_test.py
@@ -36,6 +36,16 @@ class TestDataset(unittest.TestCase):
         dataset.load_annotations(ann_df)
         self.assertTrue(len(dataset.annotations) == 100)
 
+    def test_load_invalid_annotations(self):
+        dataset = self.PROJECT.dataset()
+        ann_df = pd.DataFrame({
+            'patient': pd.Series([f'pt{p}' for p in range(100)]),
+            'slide': pd.Series(['slide_test', 'slide_test'] + [f'slide{s}' for s in range(98)]),
+            'linear': pd.Series([random.random() for _ in range(100)])
+        })
+        with self.assertRaises(sf.errors.DatasetError):
+            dataset.load_annotations(ann_df)
+
     def test_load_faulty_annotations_without_patient(self):
         dataset = self.PROJECT.dataset()
         ann_df = pd.DataFrame({

--- a/slideflow/util/__init__.py
+++ b/slideflow/util/__init__.py
@@ -44,7 +44,7 @@ except Exception:
 
 SUPPORTED_FORMATS = ['svs', 'tif', 'ndpi', 'vms', 'vmu', 'scn', 'mrxs',
                      'tiff', 'svslide', 'bif', 'jpg']
-SLIDE_ANNOTATIONS_TO_IGNORE = ['', ' ']
+EMPTY_ANNOTATIONS = ['', ' ']
 CPLEX_AVAILABLE = (importlib.util.find_spec('cplex') is not None)
 
 


### PR DESCRIPTION
Adds performance improvements in nearly all uses of `Dataset` by improving utilization of vectorized functions (via pandas DataFrame). Specifically this changes:

- `Dataset.slides()` no longer performs any filtering, and simply returns the unique (non-empty) slides present in the filtered annotations.
- `Dataset.filtered_annotations` now calculates filters using vectorized comparisons
- Similar performance improvements for `Dataset.verify_annotations_slides()`

Additionally, this adds:
- New unittest for ensuring duplicate slides in annotations are handled correctly
- `Dataset.annotations` can no longer be set directly, to prevent accidentally bypassing annotation validation. Instead, use `Dataset.load_annotations`