### PR TITLE
Handle missing pyvips or libvips

### DIFF
--- a/slideflow/slide/__init__.py
+++ b/slideflow/slide/__init__.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import cv2
 import matplotlib.colors as mcol
 import numpy as np
-import pyvips as vips
 import shapely.geometry as sg
 import skimage
 import skimage.filters
@@ -37,6 +36,12 @@ from slideflow.util import SUPPORTED_FORMATS, Path  # noqa F401
 from slideflow.util import colors as col
 from slideflow.util import log, path_to_name  # noqa F401
 from tqdm import tqdm
+
+try:
+    import pyvips as vips
+except (ModuleNotFoundError, OSError) as e:
+    log.error("Unable to load vips; slide processing will be unavailable. "
+              f"Error raised: {e}")
 
 warnings.simplefilter('ignore', Image.DecompressionBombWarning)
 Image.MAX_IMAGE_PIXELS = 100000000000

--- a/slideflow/slide/__init__.py
+++ b/slideflow/slide/__init__.py
@@ -329,7 +329,7 @@ def _wsi_extraction_worker(
     return return_dict
 
 
-def vips2numpy(vi: vips.Image) -> np.ndarray:
+def vips2numpy(vi: "vips.Image") -> np.ndarray:
     '''Converts a VIPS image into a numpy array'''
     return np.ndarray(buffer=vi.write_to_memory(),
                       dtype=VIPS_FORMAT_TO_DTYPE[vi.format],
@@ -473,7 +473,7 @@ class _VIPSWrapper:
             return 0
         return max_level
 
-    def get_downsampled_image(self, level: int) -> vips.Image:
+    def get_downsampled_image(self, level: int) -> "vips.Image":
         '''Returns a VIPS image of a given downsample.'''
         if level in range(len(self.levels)):
             if level in self.loaded_downsample_levels:
@@ -497,7 +497,7 @@ class _VIPSWrapper:
         base_level_dim: Tuple[int, int],
         downsample_level: int,
         extract_size: Tuple[int, int]
-    ) -> vips.Image:
+    ) -> "vips.Image":
         '''Extracts a region from the image at the given downsample level.'''
         base_level_x, base_level_y = base_level_dim
         extract_width, extract_height = extract_size


### PR DESCRIPTION
In some cases, someone may wish to use Slideflow without slide-processing (such as if TFRecords are already generated, or to use other functionality). Presently, however, Slideflow cannot be imported without libvips/pyvips installed.

This change will log an error if pyvips/libvips is not installed, but will allow the module to be imported.