### PR TITLE
Saliency Maps and StyleGAN2 Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "slideflow/gan/stylegan2"]
 	path = slideflow/gan/stylegan2
-	url = https://github.com/jamesdolezal/stylegan2-slideflow.git
+	url = git@github.com:jamesdolezal/stylegan2-slideflow.git
+	branch = pca_cond

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "slideflow/gan/stylegan2"]
+	path = slideflow/gan/stylegan2
+	url = https://github.com/jamesdolezal/stylegan2-slideflow.git

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Python application](https://github.com/jamesdolezal/slideflow/actions/workflows/python-app.yml/badge.svg?branch=master)](https://github.com/jamesdolezal/slideflow/actions/workflows/python-app.yml)
 [![PyPI version](https://badge.fury.io/py/slideflow.svg)](https://badge.fury.io/py/slideflow)
 
-Slideflow is a Python package which provides a unified API for building and testing deep learning models for histopathology, supporting both Tensorflow/Keras and PyTorch.
+Slideflow provides a unified API for building and testing deep learning models for digital pathology, supporting both Tensorflow/Keras and PyTorch.
 
 Slideflow includes tools for **whole-slide image processing** and segmentation, **customizable deep learning model training** with dozens of supported architectures, **explainability tools** including heatmaps and mosaic maps, **analysis of activations** from model layers, **uncertainty quantification**, and more. A variety of fast, optimized whole-slide image processing tools are included, including background filtering, blur/artifact detection, stain normalization, and efficient storage in `*.tfrecords` format. Model training is easy and highly configurable, with an easy drop-in API for training custom architectures. For external training loops, Slideflow can be used as an image processing backend, serving an optimized `tf.data.Dataset` or `torch.utils.data.DataLoader` to read and process slide images and perform real-time stain normalization.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ tensorboard
 crc32c
 h5py
 tabulate
+saliency

--- a/slideflow/__init__.py
+++ b/slideflow/__init__.py
@@ -10,7 +10,7 @@
 
 __author__ = 'James Dolezal'
 __license__ = 'GNU General Public License v3.0'
-__version__ = "1.2.0-dev1"
+__version__ = "1.2.0-dev2"
 
 import os
 

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1320,6 +1320,68 @@ class Dataset:
             ret._min_tiles = kwargs['min_tiles']
         return ret
 
+    def find_slide(
+        self,
+        *,
+        slide: Optional[str] = None,
+        patient: Optional[str] = None
+    ) -> Optional[str]:
+        """Find a slide path from a given slide or patient.
+
+        Keyword args:
+            slide (str): Find a tfrecord associated with this slide name.
+            patient (str): Find a tfrecord associated with this patient.
+
+        Returns:
+            str:    Matching path to slide, if found.
+            If not found, returns None
+        """
+        if slide is None and patient is None:
+            raise ValueError("Must supply either slide or patient.")
+        if slide is not None and patient is not None:
+            raise ValueError("Must supply either slide or patient, not both.")
+
+        if slide is not None:
+            filtered = self.filter({'slide': slide})
+        if patient is not None:
+            filtered = self.filter({'slide': patient})
+        matching = filtered.slide_paths()
+        if not len(matching):
+            return None
+        else:
+            return matching[0]
+
+    def find_tfrecord(
+        self,
+        *,
+        slide: Optional[str] = None,
+        patient: Optional[str] = None
+    ) -> Optional[str]:
+        """Find a TFRecord path from a given slide or patient.
+
+        Keyword args:
+            slide (str): Find a tfrecord associated with this slide name.
+            patient (str): Find a tfrecord associated with this patient.
+
+        Returns:
+            str:    Matching path to tfrecord, if found.
+            If not found, returns None
+        """
+        if slide is None and patient is None:
+            raise ValueError("Must supply either slide or patient.")
+        if slide is not None and patient is not None:
+            raise ValueError("Must supply either slide or patient, not both.")
+
+        if slide is not None:
+            filtered = self.filter({'slide': slide})
+        if patient is not None:
+            filtered = self.filter({'slide': patient})
+        matching = filtered.tfrecords()
+        if not len(matching):
+            return None
+        else:
+            return matching[0]
+
     def harmonize_labels(
         self,
         *args: "Dataset",

--- a/slideflow/gan/__init__.py
+++ b/slideflow/gan/__init__.py
@@ -1,4 +1,3 @@
-import slideflow.gan.gan_utils
 import slideflow.gan.stylegan2
-from slideflow.gan.stylegan2 import embedding, plot
-from slideflow.gan.stylegan2.utils import decode_batch, process_gan_batch
+from slideflow.gan.interpolate import StyleGAN2Interpolator
+from slideflow.gan.search import seed_search

--- a/slideflow/gan/__init__.py
+++ b/slideflow/gan/__init__.py
@@ -2,4 +2,3 @@
 
 import slideflow.gan.stylegan2
 from slideflow.gan.interpolate import StyleGAN2Interpolator
-from slideflow.gan.search import seed_search

--- a/slideflow/gan/__init__.py
+++ b/slideflow/gan/__init__.py
@@ -1,3 +1,5 @@
+"""Submodule used to interface with the PyTorch implementation of StyleGAN2."""
+
 import slideflow.gan.stylegan2
 from slideflow.gan.interpolate import StyleGAN2Interpolator
 from slideflow.gan.search import seed_search

--- a/slideflow/gan/__init__.py
+++ b/slideflow/gan/__init__.py
@@ -1,0 +1,4 @@
+import slideflow.gan.gan_utils
+import slideflow.gan.stylegan2
+from slideflow.gan.stylegan2 import embedding, plot
+from slideflow.gan.stylegan2.utils import decode_batch, process_gan_batch

--- a/slideflow/gan/interpolate.py
+++ b/slideflow/gan/interpolate.py
@@ -1,3 +1,5 @@
+"""Tool to assist with embedding interpolation for a class-conditional GAN."""
+
 from typing import (TYPE_CHECKING, Any, Callable, Generator, List, Optional,
                     Tuple, Union)
 

--- a/slideflow/gan/interpolate.py
+++ b/slideflow/gan/interpolate.py
@@ -1,0 +1,317 @@
+from typing import (TYPE_CHECKING, Any, Callable, Generator, List, Optional,
+                    Tuple, Union)
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import slideflow as sf
+import tensorflow as tf
+import torch
+from PIL import Image
+from slideflow.gan import tf_utils
+from slideflow.gan.search import seed_search
+from slideflow.gan.stylegan2 import embedding, utils
+from tqdm import tqdm
+
+
+class StyleGAN2Interpolator:
+
+    def __init__(
+        self,
+        gan_pkl: str,
+        start: int,
+        end: int,
+        device: torch.device,
+        **gan_kwargs
+    ) -> None:
+        """Coordinates class and embedding interpolation for a trained
+        class-conditional StyleGAN2.
+
+        Args:
+            gan_pkl (str): Path to saved network pkl.
+            start (int): Starting class index.
+            end (int): Ending class index.
+            device (torch.device): Torch device.
+        """
+        self.E_G, self.G = embedding.load_embedding_gan(gan_pkl, device)
+        self.device = device
+        self.gan_kwargs = gan_kwargs
+        self.decode_kwargs = dict(standardize=False, resize_px=299)
+        self.embed0, self.embed1 = embedding.get_class_embeddings(
+            self.G,
+            start=start,
+            end=end,
+            device=device
+        )
+        self.features = None
+        self.normalizer = None
+
+    def z(self, seed: int) -> torch.tensor:
+        """Returns a noise tensor for a given seed.
+
+        Args:
+            seed (int): Seed.
+
+        Returns:
+            torch.tensor: Noise tensor for the corresponding seed.
+        """
+        return utils.noise_tensor(seed, self.E_G.z_dim).to(self.device)
+
+    def set_feature_model(
+        self,
+        path: str,
+        layers: Union[str, List[str]] = 'postconv'
+    ) -> None:
+        """Configures a classifier model to be used for generating features
+        and predictions during interpolation.
+
+        Args:
+            path (str): Path to trained model.
+            layers (Union[str, List[str]], optional): Layers from which to
+                calculate activations for interpolated images.
+                Defaults to 'postconv'.
+        """
+        self.features = sf.model.Features(path, layers=layers, include_logits=True)
+        self.normalizer = self.features.wsi_normalizer
+
+    def seed_search(
+        self,
+        seeds: List[int],
+        batch_size: int = 32,
+        verbose: bool = False
+    ) -> pd.core.frame.DataFrame:
+        """Generates images for starting and ending classes for many seeds,
+        calculating layer activations from a set classifier.
+
+        Args:
+            seeds (List[int]): Seeds.
+            batch_size (int, optional): Batch size for GAN during generation.
+                Defaults to 32.
+            verbose (bool, optional): Verbose output. Defaults to False.
+
+        Raises:
+            Exception: If classifier model has not been been set with
+                .set_feature_model()
+
+        Returns:
+            pd.core.frame.DataFrame: Dataframe of results.
+        """
+
+        if self.features is None:
+            raise Exception("Feature model not set; use .set_feature_model()")
+        return seed_search(
+            seeds,
+            self.embed0,
+            self.embed1,
+            self.E_G,
+            self.features,
+            self.device,
+            batch_size,
+            normalizer=self.normalizer,
+            verbose=verbose,
+            **self.gan_kwargs
+        )
+
+    def plot_comparison(self, seeds: Union[int, List[int]]) -> None:
+        """Plots side-by-side comparison of images from the starting
+        and ending interpolation classes.
+
+        Args:
+            seeds (int or list(int)): Seeds to display.
+        """
+        if not isinstance(seeds, list):
+            seeds = [seeds]
+
+        scale = 5
+        fig, ax = plt.subplots(len(seeds), 2, figsize=(2 * scale, len(seeds) * scale))
+        for s, seed in enumerate(seeds):
+            # First image (starting embedding, BRAF-like)
+            img0 = self.E_G(self.z(seed), self.embed0, **self.gan_kwargs)
+            img0 = tf_utils.process_gan_batch(img0)
+            img0 = tf_utils.decode_batch(img0, **self.decode_kwargs)
+            img0 = Image.fromarray(img0['tile_image'].numpy()[0])
+
+            # Second image (ending embedding, RAS-like)
+            img1 = self.E_G(self.z(seed), self.embed1, **self.gan_kwargs)
+            img1 = tf_utils.process_gan_batch(img1)
+            img1 = tf_utils.decode_batch(img1, **self.decode_kwargs)
+            img1 = Image.fromarray(img1['tile_image'].numpy()[0])
+
+            if len(seeds) == 1:
+                _ax0 = ax[0]
+                _ax1 = ax[1]
+            else:
+                _ax0 = ax[s, 0]
+                _ax1 = ax[s, 1]
+            if s == 0:
+                _ax0.set_title('BRAF-like')
+                _ax1.set_title('RAS-like')
+            _ax0.imshow(img0)
+            _ax1.imshow(img1)
+            _ax0.axis('off')
+            _ax1.axis('off')
+
+        fig.subplots_adjust(wspace=0.05, hspace=0)
+
+    def generate_tf_from_embedding(
+        self,
+        seed: int,
+        embedding: torch.tensor
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
+        """Create a processed Tensorflow image from the GAN output from a given
+        seed and embedding.
+
+        Args:
+            seed (int): Seed for noise vector.
+            embedding (torch.tensor): Class embedding.
+
+        Returns:
+            tf.Tensor: Unprocessed image (tf.Tensor), uint8.
+
+            tf.Tensor: Processed image (tf.Tensor), standardized and normalized.
+        """
+        z = self.z(seed)
+        gan_out = self.E_G(z, embedding, **self.gan_kwargs)
+        raw, processed = tf_utils.process_gan_raw(
+            gan_out,
+            normalizer=self.normalizer,
+            **self.decode_kwargs
+        )
+        return raw, processed
+
+    def generate_tf_start(self, seed: int) -> Tuple[tf.Tensor, tf.Tensor]:
+        """Create a processed Tensorflow image from the GAN output of a given
+        seed and the starting class embedding.
+
+        Args:
+            seed (int): Seed for noise vector.
+
+        Returns:
+            tf.Tensor: Unprocessed image (tf.Tensor), uint8.
+
+            tf.Tensor: Processed image (tf.Tensor), standardized and normalized.
+        """
+        return self.generate_tf_from_embedding(seed, self.embed0)
+
+    def generate_tf_end(self, seed: int) -> Tuple[tf.Tensor, tf.Tensor]:
+        """Create a processed Tensorflow image from the GAN output of a given
+        seed and the ending class embedding.
+
+        Args:
+            seed (int): Seed for noise vector.
+
+        Returns:
+            tf.Tensor: Unprocessed image (tf.Tensor), uint8.
+
+            tf.Tensor: Processed image (tf.Tensor), standardized and normalized.
+        """
+        return self.generate_tf_from_embedding(seed, self.embed1)
+
+    def class_interpolate(self, seed: int, steps: int = 100) -> Generator:
+        """Sets up a generator that returns images during class embedding
+        interpolation.
+
+        Args:
+            seed (int): Seed for random noise vector.
+            steps (int, optional): Number of steps for interpolation.
+                Defaults to 100.
+
+        Returns:
+            Generator: Generator which yields images (torch.tensor, uint8)
+                during interpolation.
+
+        Yields:
+            Generator: images (torch.tensor, dtype=uint8)
+        """
+        return embedding.class_interpolate(
+            self.E_G,
+            self.z(seed),
+            self.embed0,
+            self.embed1,
+            device=self.device,
+            steps=steps,
+            **self.gan_kwargs
+        )
+
+    def linear_interpolate(self, seed: int, steps: int = 100) -> Generator:
+        """Sets up a generator that returns images during linear label
+        interpolation.
+
+        Args:
+            seed (int): Seed for random noise vector.
+            steps (int, optional): Number of steps for interpolation.
+                Defaults to 100.
+
+        Returns:
+            Generator: Generator which yields images (torch.tensor, uint8)
+                during interpolation.
+
+        Yields:
+            Generator: images (torch.tensor, dtype=uint8)
+        """
+        return embedding.linear_interpolate(
+            self.G,
+            self.z(seed),
+            device=self.device,
+            steps=steps,
+            **self.gan_kwargs
+        )
+
+    def interpolate(
+        self,
+        seed: int,
+        steps: int = 100,
+        watch: Callable = None
+    ) -> Tuple[List, ...]:
+        """Interpolates between starting and ending classes for a seed,
+        recording raw images, processed images, predictions, and optionally
+        calling a function on each image during interpolation and recording
+        results.
+
+        Args:
+            seed (int): Seed for random noise vector.
+            steps (int, optional): Number of steps during interpolation.
+                Defaults to 100.
+            watch (Callable, optional): Function to call on every processed
+                image during interpolation. If provided, will provide list of
+                results as last returned item. Defaults to None.
+
+        Returns:
+            Tuple[List, ...]: List of raw images, processed images, predictions,
+                and optionally a list of results from the watch function called
+                on each processed image.
+        """
+        imgs = []
+        proc_imgs = []
+        preds = []
+        watch_out = []
+
+        for img in tqdm(self.class_interpolate(seed, steps), total=steps):
+            img = torch.from_numpy(np.expand_dims(img, axis=0)).permute(0, 3, 1, 2)
+            img = (img / 127.5) - 1
+            img = tf_utils.process_gan_batch(img)
+            img = tf_utils.decode_batch(img, **self.decode_kwargs)
+            if self.normalizer:
+                img = self.normalizer.batch_to_batch(img['tile_image'])[0]
+            else:
+                img = img['tile_image']
+            processed_img = tf.image.per_image_standardization(img)
+            img = img.numpy()[0]
+            pred = self.features(processed_img)[-1].numpy()
+            preds += [pred[0][0]]
+            if watch is not None:
+                watch_out += [watch(processed_img)]
+            imgs += [img]
+            proc_imgs += [processed_img[0]]
+
+        sns.lineplot(x=range(len(preds)), y=preds, label="Prediction")
+        plt.axhline(y=0, color='black', linestyle='--')
+        plt.title("Prediction during interpolation")
+        plt.xlabel("Interpolation Step (BRAF -> RAS)")
+        plt.ylabel("Prediction")
+
+        if watch is not None:
+            return imgs, proc_imgs, preds, watch_out
+        else:
+            return imgs, proc_imgs, preds

--- a/slideflow/gan/search.py
+++ b/slideflow/gan/search.py
@@ -1,0 +1,512 @@
+
+from typing import Iterable, List, Optional, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import slideflow as sf
+import tensorflow as tf
+import torch
+from sklearn.decomposition import PCA
+from slideflow.gan import tf_utils
+from slideflow.gan.stylegan2 import utils
+from slideflow.util import colors as col
+from slideflow.util import log
+from tqdm.auto import tqdm
+
+
+def seed_search(
+    seeds: List[int],
+    embed0: torch.tensor,
+    embed1: torch.tensor,
+    E_G: torch.nn.Module,
+    classifier_features: Union["tf.keras.models.Model", torch.nn.Module],
+    device: torch.device,
+    batch_size: int = 32,
+    normalizer: Optional["sf.norm.StainNormalizer"] = None,
+    verbose: bool = True,
+    **gan_kwargs
+) -> pd.core.frame.DataFrame:
+
+    predictions = {0: [], 1: []}
+    features = {0: [], 1: []}
+    swap_labels = []
+    img_seeds = []
+
+    # --- GAN-Classifier pipeline ---------------------------------------------
+    def gan_generator(embedding):
+        def generator():
+            for seed_batch in sf.util.batch(seeds, batch_size):
+                z = torch.stack([utils.noise_tensor(s, z_dim=E_G.z_dim)[0] for s in seed_batch]).to(device)
+                img_batch = E_G(z, embedding.expand(z.shape[0], -1), **gan_kwargs)
+                yield tf_utils.process_gan_batch(img_batch)
+        return generator
+
+    # --- Input data stream ---------------------------------------------------
+    gan_embed0_dts = tf_utils.build_gan_dataset(gan_generator(embed0), 299, normalizer=normalizer)
+    gan_embed1_dts = tf_utils.build_gan_dataset(gan_generator(embed1), 299, normalizer=normalizer)
+
+    # Calculate classifier features for GAN images created from seeds.
+    # Calculation happens in batches to improve computational efficiency.
+    # noise + embedding -> GAN -> Classifier -> Predictions, Features
+    pb = tqdm(total=len(seeds), leave=False)
+    for (seed_batch, embed0_batch, embed1_batch) in zip(sf.util.batch(seeds, batch_size), gan_embed0_dts, gan_embed1_dts):
+
+        features0, pred0 = classifier_features(embed0_batch)
+        features1, pred1 = classifier_features(embed1_batch)
+        pred0 = pred0[:, 0].numpy()
+        pred1 = pred1[:, 0].numpy()
+        features0 = tf.reshape(features0, (len(seed_batch), -1)).numpy().astype(np.float32)
+        features1 = tf.reshape(features1, (len(seed_batch), -1)).numpy().astype(np.float32)
+
+        # For each seed in the batch, determine if there ids "class-swapping",
+        # where the GAN class label matches the classifier prediction.
+        #
+        # This may not happen 100% percent of the time even with a perfect GAN
+        # and perfect classifier, since both classes have images that are
+        # not class-specific (such as empty background, background tissue, etc)
+        for i in range(len(seed_batch)):
+            img_seeds += [seed_batch[i]]
+            predictions[0] += [pred0[i]]
+            predictions[1] += [pred1[i]]
+            features[0] += [features0[i]]
+            features[1] += [features1[i]]
+
+            # NOTE: This logic assumes predictions are discretized at 0,
+            # which will not be true for categorical outcomes.
+            if (pred0[i] < 0) and (pred1[i] > 0):
+                # Class-swapping is observed for this seed.
+                if (pred0[i] < -0.5) and (pred1[i] > 0.5):
+                    # Strong class swapping.
+                    tail = " **"
+                    swap_labels += ['strong_swap']
+                else:
+                    # Weak class swapping.
+                    tail = " *"
+                    swap_labels += ['weak_swap']
+            elif (pred0[i] > 0) and (pred1[i] < 0):
+                # Predictions are oppositve of what is expected.
+                tail = " (!)"
+                swap_labels += ['no_swap']
+            else:
+                tail = ""
+                swap_labels += ['no_swap']
+            if verbose:
+                tqdm.write(f"Seed {seed_batch[i]:<6}: {pred0[i]:.2f}\t{pred1[i]:.2f}{tail}")
+        pb.update(len(seed_batch))
+    pb.close()
+
+    # Convert to dataframe.
+    df = pd.DataFrame({
+        'seed': pd.Series(img_seeds),
+        'pred_start': pd.Series(predictions[0]),
+        'pred_end': pd.Series(predictions[1]),
+        'features_start': pd.Series(features[0]).astype(object),
+        'features_end': pd.Series(features[1]).astype(object),
+        'class_swap': pd.Series(swap_labels),
+    })
+    return df
+
+
+class EmbeddingSearch:
+    def __init__(
+        self,
+        E_G: torch.nn.Module,
+        classifier_features: sf.model.Features,
+        pca: PCA,
+        device: torch.device,
+        embed_first: torch.Tensor,
+        embed_end: torch.Tensor,
+        normalizer: Optional[sf.norm.StainNormalizer] = None,
+        pca_method: str = 'delta',
+        gan_kwargs: Optional[dict] = None,
+    ) -> None:
+        """Supervises an embedding search.
+
+        Detailed background information is provided in the `predict()`
+        function of this script.
+
+        Args:
+            E_G (torch.nn.Module): GAN generator which accepts (z, e) as input,
+                where z is a noise vector and e is the class embedding vector.
+            classifier_features (sf.model.Features): Function which accepts an
+                image and returns a vector of features from a classifier layer.
+            pca (sklearn.decomposition.PCA): Fit PCA.
+            device (torch.device): PyTorch device.
+            embed_first (torch.Tensor): Starting class embedding vector,
+                shape=(z_dim,)
+            embed_end (torch.Tensor): Ending class embedding vector,
+                shape=(z_dim,)
+            gan_kwargs (dict, optional): Keyword arguments for GAN.
+            process_kwargs (dict, optional): Keyword arguments for
+                tf_utils.process_gan_batch().
+        """
+        if pca_method not in ('raw', 'delta'):
+            raise ValueError("Invalid pca_method {pca_method}")
+        self.E_G = E_G
+        self.classifier_features = classifier_features
+        self.device = device
+        self.pca = pca
+        self.pca_method = pca_method
+        self.embed0 = embed_first
+        self.embed1 = embed_end
+        self.e_dim = self.embed0.shape[1]
+        self.normalizer = normalizer
+        self.gan_kwargs = gan_kwargs if gan_kwargs is not None else {}
+
+    @staticmethod
+    def _best_dim_by_pc_change(
+        arr: np.ndarray,
+        pc: int
+    ) -> Tuple[int, float, float]:
+        """From a list of principal component (PC) proportional changes,
+        finds the index (embedding dimension) with the greatest positive change
+        in the target PC while minimizing changes in other PCs.
+
+        Args:
+            arr (np.ndarray): Two-dimensional array of shape (n, num_pc),
+                list of proportions that each principal component changed.
+            pc (int): Index of the target principal component.
+
+        Returns:
+            int: Index of the first dimension corresponding to the greatest
+            increase in the target PC with smallest change in other PCs
+
+            float: Proportion by which the target PC changed
+
+            float: Sum of abs(proportion) by which all other PCs changed
+        """
+        proportion_of_pcs = arr / np.sum(np.abs(arr), axis=-1)[:, None]
+        best_prop = np.max(proportion_of_pcs[:, pc])
+        idx = int(np.where(proportion_of_pcs[:, pc]==best_prop)[0])
+        num_pcs = arr.shape[1]
+        pc_change = arr[idx, pc]
+        other_pc_change = np.sum([
+            abs(arr[
+                idx,
+                [_p for _p in range(num_pcs) if _p != pc]
+            ])
+        ])
+        return idx, pc_change, other_pc_change
+
+    def plot(self) -> None:
+        """Plots Principal Component (PC) changes during the embedding search.
+
+        Args:
+            pc_change (list): List of fractional changes in the target PC
+                during the search as dimensions are progressively added.
+            other_pc_change (list): List of the sum of fractional changes in
+                all other PCs during the search as dimensions are added.
+            title (str, optional): Title for plot. Defaults to None.
+        """
+        x = range(len(self.pc_change))
+        plt.clf()
+        sns.lineplot(x=x, y=self.pc_change, color='r', label='Target PC % Change')
+        sns.lineplot(x=x, y=self.other_pc_change, color='b', label='Other PC % Change')
+        sns.lineplot(x=x, y=self.preds, color='green', label='End prediction')
+        plt.axhline(y=0, color='black', linestyle='--')
+        plt.axhline(y=1, color='gray', linestyle='--')
+        plt.xlabel('Search depth (dimensions)')
+
+    def _compare_pc(
+        self,
+        features0: np.ndarray,
+        features1: np.ndarray,
+    ) -> np.ndarray:
+
+        if self.pca_method == 'raw':
+            return self.pca.transform(features1) - self.pca.transform(features0)
+        elif self.pca_method == 'delta':
+            return self.pca.transform(features1 - features0)
+
+    def _features_from_embedding(
+        self,
+        z: torch.Tensor,
+        embedding: torch.Tensor
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
+        """From a given noise vector and embedding, calculate classifier
+        features and prediction.
+
+        Args:
+            z (torch.Tensor): Noise vector (from seed).
+            embedding (torch.Tensor): Embedding vector.
+
+        Returns:
+            tf.Tensor: Features vector.
+
+            tf.Tensor: Predictions vector.
+        """
+        if len(z.shape) == 1:
+            z = torch.unsqueeze(z, axis=0)
+        if len(embedding.shape) == 1:
+            embedding = torch.unsqueeze(embedding, axis=0)
+
+        start_img_batch = self.E_G(z, embedding, **self.gan_kwargs)
+        start_img_batch = tf_utils.process_gan_batch(start_img_batch)
+        start_img_batch = tf_utils.decode_batch(start_img_batch, normalizer=self.normalizer, resize_px=299)
+        features0, pred0 = self.classifier_features(start_img_batch)
+        pred0 = pred0[:, 0].numpy()
+        features0 = features0.numpy()
+        return features0, pred0
+
+    def _create_mask(
+        self,
+        e: int,
+        starting_mask: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+        """Creates an embedding mask.
+
+        The mask is an array of ones of length embedding_dim, with the index `e`
+        set to 0, multipled by a given starting mask.
+
+        Args:
+            e (int): Index of the mask to set to 0.
+            starting_mask (np.ndarray, optional): Multiply the mask by this
+                array. Defaults to None.
+
+        Returns:
+            np.ndarray: Embedding mask, shape=(num_embedding_dimensions,)
+        """
+        mask = np.ones(self.e_dim)
+        mask[e] = 0
+        if starting_mask is not None:
+            mask *= starting_mask
+        return mask
+
+    def _embedding_from_mask(self, mask_batch: np.ndarray) -> torch.Tensor:
+        mask = torch.from_numpy(mask_batch).to(self.device)
+        inv_mask_batch = (~mask_batch.astype(bool)).astype(int)
+        inv_mask = torch.from_numpy(inv_mask_batch).to(self.device)
+
+        # Create images from masked embeddings.
+        embed_batch = (((self.embed0.expand(len(mask_batch), -1) * mask)
+                        + (self.embed1.expand(len(mask_batch), -1) * inv_mask)))
+        return embed_batch
+
+    def _full_interpolation(self, z: torch.Tensor):
+
+        # Calculate features at the starting embedding.
+        features0, _ = self._features_from_embedding(z, self.embed0)
+        features1, _ = self._features_from_embedding(z, self.embed1)
+
+        # Calculate Principal Components (PC) from a full class interpolation
+        full_interp_pc = self._compare_pc(features0, features1)
+
+        if self.pca_method == 'delta':
+            # Calculate Principal Components (PC) from no interpolation
+            no_interp_pc = self.pca.transform([np.zeros(self.classifier_features.num_features)])
+
+            # Calculate difference in PCs with full interpolation
+            delta_pc_full = full_interp_pc - no_interp_pc
+        elif self.pca_method == 'raw':
+            no_interp_pc = 0
+            delta_pc_full = full_interp_pc
+
+        return features0, no_interp_pc, delta_pc_full
+
+    def _find_best_embedding_dim(
+        self,
+        z: torch.Tensor,
+        pc: int,
+        starting_dims: Optional[Iterable[int]] = None,
+        batch_size: int = 1,
+    ):
+        """For a given seed `z` and target Principal Component `pc`, find the
+        embedding dimension that, when traversed, maximally changes the given
+        PC while minimizing changes in other PCs.
+
+        Args:
+            z (torch.Tensor): Noise vector (seed).
+            pc (int): Target principal component.
+            starting_dims (list(int), optional): Baseline embedding dimensions
+                to traverse. If None, will not traverse any except the
+                dimension being searched. Defaults to None.
+            batch_size (int, optional): Batch size. Defaults to 1.
+
+        Returns:
+            int: Best embedding dimension.
+
+            float: Amount the target PC changed.
+
+            float: Amount all other PCs changed.
+        """
+        # Create starting mask
+        if starting_dims is None:
+            starting_dims = []
+        log.debug(f"Starting with dims {starting_dims}")
+        starting_mask = np.ones(self.e_dim)
+        for d in starting_dims:
+            starting_mask[d] = 0
+
+        # Full interpolation, for reference.
+        features0, no_interp_pc, delta_pc_full = self._full_interpolation(z)
+
+        # Prepare masks.
+        pcs = []
+        preds = []
+        dim_to_search = [d for d in list(range(self.e_dim)) if d not in starting_dims]
+        masks = [self._create_mask(e, starting_mask=starting_mask) for e in dim_to_search]
+
+        # GAN generator.
+        def gan_generator():
+            for mask_batch in sf.util.batch(masks, batch_size):
+                embed_batch = self._embedding_from_mask(np.stack(mask_batch))
+                img_batch = self.E_G(z.expand(len(mask_batch), -1), embed_batch, **self.gan_kwargs)
+                yield tf_utils.process_gan_batch(img_batch)
+
+        # Input data stream.
+        gan_end_dts = tf_utils.build_gan_dataset(gan_generator, 299, normalizer=self.normalizer)
+
+        # Calculate differences while interpolating across each dimension.
+        pb = tqdm(total=len(masks), leave=False, position=1, desc="Inner search")
+        for img_batch in gan_end_dts:
+            features_, pred_ = self.classifier_features(img_batch)
+            pred_ = pred_[:, 0].numpy()
+            features_ = tf.reshape(features_, (features_.shape[0], -1)).numpy()
+            pc_differences = self._compare_pc(features0, features_)
+            pcs += [pc_differences]
+            preds += [pred_]
+            pb.update(features_.shape[0])
+        pb.close()
+
+        # Calculate the effect of each embedding dimension
+        # on the change in a given principal component (PC) value.
+        preds = np.concatenate(preds)
+        pc_by_embedding = np.concatenate(pcs)
+        pc_proportion_by_embedding = (pc_by_embedding - no_interp_pc) / delta_pc_full
+        dim_idx, pc_change, other_pc_change = self._best_dim_by_pc_change(pc_proportion_by_embedding, pc=pc)
+        dim = dim_to_search[dim_idx]
+        return dim, pc_change, other_pc_change, preds[dim_idx]
+
+    def ordered_search(
+        self,
+        seed: int,
+        order: Iterable[int],
+        pc: int = 0,
+        batch_size: int = 1,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Perform an embedding search by progressively interpolating each
+        specified embedding dimension specified in `order`.
+
+        Use if the dimension search order is known (eg. from a previous search)
+
+        Args:
+            seed (int): Seed.
+            order (list(int)): List of embedding dimensions to progressively
+                transverse from class 1 -> class 2.
+            pc (int, optional): _description_. Defaults to 0.
+            plot (bool, optional): _description_. Defaults to False.
+
+        Returns:
+            np.ndarray: shape=(len(order), num_princpal_components).
+            Proportion of target PC traversed as each dimension is added.
+
+            np.ndarray: shape=(len(order), num_princpal_components).
+            Sum of proportion of other PCs traversed as each dimension is added.
+
+        """
+        print("Performing ordered search.")
+        z = utils.noise_tensor(seed, self.E_G.z_dim)[0].to(self.device)
+
+        # Full interpolation, for reference.
+        features0, no_interp_pc, delta_pc_full = self._full_interpolation(z)
+
+        self.pc_change = []
+        self.other_pc_change = []
+        self.preds = []
+
+        # Create embedding masks.
+        masks = [self._create_mask(e) for e in order]
+
+        # GAN generator.
+        def gan_generator():
+            for mask_batch in sf.util.batch(masks, batch_size):
+                embed_batch = self._embedding_from_mask(np.stack(mask_batch))
+                img_batch = self.E_G(z.expand(len(mask_batch), -1), embed_batch, **self.gan_kwargs)
+                yield tf_utils.process_gan_batch(img_batch)
+
+        # Input data stream.
+        gan_end_dts = tf_utils.build_gan_dataset(gan_generator, 299, normalizer=self.normalizer)
+
+        pb = tqdm(total = len(masks), leave=False)
+        for img_batch in gan_end_dts:
+            features_, pred_ = self.classifier_features(img_batch)
+            pred_ = pred_[:, 0].numpy()
+            features_ = tf.reshape(features_, (features_.shape[0], -1)).numpy()
+            pc_differences = self._compare_pc(features0, features_)
+
+            # Calculate the effect of each embedding dimension
+            # on the change in a given principal component (PC) value.
+            pc_proportions = (pc_differences - no_interp_pc) / delta_pc_full
+            _, _pc_change, _other_pc_change = self._best_dim_by_pc_change(pc_proportions, pc=pc)
+            self.pc_change += [_pc_change]
+            self.other_pc_change += [_other_pc_change]
+            self.preds += [pred_]
+            pb.update(features_.shape[0])
+
+        self.pc_change = np.array(self.pc_change)
+        self.other_pc_change = np.array(self.other_pc_change)
+        self.preds = np.concatenate(self.preds)
+
+    def full_search(
+        self,
+        seed: int,
+        pc: int,
+        depth: Optional[int] = None,
+        batch_size: int = 1,
+        verbose: bool = True,
+    ) -> Tuple[List[int], List[float], List[float]]:
+        """Perform a full embedding search.
+
+        Args:
+            seed (int): Seed.
+            pc (int): Principal component to evaluate.
+            depth (int, optional): Maximum number of dimension combinations
+                to search. If None, will search through all possible dimensions
+                (size of the embedding). Defaults to None.
+            batch_size (int, optional): Batch size. Defaults to 1.
+            plot (bool, optional): Plot embedding search results.
+                Defaults to False.
+
+        Returns:
+            List[int]: Dimensions selected, in order.
+
+            List[float]: Proportion of target PC changed as each dimension is
+            added.
+
+            List[float]: Sum of abs(proportions) of all other target PCs changed
+            as each dimension is added.
+        """
+        if depth is None:
+            depth = self.e_dim
+
+        print(col.bold(f"\nPerforming search for PC={pc} on seed={seed} with depth={depth}"))
+
+        z = utils.noise_tensor(seed, z_dim=self.E_G.z_dim)[0].to(self.device)
+        self.selected_dims = []
+        self.pc_change = []
+        self.other_pc_change = []
+        self.preds = []
+        outer_pb = tqdm(total=depth, leave=False, position=0, desc="Outer search")
+        for d in range(depth):
+            dim, _pc_change, _other_pc_change, _preds = self._find_best_embedding_dim(
+                z,
+                pc=pc,
+                starting_dims=self.selected_dims,
+                batch_size=batch_size,
+            )
+            if verbose:
+                tqdm.write("{}: Chose {}, {:.3f} percent PC {}, {:.3f} other PC".format(
+                    col.blue(f'Depth {d}'),
+                    dim,
+                    _pc_change,
+                    pc,
+                    _other_pc_change
+                ))
+            self.selected_dims += [dim]
+            self.pc_change += [_pc_change]
+            self.other_pc_change += [_other_pc_change]
+            self.preds += [_preds]
+            outer_pb.update(1)
+        outer_pb.close()

--- a/slideflow/gan/search.py
+++ b/slideflow/gan/search.py
@@ -1,3 +1,4 @@
+"""Various search functions for use with GAN embedding interpolation."""
 
 from typing import Iterable, List, Optional, Tuple, Union
 

--- a/slideflow/gan/tf_utils.py
+++ b/slideflow/gan/tf_utils.py
@@ -1,0 +1,137 @@
+from functools import partial
+from typing import TYPE_CHECKING, Callable, Optional
+
+import numpy as np
+import slideflow as sf
+import tensorflow as tf
+import torch
+from torchvision import transforms
+
+if TYPE_CHECKING:
+    from slideflow.norm import StainNormalizer
+
+
+def decode_img(
+    img: np.ndarray,
+    normalizer: Optional["StainNormalizer"] = None
+) -> np.ndarray:
+    if normalizer is not None:
+        img = normalizer.rgb_to_rgb(img)
+    img = np.expand_dims(img, axis=0)
+    tf_img = tf.image.per_image_standardization(img)
+    return {'tile_image': tf_img}
+
+
+@tf.function
+def decode_batch(
+    img,
+    normalizer: Optional["StainNormalizer"] = None,
+    standardize: bool = True,
+    resize_px: Optional[int] = None,
+    resize_method: str = 'lanczos3',
+    resize_aa: bool = True,
+) -> np.ndarray:
+    if resize_px is not None:
+        img = tf.image.resize(img, (resize_px, resize_px), method=resize_method, antialias=resize_aa)
+        img = tf.cast(img, tf.uint8)
+    if normalizer is not None:
+        img = normalizer.batch_to_batch(img)[0]
+    if standardize:
+        img = tf.image.per_image_standardization(img)
+    return {'tile_image': img}
+
+
+def process_gan_raw(img, normalizer=None, **kwargs):
+    """Process raw GAN output, returning a
+    non-normalized image Tensor (for viewing)
+    and a normalized image Tensor (for inference)
+    """
+    img = process_gan_batch(img)
+    img = decode_batch(img, **kwargs)['tile_image']
+    if normalizer is not None:
+        img = normalizer.batch_to_batch(img)[0]
+    processed_img = tf.image.per_image_standardization(img)
+    return img, processed_img
+
+
+def build_gan_dataset(
+    generator: Callable,
+    target_px: int,
+    normalizer: Optional[sf.norm.StainNormalizer] = None
+) -> tf.data.Dataset:
+    """Builds a processed GAN image dataset from a generator.
+
+    Args:
+        generator (Callable): GAN generator which yields a GAN image batch.
+        normalizer (Optional[sf.norm.StainNormalizer], optional): Stain
+            normalizer. Defaults to None.
+
+    Returns:
+        tf.data.Dataset: Processed dataset.
+    """
+    sig = tf.TensorSpec(shape=(None, None, None, 3), dtype=tf.uint8)
+    dts = tf.data.Dataset.from_generator(generator, output_signature=sig)
+    dts = dts.map(
+        partial(decode_batch, normalizer=normalizer, resize_px=target_px),
+        num_parallel_calls=tf.data.AUTOTUNE,
+        deterministic=True
+    )
+    return dts
+
+
+def vips_resize(img, crop_width, target_px):
+    import pyvips
+    img_data = np.ascontiguousarray(img.numpy()).data
+    vips_image = pyvips.Image.new_from_memory(img_data, crop_width, crop_width, bands=3, format="uchar")
+    vips_image = vips_image.resize(target_px/crop_width)
+    img = sf.slide.vips2numpy(vips_image)
+    return img
+
+
+def process_gan_batch(
+    img: torch.Tensor,
+    resize_method=None,
+    gan_um: int = 400,
+    gan_px: int = 512,
+    target_um: int = 302,
+    target_px: int = 299
+) -> tf.Tensor:
+
+    if (resize_method is not None
+       and resize_method not in ('torch', 'torch_aa', 'vips')):
+        raise ValueError(f'Invalid resize method {resize_method}')
+
+    # Calculate parameters for resize/crop.
+    crop_factor = target_um / gan_um
+    crop_width = int(crop_factor * gan_px)
+    left = int(gan_px/2 - crop_width/2)
+    upper = int(gan_px/2 - crop_width/2)
+
+    # Perform crop/resize and convert to tensor
+    img = transforms.functional.crop(img, upper, left, crop_width, crop_width)
+
+    # Resize with PyTorch
+    if resize_method in ('torch', 'torch_aa'):
+        img = transforms.functional.resize(img, (target_px, target_px), antialias=(resize_method=='torch_aa'))
+
+    # Re-order the dimension from BCWH -> BWHC
+    img = (img.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8).cpu()
+
+    # Resize with VIPS
+    if resize_method == 'vips':
+        img = [vips_resize(i, crop_width=crop_width, target_px=target_px) for i in img]
+
+    # Convert to Tensorflow tensor
+    img = tf.convert_to_tensor(img)
+
+    return img
+
+
+def process_gan_uint8(img):
+    """Process a GAN uint8 image, returning a
+    non-normalized image Tensor (for viewing)
+    and a normalized image Tensor (for inference)
+    """
+    img = torch.from_numpy(np.expand_dims(img, axis=0)).permute(0, 3, 1, 2)
+    img = (img / 127.5) - 1
+    return process_gan_raw(img)

--- a/slideflow/gan/tf_utils.py
+++ b/slideflow/gan/tf_utils.py
@@ -1,7 +1,7 @@
 """Utilities for processing PyTorch GAN output into Tensorflow tensors."""
 
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Union
 
 import numpy as np
 import slideflow as sf
@@ -13,47 +13,47 @@ if TYPE_CHECKING:
     from slideflow.norm import StainNormalizer
 
 
-def decode_img(
-    img: np.ndarray,
-    normalizer: Optional["StainNormalizer"] = None
-) -> np.ndarray:
-    if normalizer is not None:
-        img = normalizer.rgb_to_rgb(img)
-    img = np.expand_dims(img, axis=0)
-    tf_img = tf.image.per_image_standardization(img)
-    return {'tile_image': tf_img}
-
-
 @tf.function
 def decode_batch(
-    img,
+    img: tf.Tensor,
     normalizer: Optional["StainNormalizer"] = None,
     standardize: bool = True,
     resize_px: Optional[int] = None,
     resize_method: str = 'lanczos3',
     resize_aa: bool = True,
-) -> np.ndarray:
+) -> Dict[str, tf.Tensor]:
+    """Process batch of tensorflow images, resizing, normalizing,
+    and standardizing.
+
+    Args:
+        img (tf.Tensor): Batch of tensorflow images (uint8).
+        normalizer (sf.norm.StainNormalizer, optional): Normalizer.
+            Defaults to None.
+        standardize (bool, optional): Standardize images. Defaults to True.
+        resize_px (Optional[int], optional): Resize images. Defaults to None.
+        resize_method (str, optional): Resize method. Defaults to 'lanczos3'.
+        resize_aa (bool, optional): Apply antialiasing during resizing.
+            Defaults to True.
+
+    Returns:
+        Dict[str, tf.Tensor]: Processed image.
+    """
     if resize_px is not None:
-        img = tf.image.resize(img, (resize_px, resize_px), method=resize_method, antialias=resize_aa)
+        img = tf.image.resize(
+            img,
+            (resize_px, resize_px),
+            method=resize_method,
+            antialias=resize_aa
+        )
         img = tf.cast(img, tf.uint8)
     if normalizer is not None:
-        img = normalizer.batch_to_batch(img)[0]
+        if normalizer.vectorized:
+            img = normalizer.batch_to_batch(img)  # type: ignore
+        else:
+            img = tf.stack([normalizer.tf_to_tf(_i) for _i in img])
     if standardize:
         img = tf.image.per_image_standardization(img)
     return {'tile_image': img}
-
-
-def process_gan_raw(img, normalizer=None, **kwargs):
-    """Process raw GAN output, returning a
-    non-normalized image Tensor (for viewing)
-    and a normalized image Tensor (for inference)
-    """
-    img = process_gan_batch(img)
-    img = decode_batch(img, **kwargs)['tile_image']
-    if normalizer is not None:
-        img = normalizer.batch_to_batch(img)[0]
-    processed_img = tf.image.per_image_standardization(img)
-    return img, processed_img
 
 
 def build_gan_dataset(
@@ -81,27 +81,64 @@ def build_gan_dataset(
     return dts
 
 
-def vips_resize(img, crop_width, target_px):
+def vips_resize(
+    img: Union[torch.Tensor, tf.Tensor],
+    crop_width: int,
+    target_px: int
+) -> np.ndarray:
+    """Resizes and crops an image tensor using libvips.resize()
+
+    Args:
+        img (Union[torch.Tensor, tf.Tensor]): Image.
+        crop_width (int): Height/width of image crop (before resize).
+        target_px (int): Target size of final image after resizing.
+
+    Returns:
+        np.ndarray: Resized image.
+    """
     import pyvips
     img_data = np.ascontiguousarray(img.numpy()).data
     vips_image = pyvips.Image.new_from_memory(img_data, crop_width, crop_width, bands=3, format="uchar")
     vips_image = vips_image.resize(target_px/crop_width)
-    img = sf.slide.vips2numpy(vips_image)
-    return img
+    return sf.slide.vips2numpy(vips_image)
 
 
 def process_gan_batch(
     img: torch.Tensor,
-    resize_method=None,
-    gan_um: int = 400,
-    gan_px: int = 512,
-    target_um: int = 302,
-    target_px: int = 299
+    gan_um: int,
+    gan_px: int,
+    target_um: int,
+    target_px: Optional[int] = None,
+    resize_method: Optional[str] = None
 ) -> tf.Tensor:
+    """Process a batch of raw GAN output, converting to a Tensorflow tensor.
+
+    Args:
+        img (torch.Tensor): Raw batch of GAN images.
+        resize_method (Optional[str], optional): Resize images after crop.
+            Methods include 'torch', 'torch_aa', and 'vips'. 'torch' methods
+            use torchvision.transforms.resize, with (torch_aa) or without
+            (torch) antialiasing. 'vips' uses the libvips resize method.
+            Defaults to None (no resizing).
+        gan_um (int, optional): Size of gan output images, in microns.
+        gan_px (int, optional): Size of gan output images, in pixels.
+        target_um (int, optional): Size of target images, in microns.
+            Will crop image to meet this target.
+        target_px (int, optional): Size of target images, in pixels.
+            Will crop image to meet this target.
+
+    Raises:
+        ValueError: If the method is invalid.
+
+    Returns:
+        tf.Tensor: Cropped and resized image (uint8).
+    """
 
     if (resize_method is not None
        and resize_method not in ('torch', 'torch_aa', 'vips')):
         raise ValueError(f'Invalid resize method {resize_method}')
+    if resize_method is not None and target_px is None:
+        raise ValueError("If resizing, target_px must not be None.")
 
     # Calculate parameters for resize/crop.
     crop_factor = target_um / gan_um
@@ -121,19 +158,12 @@ def process_gan_batch(
 
     # Resize with VIPS
     if resize_method == 'vips':
-        img = [vips_resize(i, crop_width=crop_width, target_px=target_px) for i in img]
+        img = [
+            vips_resize(i, crop_width=crop_width, target_px=target_px)  # type: ignore
+            for i in img
+        ]  # type: ignore
 
     # Convert to Tensorflow tensor
     img = tf.convert_to_tensor(img)
 
     return img
-
-
-def process_gan_uint8(img):
-    """Process a GAN uint8 image, returning a
-    non-normalized image Tensor (for viewing)
-    and a normalized image Tensor (for inference)
-    """
-    img = torch.from_numpy(np.expand_dims(img, axis=0)).permute(0, 3, 1, 2)
-    img = (img / 127.5) - 1
-    return process_gan_raw(img)

--- a/slideflow/gan/tf_utils.py
+++ b/slideflow/gan/tf_utils.py
@@ -1,3 +1,5 @@
+"""Utilities for processing PyTorch GAN output into Tensorflow tensors."""
+
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Optional
 

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -1,15 +1,15 @@
-#from matplotlib.widgets import MultiCursor
-from itertools import chain
+from typing import Dict, Optional
 
 import numpy as np
 import saliency.core as saliency
 import tensorflow as tf
-from matplotlib import pyplot as plt
-from PIL import Image
-from slideflow.util import batch
+from slideflow.grad.plot_utils import (comparison_plot, inferno, multi_plot,
+                                       oranges, overlay,
+                                       saliency_map_comparison)
 
 
 class SaliencyMap:
+
     def __init__(self, model, class_idx):
         self.model = model
         self.class_idx = class_idx
@@ -22,7 +22,7 @@ class SaliencyMap:
         self.fast_xrai_params.algorithm = 'fast'
         self.masks = {}
 
-    def grad_fn(self, image, call_model_args=None, expected_keys=None):
+    def _grad_fn(self, image, call_model_args=None, expected_keys=None):
         image = tf.convert_to_tensor(image)
         with tf.GradientTape() as tape:
             if expected_keys == [saliency.base.INPUT_OUTPUT_GRADIENTS]:
@@ -35,20 +35,31 @@ class SaliencyMap:
                 # For Grad-CAM
                 raise ValueError
 
-    def _calc_vanilla_map(self, img, mask_fn, **kwargs):
-        mask_3d = mask_fn(img, self.grad_fn, **kwargs)
-        return grayscale(mask_3d)
+    def _apply_mask_fn(
+        self,
+        img: np.ndarray,
+        grads: saliency.CoreSaliency,
+        baseline: bool  =False,
+        smooth: bool = False,
+        **kwargs
+    ) -> np.ndarray:
+        """Applys a saliency masking function to a gradients map.
 
-    def _calc_ig_map(self, img, mask_fn, x_steps=25, batch_size=20, **kwargs):
+        Args:
+            img (np.ndarray or list(np.ndarray)): Image or list of images.
+            grads (saliency.CoreSaliency): Gradients for saliency.
+            baseline (bool): Requires x_baseline argument.
+            smooth (bool): Use a smoothed mask.
+
+        Returns:
+            np.ndarray: Saliency map.
+        """
+        mask_fn = grads.GetSmoothedMask if smooth else grads.GetMask
 
         def _get_mask(_img):
-            return mask_fn(
-                _img,
-                self.grad_fn,
-                x_baseline=np.zeros(_img.shape),
-                x_steps=x_steps,
-                batch_size=batch_size
-            )
+            if baseline:
+                kwargs.update({'x_baseline': np.zeros(_img.shape)})
+            return mask_fn(_img, self._grad_fn, **kwargs)
 
         if isinstance(img, list):
             # Normalize together
@@ -60,77 +71,110 @@ class SaliencyMap:
         else:
             return grayscale(_get_mask(img))
 
-    def _calc_guided_ig_map(self, img, mask_fn, x_steps=25, max_dist=1.0, fraction=0.5):
-        mask_3d = mask_fn(
-            img,
-            self.grad_fn,
-            x_baseline=np.zeros(img.shape),
-            x_steps=x_steps,
-            max_dist=max_dist,
-            fraction=fraction
-        )
-        return grayscale(mask_3d)
-
-    def _calc_blur_ig_map(self, img, mask_fn, batch_size=20):
-        mask_3d = mask_fn(img, self.grad_fn, batch_size=batch_size)
-        return grayscale(mask_3d)
-
-    def all_maps(self, img):
+    def all(self, img: np.ndarray) -> Dict:
         return {
-            'Vanilla': self.vanilla_map(img),
-            'Vanilla (Smoothed)': self.vanilla_map_smooth(img),
-            'Integrated Gradients': self.integrated_gradients_map(img),
-            'Integrated Gradients (Smooth)': self.integrated_gradients_map_smooth(img),
-            'Guided Integrated Gradients': self.guided_integrated_gradients_map(img),
-            'Guided Integrated Gradients (Smooth)': self.guided_integrated_gradients_map_smooth(img),
-            'Blur Integrated Gradients': self.blur_integrated_gradients_map(img),
-            'Blur Integrated Gradients (Smooth)': self.blur_integrated_gradients_map_smooth(img),
+            'Vanilla': self.vanilla(img),
+            'Vanilla (Smoothed)': self.vanilla(img, smooth=True),
+            'Integrated Gradients': self.integrated_gradients(img),
+            'Integrated Gradients (Smooth)': self.integrated_gradients(img, smooth=True),
+            'Guided Integrated Gradients': self.guided_integrated_gradients(img),
+            'Guided Integrated Gradients (Smooth)': self.guided_integrated_gradients(img, smooth=True),
+            'Blur Integrated Gradients': self.blur_integrated_gradients(img),
+            'Blur Integrated Gradients (Smooth)': self.blur_integrated_gradients(img, smooth=True),
         }
 
-    def vanilla_map(self, img, **kwargs):
-        return self._calc_vanilla_map(img, self.gradients.GetMask, **kwargs)
+    def vanilla(
+        self,
+        img: np.ndarray,
+        smooth: bool = False,
+        **kwargs
+    ) -> np.ndarray:
+        return self._apply_mask_fn(
+            img,
+            self.gradients,
+            smooth=smooth,
+            **kwargs
+        )
 
-    def vanilla_map_smooth(self, img, **kwargs):
-        return self._calc_vanilla_map(img, self.gradients.GetSmoothedMask, **kwargs)
+    def integrated_gradients(
+        self,
+        img: np.ndarray,
+        x_steps: int = 25,
+        batch_size: int = 20,
+        smooth: bool = False,
+        **kwargs
+    ) -> np.ndarray:
+        return self._apply_mask_fn(
+            img,
+            self.ig,
+            smooth=smooth,
+            x_steps=x_steps,
+            batch_size=batch_size,
+            baseline=True,
+            **kwargs
+        )
 
-    def integrated_gradients_map(self, img, **kwargs):
-        return self._calc_ig_map(img, self.ig.GetMask, **kwargs)
+    def guided_integrated_gradients(
+        self,
+        img: np.ndarray,
+        x_steps: int = 25,
+        max_dist: float = 1.0,
+        fraction: float = 0.5,
+        smooth: bool = False,
+        **kwargs
+    ) -> np.ndarray:
+        return self._apply_mask_fn(
+            img,
+            self.guided_ig,
+            x_steps=x_steps,
+            max_dist=max_dist,
+            fraction=fraction,
+            smooth=smooth,
+            baseline=True,
+            **kwargs
+        )
 
-    def integrated_gradients_map_smooth(self, img, **kwargs):
-        return self._calc_ig_map(img, self.ig.GetSmoothedMask, **kwargs)
+    def blur_integrated_gradients(
+        self,
+        img: np.ndarray,
+        batch_size: int = 20,
+        smooth: bool = False,
+        **kwargs
+    ) -> np.ndarray:
+        return self._apply_mask_fn(
+            img,
+            self.blur_ig,
+            smooth=smooth,
+            batch_size=batch_size,
+            **kwargs
+        )
 
-    def guided_integrated_gradients_map(self, img, **kwargs):
-        return self._calc_guided_ig_map(img, self.guided_ig.GetMask, **kwargs)
-
-    def guided_integrated_gradients_map_smooth(self, img, **kwargs):
-        return self._calc_guided_ig_map(img, self.guided_ig.GetSmoothedMask, **kwargs)
-
-    def blur_integrated_gradients_map(self, img, **kwargs):
-        return self._calc_blur_ig_map(img, self.blur_ig.GetMask, **kwargs)
-
-    def blur_integrated_gradients_map_smooth(self, img, **kwargs):
-        return self._calc_blur_ig_map(img, self.blur_ig.GetSmoothedMask, **kwargs)
-
-    def xrai_map(self, img, batch_size=20, **kwargs):
-        return self.xrai.GetMask(img, self.grad_fn, batch_size=batch_size, **kwargs)
-
-    def xrai_map_fast(self, img, batch_size=20, **kwargs):
+    def xrai(
+        self,
+        img: np.ndarray,
+        batch_size: int = 20,
+        **kwargs
+    ) -> np.ndarray:
         return self.xrai.GetMask(
             img,
-            self.grad_fn,
+            self._grad_fn,
+            batch_size=batch_size,
+            **kwargs
+        )
+
+    def xrai_fast(
+        self,
+        img: np.ndarray,
+        batch_size: int = 20,
+        **kwargs
+    ) -> np.ndarray:
+        return self.xrai.GetMask(
+            img,
+            self._grad_fn,
             batch_size=batch_size,
             extra_parameters=self.fast_xrai_params,
-            **kwargs)
-
-
-def inferno(img):
-    cmap = plt.get_cmap('inferno')
-    return (cmap(img) * 255).astype(np.uint8)
-
-
-def oranges(img):
-    cmap = plt.get_cmap('Oranges')
-    return (cmap(img) * 255).astype(np.uint8)
+            **kwargs
+        )
 
 
 def grayscale(image_3d, vmax=None, vmin=None, percentile=99):
@@ -144,88 +188,8 @@ def grayscale(image_3d, vmax=None, vmin=None, percentile=99):
     return np.clip((image_2d - vmin) / (vmax - vmin), 0, 1)
 
 
-def overlay(image, mask):
-    base = Image.fromarray(image)
-    cmap = Image.fromarray(oranges(mask))
-    cmap.putalpha(int(0.6*255))
-    base.paste(cmap, mask=cmap)
-    return np.array(base)
-
-
 def max_min(image_3d, percentile=99):
     image_2d = np.sum(np.abs(image_3d), axis=2)
     vmax = np.percentile(image_2d, percentile)
     vmin = np.min(image_2d)
     return vmax, vmin
-
-
-def comparison_plot(original, maps, cmap=plt.cm.gray):
-    n_rows = 3
-    n_cols = 3
-    scale = 5
-    ax_idx = [[i, j] for i in range(n_rows) for j in range(n_cols)]
-    fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_rows * scale, n_cols * scale))
-    #multi = MultiCursor(fig.canvas, list(chain.from_iterable(ax)), color='r', lw=1)
-
-    ax[ax_idx[0][0], ax_idx[0][1]].axis('off')
-    ax[ax_idx[0][0], ax_idx[0][1]].imshow(original)
-    ax[ax_idx[0][0], ax_idx[0][1]].set_title('Original')
-
-    for i, (map_name, map_img) in enumerate(maps.items()):
-        ax[ax_idx[i+1][0], ax_idx[i+1][1]].axis('off')
-        ax[ax_idx[i+1][0], ax_idx[i+1][1]].imshow(map_img, cmap=cmap, vmin=0, vmax=1)
-        ax[ax_idx[i+1][0], ax_idx[i+1][1]].set_title(map_name)
-
-    fig.subplots_adjust(wspace=0, hspace=0)
-
-def multi_plot(originals, maps, method='adjacent', n_rows=4, cmap='inferno'):
-    assert method in ('adjacent', 'overlay')
-    orig_batch = list(batch(originals, n_rows))
-    maps_batch = list(batch(maps, n_rows))
-    n_cols = len(orig_batch) * 4
-    scale = 5
-
-    gridspec = dict(hspace=0.0, width_ratios=[1, 1, 1, 0.2]*len(orig_batch))
-    figsize = (n_cols * scale * 0.79, n_rows * scale)
-    fig, ax = plt.subplots(n_rows, n_cols, figsize=figsize, gridspec_kw=gridspec)
-
-    def remove_ticks(axis):
-        axis.spines.right.set_visible(False)
-        axis.spines.top.set_visible(False)
-        axis.spines.left.set_visible(False)
-        axis.spines.bottom.set_visible(False)
-        axis.set_xticklabels([])
-        axis.set_xticks([])
-        axis.set_yticklabels([])
-        axis.set_yticks([])
-
-    for c in range(len(orig_batch)):
-        for r in range(len(orig_batch[c])):
-            _c = c * 4
-
-            ax[r, _c+3].set_visible(False)
-
-            remove_ticks(ax[r, _c])
-            ax[r, _c].set_ylabel(f"{(c*4)+r}")
-            ax[r, _c].imshow(orig_batch[c][r])
-            ax[r, _c].set_aspect('equal')
-            ax
-
-            ax[r, _c+1].axis('off')
-            ax[r, _c+1].imshow(orig_batch[c][r])
-            ax[r, _c+1].set_aspect('equal')
-
-            ax[r, _c+1].axis('off')
-            ax[r, _c+1].imshow(maps_batch[c][r], cmap='Oranges', vmin=0, vmax=1, alpha=0.6)
-            ax[r, _c+1].set_aspect('equal')
-
-            ax[r, _c+2].axis('off')
-            ax[r, _c+2].imshow(maps_batch[c][r], cmap=cmap, vmin=0, vmax=1)
-            ax[r, _c+2].set_aspect('equal')
-
-            if r == 0:
-                ax[r, _c].set_title("Original")
-                ax[r, _c+1].set_title("Overlay")
-                ax[r, _c+2].set_title("Saliency Map")
-
-    fig.subplots_adjust(wspace=0, hspace=0)

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -1,11 +1,12 @@
-import tensorflow as tf
-import numpy as np
-from matplotlib import pyplot as plt
 #from matplotlib.widgets import MultiCursor
 from itertools import chain
+
+import numpy as np
+import saliency.core as saliency
+import tensorflow as tf
+from matplotlib import pyplot as plt
 from slideflow.util import batch
 
-import saliency.core as saliency
 
 class SaliencyMap:
     def __init__(self, model, class_idx):
@@ -32,7 +33,7 @@ class SaliencyMap:
             else:
                 # For Grad-CAM
                 raise ValueError
-    
+
     def _calc_vanilla_map(self, img, mask_fn, **kwargs):
         mask_3d = mask_fn(img, self.grad_fn, **kwargs)
         return saliency.VisualizeImageGrayscale(mask_3d)
@@ -61,11 +62,11 @@ class SaliencyMap:
     def _calc_blur_ig_map(self, img, mask_fn, batch_size=20):
         mask_3d = mask_fn(img, self.grad_fn, batch_size=batch_size)
         return saliency.VisualizeImageGrayscale(mask_3d)
-    
+
     def all_maps(self, img):
         return {
             'Vanilla': self.vanilla_map(img),
-            'Vanilla (Smoothed)': self.vanilla_map_smooth(img), 
+            'Vanilla (Smoothed)': self.vanilla_map_smooth(img),
             'Integrated Gradients': self.integrated_gradients_map(img),
             'Integrated Gradients (Smooth)': self.integrated_gradients_map_smooth(img),
             'Guided Integrated Gradients': self.guided_integrated_gradients_map(img),
@@ -79,19 +80,19 @@ class SaliencyMap:
 
     def vanilla_map_smooth(self, img, **kwargs):
         return self._calc_vanilla_map(img, self.gradients.GetSmoothedMask, **kwargs)
-    
+
     def integrated_gradients_map(self, img, **kwargs):
         return self._calc_ig_map(img, self.ig.GetMask, **kwargs)
 
     def integrated_gradients_map_smooth(self, img, **kwargs):
         return self._calc_ig_map(img, self.ig.GetSmoothedMask, **kwargs)
-        
+
     def guided_integrated_gradients_map(self, img, **kwargs):
         return self._calc_guided_ig_map(img, self.guided_ig.GetMask, **kwargs)
 
     def guided_integrated_gradients_map_smooth(self, img, **kwargs):
         return self._calc_guided_ig_map(img, self.guided_ig.GetSmoothedMask, **kwargs)
-        
+
     def blur_integrated_gradients_map(self, img, **kwargs):
         return self._calc_blur_ig_map(img, self.blur_ig.GetMask, **kwargs)
 
@@ -100,13 +101,13 @@ class SaliencyMap:
 
     def xrai_map(self, img, batch_size=20, **kwargs):
         return self.xrai.GetMask(img, self.grad_fn, batch_size=batch_size, **kwargs)
-    
+
     def xrai_map_fast(self, img, batch_size=20, **kwargs):
         return self.xrai.GetMask(
-            img, 
-            self.grad_fn, 
-            batch_size=batch_size, 
-            extra_parameters=self.fast_xrai_params, 
+            img,
+            self.grad_fn,
+            batch_size=batch_size,
+            extra_parameters=self.fast_xrai_params,
             **kwargs)
 
 
@@ -117,27 +118,29 @@ def comparison_plot(original, maps, cmap=plt.cm.gray):
     ax_idx = [[i, j] for i in range(n_rows) for j in range(n_cols)]
     fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_rows * scale, n_cols * scale))
     #multi = MultiCursor(fig.canvas, list(chain.from_iterable(ax)), color='r', lw=1)
-    
-    ax[ax_idx[0][0], ax_idx[0][1]].axis('off') 
+
+    ax[ax_idx[0][0], ax_idx[0][1]].axis('off')
     ax[ax_idx[0][0], ax_idx[0][1]].imshow(original)
     ax[ax_idx[0][0], ax_idx[0][1]].set_title('Original')
-    
+
     for i, (map_name, map_img) in enumerate(maps.items()):
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].axis('off')
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].imshow(map_img, cmap=cmap, vmin=0, vmax=1)
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].set_title(map_name)
-        
+
+    fig.subplots_adjust(wspace=0, hspace=0)
+
 def multi_plot(originals, maps, method='adjacent', n_rows=4, cmap='inferno'):
     assert method in ('adjacent', 'overlay')
     orig_batch = list(batch(originals, n_rows))
     maps_batch = list(batch(maps, n_rows))
     n_cols = len(orig_batch) * 4
     scale = 5
-    
-    gridspec = dict(hspace=0.0, width_ratios=[1, 1, 1, 0.2, 1, 1, 1, 0.2])
+
+    gridspec = dict(hspace=0.0, width_ratios=[1, 1, 1, 0.2]*len(orig_batch))
     figsize = (n_cols * scale * 0.79, n_rows * scale)
     fig, ax = plt.subplots(n_rows, n_cols, figsize=figsize, gridspec_kw=gridspec)
-    
+
     def remove_ticks(axis):
         axis.spines.right.set_visible(False)
         axis.spines.top.set_visible(False)
@@ -147,34 +150,34 @@ def multi_plot(originals, maps, method='adjacent', n_rows=4, cmap='inferno'):
         axis.set_xticks([])
         axis.set_yticklabels([])
         axis.set_yticks([])
-        
+
     for c in range(len(orig_batch)):
-        for r in range(n_rows):
+        for r in range(len(orig_batch[c])):
             _c = c * 4
-            
+
             ax[r, _c+3].set_visible(False)
-            
+
             remove_ticks(ax[r, _c])
-            ax[r, _c].set_ylabel(f"{(c*3)+r}")
+            ax[r, _c].set_ylabel(f"{(c*4)+r}")
             ax[r, _c].imshow(orig_batch[c][r])
             ax[r, _c].set_aspect('equal')
             ax
-            
-            ax[r, _c+1].axis('off') 
+
+            ax[r, _c+1].axis('off')
             ax[r, _c+1].imshow(orig_batch[c][r])
             ax[r, _c+1].set_aspect('equal')
-            
+
             ax[r, _c+1].axis('off')
             ax[r, _c+1].imshow(maps_batch[c][r], cmap='Oranges', vmin=0, vmax=1, alpha=0.6)
             ax[r, _c+1].set_aspect('equal')
-            
+
             ax[r, _c+2].axis('off')
             ax[r, _c+2].imshow(maps_batch[c][r], cmap=cmap, vmin=0, vmax=1)
             ax[r, _c+2].set_aspect('equal')
-            
+
             if r == 0:
                 ax[r, _c].set_title("Original")
                 ax[r, _c+1].set_title("Overlay")
                 ax[r, _c+2].set_title("Saliency Map")
-        
+
     fig.subplots_adjust(wspace=0, hspace=0)

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -1,4 +1,6 @@
-from typing import Dict
+"""Submodule for calculating/displaying pixel attribution (saliency maps)."""
+
+from typing import Any, Callable, Dict
 
 import numpy as np
 import saliency.core as saliency
@@ -10,7 +12,14 @@ from slideflow.grad.plot_utils import (comparison_plot, inferno, multi_plot,
 
 class SaliencyMap:
 
-    def __init__(self, model, class_idx):
+    def __init__(self, model: Callable, class_idx: int) -> None:
+        """Class to assist with calculation and display of saliency maps.
+
+        Args:
+            model (Callable): Differentiable model from which saliency is
+                calculated.
+            class_idx (int): Index of class for backpropagating gradients.
+        """
         self.model = model
         self.class_idx = class_idx
         self.gradients = saliency.GradientSaliency()
@@ -22,7 +31,13 @@ class SaliencyMap:
         self.fast_xrai_params.algorithm = 'fast'
         self.masks = {}
 
-    def _grad_fn(self, image, call_model_args=None, expected_keys=None):
+    def _grad_fn(
+        self,
+        image: np.ndarray,
+        call_model_args: Any = None,
+        expected_keys: Dict = None
+    ) -> Any:
+        """Calculate gradient attribution."""
         image = tf.convert_to_tensor(image)
         with tf.GradientTape() as tape:
             if expected_keys == [saliency.base.INPUT_OUTPUT_GRADIENTS]:

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict
 
 import numpy as np
 import saliency.core as saliency
@@ -64,7 +64,7 @@ class SaliencyMap:
 
         if isinstance(img, list):
             # Normalize together
-            image_3d = [_get_mask(_img) for _img in img]
+            image_3d = map(_get_mask, img)
             v_maxes, v_mins = zip(*[max_min(img3d) for img3d in image_3d])
             vmax = max(v_maxes)
             vmin = min(v_mins)

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -8,8 +8,9 @@ from slideflow.util import batch
 import saliency.core as saliency
 
 class SaliencyMap:
-    def __init__(self, model):
+    def __init__(self, model, class_idx):
         self.model = model
+        self.class_idx = class_idx
         self.gradients = saliency.GradientSaliency()
         self.ig = saliency.IntegratedGradients()
         self.guided_ig = saliency.GuidedIG()
@@ -25,7 +26,7 @@ class SaliencyMap:
             if expected_keys == [saliency.base.INPUT_OUTPUT_GRADIENTS]:
                 # For vanilla gradient, Integrated Gradients, XRAI
                 tape.watch(image)
-                output = self.model(image)[:, 0]
+                output = self.model(image)[:, self.class_idx]
                 gradients = tape.gradient(output, image)
                 return {saliency.base.INPUT_OUTPUT_GRADIENTS: gradients}
             else:
@@ -125,21 +126,55 @@ def comparison_plot(original, maps, cmap=plt.cm.gray):
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].axis('off')
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].imshow(map_img, cmap=cmap, vmin=0, vmax=1)
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].set_title(map_name)
-
-def side_by_side_plot(originals, maps, n_rows=4, cmap=plt.cm.gray):
+        
+def multi_plot(originals, maps, method='adjacent', n_rows=4, cmap='inferno'):
+    assert method in ('adjacent', 'overlay')
     orig_batch = list(batch(originals, n_rows))
     maps_batch = list(batch(maps, n_rows))
-    n_cols = len(orig_batch)*2
+    n_cols = len(orig_batch) * 4
     scale = 5
-    fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_cols * scale, n_rows * scale))
-
+    
+    gridspec = dict(hspace=0.0, width_ratios=[1, 1, 1, 0.2, 1, 1, 1, 0.2])
+    figsize = (n_cols * scale * 0.79, n_rows * scale)
+    fig, ax = plt.subplots(n_rows, n_cols, figsize=figsize, gridspec_kw=gridspec)
+    
+    def remove_ticks(axis):
+        axis.spines.right.set_visible(False)
+        axis.spines.top.set_visible(False)
+        axis.spines.left.set_visible(False)
+        axis.spines.bottom.set_visible(False)
+        axis.set_xticklabels([])
+        axis.set_xticks([])
+        axis.set_yticklabels([])
+        axis.set_yticks([])
+        
     for c in range(len(orig_batch)):
         for r in range(n_rows):
-            ax[r, c*2].axis('off') 
-            ax[r, c*2].imshow(orig_batch[c][r])
-            ax[r, c*2].set_aspect('equal')
-            ax[r, (c*2)+1].axis('off')
-            ax[r, (c*2)+1].imshow(maps_batch[c][r], cmap=cmap, vmin=0, vmax=1)
-            ax[r, (c*2)+1].set_aspect('equal')
+            _c = c * 4
+            
+            ax[r, _c+3].set_visible(False)
+            
+            remove_ticks(ax[r, _c])
+            ax[r, _c].set_ylabel(f"{(c*3)+r}")
+            ax[r, _c].imshow(orig_batch[c][r])
+            ax[r, _c].set_aspect('equal')
+            ax
+            
+            ax[r, _c+1].axis('off') 
+            ax[r, _c+1].imshow(orig_batch[c][r])
+            ax[r, _c+1].set_aspect('equal')
+            
+            ax[r, _c+1].axis('off')
+            ax[r, _c+1].imshow(maps_batch[c][r], cmap='Oranges', vmin=0, vmax=1, alpha=0.6)
+            ax[r, _c+1].set_aspect('equal')
+            
+            ax[r, _c+2].axis('off')
+            ax[r, _c+2].imshow(maps_batch[c][r], cmap=cmap, vmin=0, vmax=1)
+            ax[r, _c+2].set_aspect('equal')
+            
+            if r == 0:
+                ax[r, _c].set_title("Original")
+                ax[r, _c+1].set_title("Overlay")
+                ax[r, _c+2].set_title("Saliency Map")
         
     fig.subplots_adjust(wspace=0, hspace=0)

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -39,7 +39,7 @@ class SaliencyMap:
         self,
         img: np.ndarray,
         grads: saliency.CoreSaliency,
-        baseline: bool  =False,
+        baseline: bool = False,
         smooth: bool = False,
         **kwargs
     ) -> np.ndarray:
@@ -59,6 +59,7 @@ class SaliencyMap:
         def _get_mask(_img):
             if baseline:
                 kwargs.update({'x_baseline': np.zeros(_img.shape)})
+
             return mask_fn(_img, self._grad_fn, **kwargs)
 
         if isinstance(img, list):

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -26,10 +26,9 @@ class SaliencyMap:
         self.ig = saliency.IntegratedGradients()
         self.guided_ig = saliency.GuidedIG()
         self.blur_ig = saliency.BlurIG()
-        self.xrai = saliency.XRAI()
+        self.xrai_grads = saliency.XRAI()
         self.fast_xrai_params = saliency.XRAIParameters()
         self.fast_xrai_params.algorithm = 'fast'
-        self.masks = {}
 
     def _grad_fn(
         self,
@@ -171,7 +170,7 @@ class SaliencyMap:
         batch_size: int = 20,
         **kwargs
     ) -> np.ndarray:
-        return self.xrai.GetMask(
+        return self.xrai_grads.GetMask(
             img,
             self._grad_fn,
             batch_size=batch_size,
@@ -184,7 +183,7 @@ class SaliencyMap:
         batch_size: int = 20,
         **kwargs
     ) -> np.ndarray:
-        return self.xrai.GetMask(
+        return self.xrai_grads.GetMask(
             img,
             self._grad_fn,
             batch_size=batch_size,

--- a/slideflow/grad/__init__.py
+++ b/slideflow/grad/__init__.py
@@ -1,0 +1,145 @@
+import tensorflow as tf
+import numpy as np
+from matplotlib import pyplot as plt
+#from matplotlib.widgets import MultiCursor
+from itertools import chain
+from slideflow.util import batch
+
+import saliency.core as saliency
+
+class SaliencyMap:
+    def __init__(self, model):
+        self.model = model
+        self.gradients = saliency.GradientSaliency()
+        self.ig = saliency.IntegratedGradients()
+        self.guided_ig = saliency.GuidedIG()
+        self.blur_ig = saliency.BlurIG()
+        self.xrai = saliency.XRAI()
+        self.fast_xrai_params = saliency.XRAIParameters()
+        self.fast_xrai_params.algorithm = 'fast'
+        self.masks = {}
+
+    def grad_fn(self, image, call_model_args=None, expected_keys=None):
+        image = tf.convert_to_tensor(image)
+        with tf.GradientTape() as tape:
+            if expected_keys == [saliency.base.INPUT_OUTPUT_GRADIENTS]:
+                # For vanilla gradient, Integrated Gradients, XRAI
+                tape.watch(image)
+                output = self.model(image)[:, 0]
+                gradients = tape.gradient(output, image)
+                return {saliency.base.INPUT_OUTPUT_GRADIENTS: gradients}
+            else:
+                # For Grad-CAM
+                raise ValueError
+    
+    def _calc_vanilla_map(self, img, mask_fn, **kwargs):
+        mask_3d = mask_fn(img, self.grad_fn, **kwargs)
+        return saliency.VisualizeImageGrayscale(mask_3d)
+
+    def _calc_ig_map(self, img, mask_fn, x_steps=25, batch_size=20, **kwargs):
+        mask_3d = mask_fn(
+            img,
+            self.grad_fn,
+            x_baseline=np.zeros(img.shape),
+            x_steps=x_steps,
+            batch_size=batch_size
+        )
+        return saliency.VisualizeImageGrayscale(mask_3d)
+
+    def _calc_guided_ig_map(self, img, mask_fn, x_steps=25, max_dist=1.0, fraction=0.5):
+        mask_3d = mask_fn(
+            img,
+            self.grad_fn,
+            x_baseline=np.zeros(img.shape),
+            x_steps=x_steps,
+            max_dist=max_dist,
+            fraction=fraction
+        )
+        return saliency.VisualizeImageGrayscale(mask_3d)
+
+    def _calc_blur_ig_map(self, img, mask_fn, batch_size=20):
+        mask_3d = mask_fn(img, self.grad_fn, batch_size=batch_size)
+        return saliency.VisualizeImageGrayscale(mask_3d)
+    
+    def all_maps(self, img):
+        return {
+            'Vanilla': self.vanilla_map(img),
+            'Vanilla (Smoothed)': self.vanilla_map_smooth(img), 
+            'Integrated Gradients': self.integrated_gradients_map(img),
+            'Integrated Gradients (Smooth)': self.integrated_gradients_map_smooth(img),
+            'Guided Integrated Gradients': self.guided_integrated_gradients_map(img),
+            'Guided Integrated Gradients (Smooth)': self.guided_integrated_gradients_map_smooth(img),
+            'Blur Integrated Gradients': self.blur_integrated_gradients_map(img),
+            'Blur Integrated Gradients (Smooth)': self.blur_integrated_gradients_map_smooth(img),
+        }
+
+    def vanilla_map(self, img, **kwargs):
+        return self._calc_vanilla_map(img, self.gradients.GetMask, **kwargs)
+
+    def vanilla_map_smooth(self, img, **kwargs):
+        return self._calc_vanilla_map(img, self.gradients.GetSmoothedMask, **kwargs)
+    
+    def integrated_gradients_map(self, img, **kwargs):
+        return self._calc_ig_map(img, self.ig.GetMask, **kwargs)
+
+    def integrated_gradients_map_smooth(self, img, **kwargs):
+        return self._calc_ig_map(img, self.ig.GetSmoothedMask, **kwargs)
+        
+    def guided_integrated_gradients_map(self, img, **kwargs):
+        return self._calc_guided_ig_map(img, self.guided_ig.GetMask, **kwargs)
+
+    def guided_integrated_gradients_map_smooth(self, img, **kwargs):
+        return self._calc_guided_ig_map(img, self.guided_ig.GetSmoothedMask, **kwargs)
+        
+    def blur_integrated_gradients_map(self, img, **kwargs):
+        return self._calc_blur_ig_map(img, self.blur_ig.GetMask, **kwargs)
+
+    def blur_integrated_gradients_map_smooth(self, img, **kwargs):
+        return self._calc_blur_ig_map(img, self.blur_ig.GetSmoothedMask, **kwargs)
+
+    def xrai_map(self, img, batch_size=20, **kwargs):
+        return self.xrai.GetMask(img, self.grad_fn, batch_size=batch_size, **kwargs)
+    
+    def xrai_map_fast(self, img, batch_size=20, **kwargs):
+        return self.xrai.GetMask(
+            img, 
+            self.grad_fn, 
+            batch_size=batch_size, 
+            extra_parameters=self.fast_xrai_params, 
+            **kwargs)
+
+
+def comparison_plot(original, maps, cmap=plt.cm.gray):
+    n_rows = 3
+    n_cols = 3
+    scale = 5
+    ax_idx = [[i, j] for i in range(n_rows) for j in range(n_cols)]
+    fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_rows * scale, n_cols * scale))
+    #multi = MultiCursor(fig.canvas, list(chain.from_iterable(ax)), color='r', lw=1)
+    
+    ax[ax_idx[0][0], ax_idx[0][1]].axis('off') 
+    ax[ax_idx[0][0], ax_idx[0][1]].imshow(original)
+    ax[ax_idx[0][0], ax_idx[0][1]].set_title('Original')
+    
+    for i, (map_name, map_img) in enumerate(maps.items()):
+        ax[ax_idx[i+1][0], ax_idx[i+1][1]].axis('off')
+        ax[ax_idx[i+1][0], ax_idx[i+1][1]].imshow(map_img, cmap=cmap, vmin=0, vmax=1)
+        ax[ax_idx[i+1][0], ax_idx[i+1][1]].set_title(map_name)
+
+def side_by_side_plot(originals, maps, n_rows=4, cmap=plt.cm.gray):
+    orig_batch = list(batch(originals, n_rows))
+    maps_batch = list(batch(maps, n_rows))
+    n_cols = len(orig_batch)*2
+    scale = 5
+    fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_cols * scale, n_rows * scale))
+
+    for c in range(len(orig_batch)):
+        for r in range(n_rows):
+            ax[r, c*2].axis('off') 
+            ax[r, c*2].imshow(orig_batch[c][r])
+            ax[r, c*2].set_aspect('equal')
+            ax[r, (c*2)+1].axis('off')
+            ax[r, (c*2)+1].imshow(maps_batch[c][r], cmap=cmap, vmin=0, vmax=1)
+            ax[r, (c*2)+1].set_aspect('equal')
+        
+    fig.subplots_adjust(wspace=0, hspace=0)

--- a/slideflow/grad/plot_utils.py
+++ b/slideflow/grad/plot_utils.py
@@ -43,7 +43,7 @@ def comparison_plot(
     n_rows: int = 3,
     n_cols: int = 3,
 ) -> None:
-    """Plots comparison of many saliency maps for a single iamge.
+    """Plots comparison of many saliency maps for a single image in a grid.
 
     Args:
         original (np.ndarray): Original (unprocessed) image.
@@ -170,6 +170,10 @@ def saliency_map_comparison(
     **kwargs: Any
 ) -> None:
     """Plots several saliency maps for a list of images.
+
+    Each row is a unique image.
+    The first column is the original image. Each column after is a saliency
+    map generated each of the functions provided to `saliency_fn`.
 
     Args:
         orig_imgs (list(np.ndarray)): Original (unprocessed) images for

--- a/slideflow/grad/plot_utils.py
+++ b/slideflow/grad/plot_utils.py
@@ -52,7 +52,7 @@ def comparison_plot(original, maps, cmap=plt.cm.gray):
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].imshow(map_img, cmap=cmap, vmin=0, vmax=1)
         ax[ax_idx[i+1][0], ax_idx[i+1][1]].set_title(map_name)
 
-    fig.subplots_adjust(wspace=0, hspace=0)
+    fig.subplots_adjust(wspace=0, hspace=0.1)
 
 
 def multi_plot(

--- a/slideflow/grad/plot_utils.py
+++ b/slideflow/grad/plot_utils.py
@@ -1,5 +1,6 @@
-#from matplotlib.widgets import MultiCursor
-from typing import Callable, Iterable, List, Optional
+"""Plotting functions for displaying saliency maps."""
+
+from typing import Any, Callable, Iterable, List, Optional
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -36,12 +37,28 @@ def remove_ticks(axis):
     axis.set_yticks([])
 
 
-def comparison_plot(original, maps, cmap=plt.cm.gray):
-    n_rows = 3
-    n_cols = 3
+def comparison_plot(
+    original: np.ndarray,
+    maps: List[np.ndarray],
+    cmap: Any = plt.cm.gray,
+    n_rows: int = 3,
+    n_cols: int = 3,
+) -> None:
+    """Plots comparison of many saliency maps for a single iamge.
+
+    Args:
+        original (np.ndarray): Original (unprocessed) image.
+        maps (list(np.ndarray)): List of saliency maps.
+        cmap (matplotlib colormap, optional): Colormap for maps.
+            Defaults to plt.cm.gray.
+    """
     scale = 5
     ax_idx = [[i, j] for i in range(n_rows) for j in range(n_cols)]
-    fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_rows * scale, n_cols * scale))
+    fig, ax = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(n_rows * scale, n_cols * scale)
+    )
 
     ax[ax_idx[0][0], ax_idx[0][1]].axis('off')
     ax[ax_idx[0][0], ax_idx[0][1]].imshow(original)
@@ -75,8 +92,10 @@ def multi_plot(
         processed_imgs (Iterable[np.ndarray]): _description_
         method (Callable): _description_
         cmap (str, optional): _description_. Defaults to 'inferno'.
-        xlabels (Optional[List[str]], optional): _description_. Defaults to None.
-        ylabels (Optional[List[str]], optional): _description_. Defaults to None.
+        xlabels (Optional[List[str]], optional): _description_.
+            Defaults to None.
+        ylabels (Optional[List[str]], optional): _description_.
+            Defaults to None.
 
     Raises:
         ValueError: If length of raw_imgs, processed_imgs are not equal.
@@ -142,7 +161,28 @@ def multi_plot(
     fig.subplots_adjust(wspace=0, hspace=0)
 
 
-def saliency_map_comparison(orig_imgs, saliency_fn, process_fn, saliency_labels=None, cmap='inferno', **kwargs):
+def saliency_map_comparison(
+    orig_imgs: Iterable[np.ndarray],
+    saliency_fn: Iterable[Callable],
+    process_fn: Callable,
+    saliency_labels: Iterable[str] = None,
+    cmap: str = 'inferno',
+    **kwargs: Any
+) -> None:
+    """Plots several saliency maps for a list of images.
+
+    Args:
+        orig_imgs (list(np.ndarray)): Original (unprocessed) images for
+            which to generate saliency maps.
+        saliency_fn (list(Callable)): List of saliency map functions.
+        process_fn (Callable): Function for processing images. This function
+            will be applied to images before images are passed to the
+            saliency map function.
+        saliency_labels (list(str), optional): Labels for provided saliency
+            maps. Defaults to None.
+        cmap (str, optional): Colormap for saliency maps.
+            Defaults to 'inferno'.
+    """
 
     def apply_cmap(_img):
         cmap_fn = plt.get_cmap(cmap)
@@ -150,8 +190,11 @@ def saliency_map_comparison(orig_imgs, saliency_fn, process_fn, saliency_labels=
 
     n_imgs = len(orig_imgs)
     n_saliency = len(saliency_fn)
-    fig, ax = plt.subplots(n_imgs, n_saliency+1, figsize=((n_saliency+1)*5, n_imgs*5))
-
+    fig, ax = plt.subplots(
+        n_imgs,
+        n_saliency+1,
+        figsize=((n_saliency+1)*5, n_imgs*5)
+    )
     if saliency_labels is None:
         saliency_labels = [f"Saliency{n}" for n in range(n_saliency)]
     assert len(saliency_labels) == len(saliency_fn)

--- a/slideflow/grad/plot_utils.py
+++ b/slideflow/grad/plot_utils.py
@@ -1,11 +1,10 @@
 """Plotting functions for displaying saliency maps."""
 
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 from matplotlib import pyplot as plt
 from PIL import Image
-from slideflow.util import batch
 
 
 def inferno(img):
@@ -39,7 +38,7 @@ def remove_ticks(axis):
 
 def comparison_plot(
     original: np.ndarray,
-    maps: List[np.ndarray],
+    maps: Dict[str, np.ndarray],
     cmap: Any = plt.cm.gray,
     n_rows: int = 3,
     n_cols: int = 3,
@@ -48,7 +47,8 @@ def comparison_plot(
 
     Args:
         original (np.ndarray): Original (unprocessed) image.
-        maps (list(np.ndarray)): List of saliency maps.
+        maps (dict(str, np.ndarray)): Dictionary mapping saliency map names
+            to the numpy array maps.
         cmap (matplotlib colormap, optional): Colormap for maps.
             Defaults to plt.cm.gray.
     """
@@ -73,8 +73,8 @@ def comparison_plot(
 
 
 def multi_plot(
-    raw_imgs: Iterable[np.ndarray],
-    processed_imgs: Iterable[np.ndarray],
+    raw_imgs: List[np.ndarray],
+    processed_imgs: List[np.ndarray],
     method: Callable,
     cmap: str = 'inferno',
     xlabels: Optional[List[str]] = None,
@@ -88,13 +88,13 @@ def multi_plot(
     The third row will be the saliency maps.
 
     Args:
-        raw_imgs (Iterable[np.ndarray]): Raw, unprocessed images.
-        processed_imgs (Iterable[np.ndarray]): _description_
-        method (Callable): _description_
-        cmap (str, optional): _description_. Defaults to 'inferno'.
-        xlabels (Optional[List[str]], optional): _description_.
+        raw_imgs (List[np.ndarray]): Raw, unprocessed images.
+        processed_imgs (List[np.ndarray]): Processed images.
+        method (Callable): Saliency method.
+        cmap (str, optional): Colormap. Defaults to 'inferno'.
+        xlabels (Optional[List[str]], optional): Labels for x-axis.
             Defaults to None.
-        ylabels (Optional[List[str]], optional): _description_.
+        ylabels (Optional[List[str]], optional): Labels for y-axis.
             Defaults to None.
 
     Raises:
@@ -162,10 +162,10 @@ def multi_plot(
 
 
 def saliency_map_comparison(
-    orig_imgs: Iterable[np.ndarray],
-    saliency_fn: Iterable[Callable],
+    orig_imgs: List[np.ndarray],
+    saliency_fn: List[Callable],
     process_fn: Callable,
-    saliency_labels: Iterable[str] = None,
+    saliency_labels: List[str] = None,
     cmap: str = 'inferno',
     **kwargs: Any
 ) -> None:

--- a/slideflow/grad/plot_utils.py
+++ b/slideflow/grad/plot_utils.py
@@ -1,0 +1,168 @@
+#from matplotlib.widgets import MultiCursor
+from typing import Callable, Iterable, List, Optional
+
+import numpy as np
+from matplotlib import pyplot as plt
+from PIL import Image
+from slideflow.util import batch
+
+
+def inferno(img):
+    cmap = plt.get_cmap('inferno')
+    return (cmap(img) * 255).astype(np.uint8)
+
+
+def oranges(img):
+    cmap = plt.get_cmap('Oranges')
+    return (cmap(img) * 255).astype(np.uint8)
+
+
+def overlay(image, mask):
+    base = Image.fromarray(image)
+    cmap = Image.fromarray(oranges(mask))
+    cmap.putalpha(int(0.6*255))
+    base.paste(cmap, mask=cmap)
+    return np.array(base)
+
+
+def remove_ticks(axis):
+    axis.spines.right.set_visible(False)
+    axis.spines.top.set_visible(False)
+    axis.spines.left.set_visible(False)
+    axis.spines.bottom.set_visible(False)
+    axis.set_xticklabels([])
+    axis.set_xticks([])
+    axis.set_yticklabels([])
+    axis.set_yticks([])
+
+
+def comparison_plot(original, maps, cmap=plt.cm.gray):
+    n_rows = 3
+    n_cols = 3
+    scale = 5
+    ax_idx = [[i, j] for i in range(n_rows) for j in range(n_cols)]
+    fig, ax = plt.subplots(n_rows, n_cols, figsize=(n_rows * scale, n_cols * scale))
+
+    ax[ax_idx[0][0], ax_idx[0][1]].axis('off')
+    ax[ax_idx[0][0], ax_idx[0][1]].imshow(original)
+    ax[ax_idx[0][0], ax_idx[0][1]].set_title('Original')
+
+    for i, (map_name, map_img) in enumerate(maps.items()):
+        ax[ax_idx[i+1][0], ax_idx[i+1][1]].axis('off')
+        ax[ax_idx[i+1][0], ax_idx[i+1][1]].imshow(map_img, cmap=cmap, vmin=0, vmax=1)
+        ax[ax_idx[i+1][0], ax_idx[i+1][1]].set_title(map_name)
+
+    fig.subplots_adjust(wspace=0, hspace=0)
+
+
+def multi_plot(
+    raw_imgs: Iterable[np.ndarray],
+    processed_imgs: Iterable[np.ndarray],
+    method: Callable,
+    cmap: str = 'inferno',
+    xlabels: Optional[List[str]] = None,
+    ylabels: Optional[List[str]]  =None,
+    **kwargs
+) -> None:
+    """Creates a plot of saliency maps and overlays for a given set of images.
+
+    The first row will be the raw images.
+    The second row will be an overlay of the saliency map and the raw image.
+    The third row will be the saliency maps.
+
+    Args:
+        raw_imgs (Iterable[np.ndarray]): Raw, unprocessed images.
+        processed_imgs (Iterable[np.ndarray]): _description_
+        method (Callable): _description_
+        cmap (str, optional): _description_. Defaults to 'inferno'.
+        xlabels (Optional[List[str]], optional): _description_. Defaults to None.
+        ylabels (Optional[List[str]], optional): _description_. Defaults to None.
+
+    Raises:
+        ValueError: If length of raw_imgs, processed_imgs are not equal.
+        ValueError: If xlabels is provided and not a list.
+        ValueError: If ylabels is provided and not a list.
+        ValueError: If xlabels is provided and length does not equal raw_imgs.
+        ValueError: If ylabels is provided and length does not equal raw_imgs.
+    """
+
+    # Error checking
+    if len(raw_imgs) != len(processed_imgs):
+        raise ValueError(
+            "Length of raw_imgs ({}) and processed_imgs ({}) unequal".format(
+                len(raw_imgs),
+                len(processed_imgs)
+            )
+        )
+    if xlabels:
+        if not isinstance(xlabels, list):
+            raise ValueError("xlabels must be a list.")
+        if len(xlabels) != len(raw_imgs):
+            raise ValueError(
+                "Length of raw_imgs ({}) and xlabels ({}) unequal".format(
+                    len(raw_imgs),
+                    len(xlabels)
+                )
+            )
+    if ylabels:
+        if not isinstance(ylabels, list):
+            raise ValueError("ylabels must be a list of length 3.")
+        if len(ylabels) != 3:
+            raise ValueError(
+                f"Unexpected length for ylabels; expected 3, got {len(ylabels)}"
+            )
+
+    # Calculate masks ans overlays
+    masks = [method(p_img, **kwargs) for p_img in processed_imgs]
+    overlays = [overlay(img, mask) for img, mask in zip(raw_imgs, masks)]
+
+    # Initialize figure.
+    figsize = (len(raw_imgs)*5, 15)
+    fig, ax = plt.subplots(3, len(raw_imgs), figsize=figsize)
+
+    # Plot labels if provided.
+    if xlabels:
+        for i in range(len(xlabels)):
+            ax[0, i].set_title(xlabels[i], fontsize=22)
+    if ylabels:
+        for i in range(len(ylabels)):
+            ax[i, 0].set_ylabel(ylabels[i], fontsize=22)
+
+    # Plot the originals, overlays, and masks
+    for i, img in enumerate(raw_imgs):
+        remove_ticks(ax[0, i])
+        ax[0, i].imshow(Image.fromarray(img))
+    for i, ov in enumerate(overlays):
+        remove_ticks(ax[1, i])
+        ax[1, i].imshow(Image.fromarray(ov))
+    for i, mask in enumerate(masks):
+        remove_ticks(ax[2, i])
+        ax[2, i].imshow(mask, cmap=cmap)
+
+    fig.subplots_adjust(wspace=0, hspace=0)
+
+
+def saliency_map_comparison(orig_imgs, saliency_fn, process_fn, saliency_labels=None, cmap='inferno', **kwargs):
+
+    def apply_cmap(_img):
+        cmap_fn = plt.get_cmap(cmap)
+        return (cmap_fn(_img) * 255).astype(np.uint8)
+
+    n_imgs = len(orig_imgs)
+    n_saliency = len(saliency_fn)
+    fig, ax = plt.subplots(n_imgs, n_saliency+1, figsize=((n_saliency+1)*5, n_imgs*5))
+
+    if saliency_labels is None:
+        saliency_labels = [f"Saliency{n}" for n in range(n_saliency)]
+    assert len(saliency_labels) == len(saliency_fn)
+
+    ax[0, 0].set_title("Original")
+    for idx, orig in enumerate(orig_imgs):
+        ax[idx, 0].axis('off')
+        ax[idx, 0].imshow(orig)
+        for s, s_fn in enumerate(saliency_fn):
+            ax[0, s+1].set_title(saliency_labels[s])
+            ax[idx, s+1].axis('off')
+            ax[idx, s+1].imshow(apply_cmap(s_fn(process_fn(orig), **kwargs)))
+
+    fig.subplots_adjust(wspace=0, hspace=0)

--- a/slideflow/heatmap.py
+++ b/slideflow/heatmap.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import matplotlib.colors as mcol
 import numpy as np
@@ -12,6 +12,10 @@ from slideflow.slide import WSI
 from slideflow.util import Path
 from slideflow.util import colors as col
 from slideflow.util import log
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
+    from matplotlib.axes import Axes
 
 
 class Heatmap:
@@ -28,7 +32,6 @@ class Heatmap:
         roi_method: str = 'auto',
         batch_size: int = 32,
         num_threads: Optional[int] = None,
-        buffer: Optional[str] = None,
         enable_downsample: bool = True,
         img_format: str = 'auto'
     ) -> None:
@@ -57,8 +60,6 @@ class Heatmap:
                 Defaults to 32.
             num_threads (int, optional): Number of tile worker threads.
                 Defaults to CPU core count.
-            buffer (str, optional): Path to use for buffering slides.
-                Defaults to None.
             enable_downsample (bool, optional): Enable the use of downsampled
                 slide image layers. Defaults to True.
             img_format (str, optional): Image format (png, jpg) to use when
@@ -95,15 +96,6 @@ class Heatmap:
         self.num_features = interface.num_features
         self.num_uncertainty = interface.num_uncertainty
 
-        # Create slide buffer
-        if buffer and os.path.isdir(buffer):
-            new_path = os.path.join(buffer, os.path.basename(slide))
-            shutil.copy(slide, new_path)
-            slide = new_path
-            buffered_slide = True
-        else:
-            buffered_slide = False
-
         # Load the slide
         try:
             self.slide = WSI(
@@ -134,21 +126,42 @@ class Heatmap:
             self.logits = out
             self.uncertainty = None
         log.info(f"Heatmap complete for {col.green(self.slide.name)}")
-        if buffered_slide:
-            os.remove(new_path)
 
-    def _prepare_figure(self, show_roi: bool = True) -> None:
-        """Prepares matplotlib figure of Heatmap.
+    @staticmethod
+    def _prepare_ax(ax: Optional["Axes"] = None) -> "Axes":
+        """Creates matplotlib figure and axis if one is not supplied,
+        otherwise clears the axis contents.
 
         Args:
-            show_roi (bool, optional): Include ROI on heatmap. Defaults to True.
+            ax (matplotlib.axes.Axes): Figure axis. If not supplied,
+                will create a new figure and axis. Otherwise, clears axis
+                contents. Defaults to None.
+
+        Returns:
+            matplotlib.axes.Axes: Figure axes.
         """
         import matplotlib.pyplot as plt
-        self.fig = plt.figure(figsize=(18, 16))
-        self.ax = self.fig.add_subplot(111)
-        self.fig.subplots_adjust(bottom=0.25, top=0.95)
-        gca = plt.gca()
-        gca.tick_params(
+        if ax is None:
+            fig = plt.figure(figsize=(18, 16))
+            ax = fig.add_subplot(111)
+            fig.subplots_adjust(bottom=0.25, top=0.95)
+        else:
+            ax.clear()
+        return ax
+
+    def _format_ax(
+        self,
+        ax: "Axes",
+        show_roi: bool = True,
+        **kwargs
+    ) -> None:
+        """Formats matplotlib axis in preparation for heatmap plotting.
+
+        Args:
+            ax (matplotlib.axes.Axes): Figure axis.
+            show_roi (bool, optional): Include ROI on heatmap. Defaults to True.
+        """
+        ax.tick_params(
             axis='x',
             top=True,
             labeltop=True,
@@ -157,7 +170,6 @@ class Heatmap:
         )
         # Plot ROIs
         if show_roi:
-            print('\r\033[KPlotting ROIs...', end='')
             roi_scale = self.slide.dimensions[0] / 2048
             annPolys = [
                 sg.Polygon(annotation.scaled_area(roi_scale))
@@ -165,18 +177,210 @@ class Heatmap:
             ]
             for poly in annPolys:
                 x, y = poly.exterior.xy
-                plt.plot(x, y, zorder=20, color='k', linewidth=5)
+                ax.plot(x, y, zorder=20, **kwargs)
+
+    def plot_thumbnail(
+        self,
+        show_roi: bool = False,
+        roi_color: str = 'k',
+        linewidth: int = 5,
+        ax: Optional["Axes"] = None,
+    ) -> "plt.image.AxesImage":
+        """Plot a thumbnail of the slide, with or without ROI.
+
+        Args:
+            show_roi (bool, optional): Overlay ROIs onto heatmap image.
+                Defaults to True.
+            roi_color (str): ROI line color. Defaults to 'k' (black).
+            linewidth (int): Width of ROI line. Defaults to 5.
+            ax (matplotlib.axes.Axes, optional): Figure axis. If not supplied,
+                will prepare a new figure axis.
+
+        Returns:
+            plt.image.AxesImage: Result from ax.imshow().
+        """
+        self._prepare_ax(ax)
+        self._format_ax(
+            ax,
+            show_roi=show_roi,
+            color=roi_color,
+            linewidth=linewidth
+        )
+        return ax.imshow(self.slide.thumb(width=2048), zorder=0)
+
+    def plot_with_logit_cmap(
+        self,
+        logit_cmap: Union[Callable, Dict],
+        interpolation: str = 'none',
+        ax: Optional["Axes"] = None,
+        **thumb_kwargs,
+    ) -> None:
+        """Plot a heatmap using a specified logit colormap.
+
+        Args:
+            logit_cmap (obj, optional): Either function or a dictionary use to
+                create heatmap colormap. Each image tile will generate a list
+                of predictions of length O, where O is the number of outcomes.
+                If logit_cmap is a function, then the logit prediction list
+                will be passed to the function, and the function is expected
+                to return [R, G, B] values for display. If logit_cmap is a
+                dictionary, it should map 'r', 'g', and 'b' to indices; the
+                prediction for these outcome indices will be mapped to the RGB
+                colors. Thus, the corresponding color will only reflect up to
+                three outcomes. Example mapping prediction for outcome 0 to the
+                red colorspace, 3 to green, etc: {'r': 0, 'g': 3, 'b': 1}
+            interpolation (str, optional): Interpolation strategy to use for
+                smoothing heatmap. Defaults to 'none'.
+            ax (matplotlib.axes.Axes, optional): Figure axis. If not supplied,
+                will prepare a new figure axis.
+
+        Keyword args:
+            show_roi (bool, optional): Overlay ROIs onto heatmap image.
+                Defaults to True.
+            roi_color (str): ROI line color. Defaults to 'k' (black).
+            linewidth (int): Width of ROI line. Defaults to 5.
+        """
+        ax = self._prepare_ax(ax)
+        implot = self.plot_thumbnail(ax=ax, **thumb_kwargs)
+        ax.set_facecolor("black")
+        if callable(logit_cmap):
+            map_logit = logit_cmap
+        else:
+            # Make heatmap with specific logit predictions mapped
+            # to r, g, and b
+            def map_logit(logit):
+                return (logit[logit_cmap['r']],
+                        logit[logit_cmap['g']],
+                        logit[logit_cmap['b']])
+        ax.imshow(
+            [[map_logit(logit) for logit in row] for row in self.logits],
+            extent=implot.get_extent(),
+            interpolation=interpolation,
+            zorder=10
+        )
+
+    def plot_uncertainty(
+        self,
+        heatmap_alpha: float = 0.6,
+        cmap: str = 'coowarm',
+        interpolation: str = 'none',
+        ax: Optional["Axes"] = None,
+        **thumb_kwargs
+    ):
+        """Plot heatmap of uncertainty.
+
+        Args:
+            heatmap_alpha (float, optional): Alpha of heatmap overlay.
+                Defaults to 0.6.
+            cmap (str, optional): Matplotlib heatmap colormap.
+                Defaults to 'coolwarm'.
+            interpolation (str, optional): Interpolation strategy to use for
+                smoothing heatmap. Defaults to 'none'.
+            ax (matplotlib.axes.Axes, optional): Figure axis. If not supplied,
+                will prepare a new figure axis.
+
+        Keyword args:
+            show_roi (bool, optional): Overlay ROIs onto heatmap image.
+                Defaults to True.
+            roi_color (str): ROI line color. Defaults to 'k' (black).
+            linewidth (int): Width of ROI line. Defaults to 5.
+        """
+        ax = self._prepare_ax(ax)
+        implot = self.plot_thumbnail(ax=ax, **thumb_kwargs)
+        if heatmap_alpha == 1:
+            implot.set_alpha(0)
+        uqnorm = mcol.TwoSlopeNorm(
+            vmin=0,
+            vcenter=self.uncertainty.max()/2,
+            vmax=self.uncertainty.max()
+        )
+        masked_uncertainty = np.ma.masked_where(
+            self.uncertainty == -1,
+            self.uncertainty
+        )
+        ax.imshow(
+            masked_uncertainty,
+            norm=uqnorm,
+            extent=implot.get_extent(),
+            cmap=cmap,
+            alpha=heatmap_alpha,
+            interpolation=interpolation,
+            zorder=10
+        )
+
+    def plot(
+        self,
+        class_idx: int,
+        heatmap_alpha: float = 0.6,
+        cmap: str = 'coolwarm',
+        interpolation: str = 'none',
+        vmin: float = 0,
+        vmax: float = 1,
+        vcenter: float = 0.5,
+        ax: Optional["Axes"] = None,
+        **thumb_kwargs
+    ) -> None:
+        """Plot a predictive heatmap.
+
+        Args:
+            class_idx (int): Class index to plot.
+            heatmap_alpha (float, optional): Alpha of heatmap overlay.
+                Defaults to 0.6.
+            show_roi (bool, optional): Overlay ROIs onto heatmap image.
+                Defaults to True.
+            cmap (str, optional): Matplotlib heatmap colormap.
+                Defaults to 'coolwarm'.
+            interpolation (str, optional): Interpolation strategy to use for
+                smoothing heatmap. Defaults to 'none'.
+            vmin (float): Minimimum value to display on heatmap.
+                Defaults to 0.
+            vcenter (float): Center value for color display on heatmap.
+                Defaults to 0.5.
+            vmax (float): Maximum value to display on heatmap.
+                Defaults to 1.
+            ax (matplotlib.axes.Axes, optional): Figure axis. If not supplied,
+                will prepare a new figure axis.
+
+        Keyword args:
+            show_roi (bool, optional): Overlay ROIs onto heatmap image.
+                Defaults to True.
+            roi_color (str): ROI line color. Defaults to 'k' (black).
+            linewidth (int): Width of ROI line. Defaults to 5.
+        """
+
+        ax = self._prepare_ax(ax)
+        implot = self.plot_thumbnail(ax=ax, **thumb_kwargs)
+        if heatmap_alpha == 1:
+            implot.set_alpha(0)
+        ax.set_facecolor("black")
+        divnorm = mcol.TwoSlopeNorm(
+            vmin=vmin,
+            vcenter=vcenter,
+            vmax=vmax
+        )
+        masked_arr = np.ma.masked_where(
+            self.logits[:, :, class_idx] == -1,
+            self.logits[:, :, class_idx]
+        )
+        ax.imshow(
+            masked_arr,
+            norm=divnorm,
+            extent=implot.get_extent(),
+            cmap=cmap,
+            alpha=heatmap_alpha,
+            interpolation=interpolation,
+            zorder=10
+        )
 
     def save(
         self,
         outdir: Path,
         show_roi: bool = True,
         interpolation: str = 'none',
-        cmap: str = 'coolwarm',
         logit_cmap: Optional[Union[Callable, Dict]] = None,
-        vmin: float = 0,
-        vmax: float = 1,
-        vcenter: float = 0.5
+        roi_color: str = 'k',
+        linewidth: int = 5,
+        **kwargs
     ) -> None:
         """Saves calculated logits as heatmap overlays.
 
@@ -197,135 +401,79 @@ class Heatmap:
                 colors. Thus, the corresponding color will only reflect up to
                 three outcomes. Example mapping prediction for outcome 0 to the
                 red colorspace, 3 to green, etc: {'r': 0, 'g': 3, 'b': 1}
+            roi_color (str): ROI line color. Defaults to 'k' (black).
+            linewidth (int): Width of ROI line. Defaults to 5.
+
+        Keyword args:
+            cmap (str, optional): Matplotlib heatmap colormap.
+                Defaults to 'coolwarm'.
             vmin (float): Minimimum value to display on heatmap.
                 Defaults to 0.
             vcenter (float): Center value for color display on heatmap.
                 Defaults to 0.5.
             vmax (float): Maximum value to display on heatmap.
                 Defaults to 1.
+
         """
         import matplotlib.pyplot as plt
 
         if self.logits is None:
             raise errors.HeatmapError("Logits not yet calculated.")
 
+        def _savefig(label, bbox_inches='tight', **kwargs):
+            plt.savefig(
+                os.path.join(outdir, f'{self.slide.name}-{label}.png'),
+                bbox_inches=bbox_inches,
+                **kwargs
+            )
+
         print('\r\033[KSaving base figures...', end='')
+
+        # Prepare matplotlib figure
+        ax = self._prepare_ax()
+
+        thumb_kwargs = dict(roi_color=roi_color, linewidth=linewidth)
+
         # Save base thumbnail as separate figure
-        self._prepare_figure(show_roi=False)
-        self.ax.imshow(self.slide.thumb(width=2048), zorder=0)
-        plt.savefig(
-            os.path.join(outdir, f'{self.slide.name}-raw.png'),
-            bbox_inches='tight'
-        )
-        plt.clf()
+        self.plot_thumbnail(show_roi=False, ax=ax, **thumb_kwargs)
+        _savefig('raw')
+
         # Save thumbnail + ROI as separate figure
-        self._prepare_figure(show_roi=False)
-        self.ax.imshow(self.slide.thumb(width=2048, rois=True), zorder=0)
-        plt.savefig(
-            os.path.join(outdir, f'{self.slide.name}-raw+roi.png'),
-            bbox_inches='tight'
-        )
-        plt.clf()
-        # Now prepare base image for the the heatmap overlay
-        self._prepare_figure(show_roi=False)
-        implot = self.ax.imshow(
-            self.slide.thumb(width=2048, rois=show_roi),
-            zorder=0
-        )
-        self.ax.set_facecolor("black")
+        self.plot_thumbnail(show_roi=True, ax=ax, **thumb_kwargs)
+        _savefig('raw+roi')
 
         if logit_cmap:
-            if callable(logit_cmap):
-                map_logit = logit_cmap
-            else:
-                # Make heatmap with specific logit predictions mapped
-                # to r, g, and b
-                def map_logit(logit):
-                    return (logit[logit_cmap['r']],
-                            logit[logit_cmap['g']],
-                            logit[logit_cmap['b']])
-
-            heatmap = self.ax.imshow(
-                [[map_logit(logit) for logit in row] for row in self.logits],
-                extent=implot.get_extent(),
-                interpolation=interpolation,
-                zorder=10
-            )
-            plt.savefig(
-                os.path.join(outdir, f'{self.slide.name}-custom.png'),
-                bbox_inches='tight'
-            )
+            self.plot_with_logit_cmap(logit_cmap, show_roi=show_roi, ax=ax)
+            _savefig('custom')
         else:
-            heatmap_kwargs = {
-                'extent': implot.get_extent(),
-                'cmap': cmap,
-                'alpha': 0.6,
-                'interpolation': interpolation,
-                'zorder': 10
-            }
-            save_kwargs = {
-                'bbox_inches': 'tight',
-                'facecolor': self.ax.get_facecolor(),
-                'edgecolor': 'none'
-            }
+            heatmap_kwargs = dict(
+                show_roi=show_roi,
+                interpolation=interpolation,
+                **kwargs
+            )
+            save_kwargs = dict(
+                bbox_inches='tight',
+                facecolor=ax.get_facecolor(),
+                edgecolor='none'
+            )
             # Make heatmap plots and sliders for each outcome category
             for i in range(self.num_classes):
                 print(f'\r\033[KMaking {i+1}/{self.num_classes}...', end='')
-                divnorm = mcol.TwoSlopeNorm(
-                    vmin=vmin,
-                    vcenter=vcenter,
-                    vmax=vmax
-                )
-                masked_arr = np.ma.masked_where(
-                    self.logits[:, :, i] == -1,
-                    self.logits[:, :, i]
-                )
-                heatmap = self.ax.imshow(
-                    masked_arr,
-                    norm=divnorm,
-                    **heatmap_kwargs
-                )
-                plt.savefig(
-                    os.path.join(outdir, f'{self.slide.name}-{i}.png'),
-                    **save_kwargs
-                )
-                heatmap.set_alpha(1)
-                implot.set_alpha(0)
-                plt.savefig(
-                    os.path.join(outdir, f'{self.slide.name}-{i}-solid.png'),
-                    **save_kwargs
-                )
-                heatmap.remove()
-                implot.set_alpha(1)
+                self.plot(i, heatmap_alpha=0.6, ax=ax, **heatmap_kwargs)
+                _savefig(str(i), **save_kwargs)
+
+                self.plot(i, heatmap_alpha=1, ax=ax, **heatmap_kwargs)
+                _savefig(f'{i}-solid', **save_kwargs)
 
             # Uncertainty map
             if self.uq:
                 print('\r\033[KMaking uncertainty heatmap...', end='')
-                uqnorm = mcol.TwoSlopeNorm(
-                    vmin=0,
-                    vcenter=self.uncertainty.max()/2,
-                    vmax=self.uncertainty.max()
-                )
-                masked_uncertainty = np.ma.masked_where(
-                    self.uncertainty == -1,
-                    self.uncertainty
-                )
-                heatmap = self.ax.imshow(
-                    masked_uncertainty,
-                    norm=uqnorm,
-                    **heatmap_kwargs
-                )
-                plt.savefig(
-                    os.path.join(outdir, f'{self.slide.name}-UQ.png'),
-                    **save_kwargs
-                )
-                heatmap.set_alpha(1)
-                implot.set_alpha(0)
-                plt.savefig(
-                    os.path.join(outdir, f'{self.slide.name}-UQ-solid.png'),
-                    **save_kwargs
-                )
-                heatmap.remove()
+                self.plot_uncertainty(heatmap_alpha=0.6, ax=ax, **heatmap_kwargs)
+                _savefig('UQ', **save_kwargs)
+
+                self.plot_uncertainty(heatmap_alpha=1, ax=ax, **heatmap_kwargs)
+                _savefig('UQ-solid', **save_kwargs)
+
         plt.close()
         print('\r\033[K', end='')
         log.info(f'Saved heatmaps for {col.green(self.slide.name)}')

--- a/slideflow/model/tensorflow.py
+++ b/slideflow/model/tensorflow.py
@@ -19,6 +19,7 @@ from packaging import version
 from slideflow import errors
 from slideflow.model import tensorflow_utils as tf_utils
 from slideflow.model.base import log_manifest, no_scope
+from slideflow.model.tensorflow_utils import unwrap
 from slideflow.util import NormFit, Path
 from slideflow.util import colors as col
 from slideflow.util import log

--- a/slideflow/model/tensorflow.py
+++ b/slideflow/model/tensorflow.py
@@ -8,7 +8,6 @@ import json
 import os
 import shutil
 from os.path import dirname, exists, join
-from packaging import version
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
@@ -16,6 +15,7 @@ import numpy as np
 import slideflow as sf
 import slideflow.model.base as _base
 import slideflow.util.neptune_utils
+from packaging import version
 from slideflow import errors
 from slideflow.model import tensorflow_utils as tf_utils
 from slideflow.model.base import log_manifest, no_scope
@@ -1377,13 +1377,13 @@ class Trainer:
             reduce_method=reduce_method,
             **metric_kwargs
         )
-        results_dict = {'eval': {}}  # type: Dict[str, Dict[str, float]]
+        results = {'eval': {}}  # type: Dict[str, Dict[str, float]]
         for metric in metrics:
             if metrics[metric]:
                 log.info(f"Tile {metric}: {metrics[metric]['tile']}")
                 log.info(f"Slide {metric}: {metrics[metric]['slide']}")
                 log.info(f"Patient {metric}: {metrics[metric]['patient']}")
-                results_dict['eval'].update({
+                results['eval'].update({
                     f'tile_{metric}': metrics[metric]['tile'],
                     f'slide_{metric}': metrics[metric]['slide'],
                     f'patient_{metric}': metrics[metric]['patient']
@@ -1396,15 +1396,15 @@ class Trainer:
         log.info('Evaluation metrics:')
         for m in val_metrics:
             log.info(f'{m}: {val_metrics[m]}')
-        results_dict['eval'].update(val_metrics)
-        sf.util.update_results_log(results_log, 'eval_model', results_dict)
+        results['eval'].update(val_metrics)
+        sf.util.update_results_log(results_log, 'eval_model', results)
 
         # Update neptune log
         if self.neptune_run:
             self.neptune_run['eval/results'] = val_metrics
             self.neptune_run.stop()
 
-        return val_metrics
+        return results
 
     def train(
         self,

--- a/slideflow/mosaic.py
+++ b/slideflow/mosaic.py
@@ -8,7 +8,7 @@ import time
 from functools import partial
 from multiprocessing.dummy import Pool as DPool
 from random import shuffle
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
@@ -228,9 +228,9 @@ class Mosaic:
         if self.mapping_method == 'expanded':
             self.tile_point_distances.sort(key=lambda d: d['distance'])
 
-    def place_tiles(
+    def plot(
         self,
-        resolution: str = 'high',
+        figsize: Tuple[int, int] = (200, 200),
         tile_zoom: int = 15,
         relative_size: bool = False,
         focus: Optional[List[Path]] = None,
@@ -239,8 +239,8 @@ class Mosaic:
         """Initializes figures and places image tiles.
 
         Args:
-            resolution (str, optional): Resolution of exported figure; 'high',
-                'medium', or 'low'. Defaults to 'high'.
+            figsize (Tuple[int, int], optional): Figure size. Defaults to
+                (200, 200).
             tile_zoom (int, optional): Factor which determines how large
                 individual tiles appear. Defaults to 15.
             relative_size (bool, optional): Physically size grid images in
@@ -254,14 +254,8 @@ class Mosaic:
         import matplotlib.pyplot as plt
 
         # Initialize figure
-        if resolution not in ('high', 'low'):
-            raise ValueError(f"Unknown resolution option '{resolution}'")
-        elif resolution == 'high':
-            fig = plt.figure(figsize=(200, 200))
-            ax = fig.add_subplot(111, aspect='equal')
-        else:
-            fig = plt.figure(figsize=(24, 18))
-            ax = fig.add_subplot(121, aspect='equal')
+        fig = plt.figure(figsize=figsize)
+        ax = fig.add_subplot(111, aspect='equal')
         ax.set_facecolor('#dfdfdf')
         fig.tight_layout()
         plt.subplots_adjust(
@@ -454,8 +448,8 @@ class Mosaic:
             filename (str): Path at which to save the mosiac image.
 
         Keyword args:
-            resolution (str, optional): Resolution of exported figure; 'high',
-                'medium', or 'low'. Defaults to 'high'.
+            figsize (Tuple[int, int], optional): Figure size. Defaults to
+                (200, 200).
             tile_zoom (int, optional): Factor which determines how large
                 individual tiles appear. Defaults to 15.
             relative_size (bool, optional): Physically size grid images in
@@ -466,7 +460,7 @@ class Mosaic:
         """
         import matplotlib.pyplot as plt
 
-        self.place_tiles(**kwargs)
+        self.plot(**kwargs)
         log.info('Exporting figure...')
         try:
             if not os.path.exists(os.path.dirname(filename)):

--- a/slideflow/norm/__init__.py
+++ b/slideflow/norm/__init__.py
@@ -6,14 +6,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
-from PIL import Image
-from tqdm import tqdm
-
 import slideflow as sf
+from PIL import Image
 from slideflow import errors
 from slideflow.dataset import Dataset
 from slideflow.norm.utils import BaseNormalizer
-from slideflow.util import log
+from slideflow.util import detuple, log
+from tqdm import tqdm
 
 if sf.backend() == 'tensorflow':
     import tensorflow as tf
@@ -212,7 +211,7 @@ class StainNormalizer:
             )
         else:
             image = tf.py_function(self.tf_to_rgb, [image], tf.int32)
-        return tuple([image] + list(args))
+        return detuple(image, args)
 
     def tf_to_rgb(self, image: "tf.Tensor") -> np.ndarray:
         '''Non-normalized tensorflow RGB array -> normalized RGB numpy array'''

--- a/slideflow/norm/tensorflow/__init__.py
+++ b/slideflow/norm/tensorflow/__init__.py
@@ -3,14 +3,14 @@ from os.path import join
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import tensorflow as tf
-from tqdm import tqdm
-
 from slideflow import errors
 from slideflow.dataset import Dataset
 from slideflow.norm import StainNormalizer
 from slideflow.norm.tensorflow import reinhard, reinhard_fast
-from slideflow.util import log
+from slideflow.util import detuple, log
+from tqdm import tqdm
+
+import tensorflow as tf
 
 
 class TensorflowStainNormalizer(StainNormalizer):
@@ -264,7 +264,7 @@ class TensorflowStainNormalizer(StainNormalizer):
         self,
         batch: Union[Dict, tf.Tensor],
         *args: Any
-    ) -> Tuple[Union[Dict, tf.Tensor], ...]:
+    ) -> Union[Dict, tf.Tensor, Tuple[Union[Dict, tf.Tensor], ...]]:
         """Normalize a batch of tensors.
 
         Args:
@@ -282,9 +282,9 @@ class TensorflowStainNormalizer(StainNormalizer):
                     if k != 'tile_image'
                 }
                 to_return['tile_image'] = self.tf_to_tf(batch['tile_image'])
-                return tuple([to_return] + list(args))
+                return detuple(to_return, args)
             else:
-                return tuple([self.tf_to_tf(batch)] + list(args))
+                return detuple(self.tf_to_tf(batch), args)
 
     @tf.function
     def tf_to_tf(self, image: tf.Tensor) -> tf.Tensor:

--- a/slideflow/norm/torch/__init__.py
+++ b/slideflow/norm/torch/__init__.py
@@ -3,11 +3,12 @@ from os.path import join
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import torch
 import torchvision
-
 from slideflow.norm import StainNormalizer
 from slideflow.norm.torch import reinhard, reinhard_fast
+from slideflow.util import detuple
+
+import torch
 
 
 class TorchStainNormalizer(StainNormalizer):
@@ -95,9 +96,9 @@ class TorchStainNormalizer(StainNormalizer):
         if isinstance(batch, dict):
             to_return = {k: v for k, v in batch.items() if k != 'tile_image'}
             to_return['tile_image'] = self.torch_to_torch(batch['tile_image'])
-            return tuple([to_return] + list(args))
+            return detuple(to_return, args)
         else:
-            return tuple([self.torch_to_torch(batch)] + list(args))
+            return detuple(self.torch_to_torch(batch), args)
 
     def torch_to_torch(self, image: torch.Tensor) -> torch.Tensor:
         if len(image.shape) == 3:

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -1622,9 +1622,8 @@ class Project:
                 a model's metadata file (params.json). Defaults to True.
 
         Keyword Args:
-            resolution (str): Mosaic map resolution, determines size of
-                exported figure. Either 'low', 'medium' or 'high'.
-                Defaults to 'high'.
+            figsize (Tuple[int, int], optional): Figure size. Defaults to
+                (200, 200).
             num_tiles_x (int): Specifies the size of the mosaic map grid.
             expanded (bool): Controls tile assignment on grid spaces.
                 If False, tile assignment is strict.
@@ -1809,7 +1808,8 @@ class Project:
             batch_size (int, optional): Batch size for model. Defaults to 64.
 
         Keyword Args:
-            resolution (str): Resolution of the mosaic. Low, medium, or high.
+            figsize (Tuple[int, int], optional): Figure size. Defaults to
+                (200, 200).
             num_tiles_x (int): Specifies the size of the mosaic map grid.
             expanded (bool): Controls tile assignment on grid spaces.
                 If False, tile assignment is strict.

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -1341,7 +1341,7 @@ class Project:
                                 annotations=labels,
                                 **kwargs)
         if torch_export:
-            df.export_to_torch(torch_export)
+            df.to_torch(torch_export)
         return df
 
     @auto_dataset
@@ -1429,7 +1429,7 @@ class Project:
             layers=layers,
             include_logits=False,
         )
-        df.export_to_torch(outdir)
+        df.to_torch(outdir)
         return outdir
 
     @auto_dataset

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -1445,7 +1445,6 @@ class Project:
         resolution: str = 'low',
         batch_size: int = 32,
         roi_method: str = 'inside',
-        buffer: Optional[Path] = None,
         num_threads: Optional[int] = None,
         img_format: str = 'auto',
         skip_completed: bool = False,
@@ -1480,8 +1479,6 @@ class Project:
                 If 'ignore', will extract tiles across the whole-slide
                 regardless of whether an ROI is available.
                 Defaults to 'auto'.
-            buffer (str, optional): Path to which slides are copied prior to
-                heatmap generation. Defaults to None.
             num_threads (int, optional): Number of threads for tile extraction.
                 Defaults to CPU core count.
             skip_completed (bool, optional): Skip heatmaps for slides that

--- a/slideflow/project_utils.py
+++ b/slideflow/project_utils.py
@@ -88,7 +88,6 @@ def _heatmap_worker(
                          stride_div=heatmap_args.stride_div,
                          rois=heatmap_args.rois,
                          roi_method=heatmap_args.roi_method,
-                         buffer=heatmap_args.buffer,
                          batch_size=heatmap_args.batch_size,
                          img_format=heatmap_args.img_format,
                          num_threads=heatmap_args.num_threads)

--- a/slideflow/sample_actions.py
+++ b/slideflow/sample_actions.py
@@ -5,8 +5,8 @@ def main(P):
 
     # Configure model parameters
     # --------------------------
-    # from slideflow.model import ModelParams
-    # params = ModelParams(
+    # import slideflow as sf
+    # params = sf.ModelParams(
     #    tile_px=299,
     #    tile_um=302,
     #    learning_rate=0.0001,

--- a/slideflow/stats.py
+++ b/slideflow/stats.py
@@ -350,7 +350,7 @@ class SlideMap:
                 ])
             elif method == 'average':
                 umap_input = np.array([
-                    np.mean(self.df.activations[slide])
+                    np.mean(self.df.activations[slide], axis=0)
                     for slide in self.slides
                 ])
 

--- a/slideflow/test/functional.py
+++ b/slideflow/test/functional.py
@@ -69,7 +69,7 @@ def activations_tester(
         key=lambda f: tile_stats[f]['p']
     )
     for feature in top_features_by_tile[:5]:
-        umap.save_3d_plot(
+        umap.save_3d(
             join(project.root, 'stats', f'3d_feature{feature}.png'),
             feature=feature
         )

--- a/slideflow/test/functional.py
+++ b/slideflow/test/functional.py
@@ -80,7 +80,7 @@ def activations_tester(
 
     # Test mosaic.
     mosaic = project.generate_mosaic(df)
-    mosaic.save(join(project.root, "mosaic_test.png"), resolution='low')
+    mosaic.save(join(project.root, "mosaic_test.png"), figsize=(15, 15))
 
 
 @handle_errors

--- a/slideflow/util/__init__.py
+++ b/slideflow/util/__init__.py
@@ -13,7 +13,8 @@ from functools import partial
 from glob import glob
 from os.path import dirname, exists, isdir, join
 from statistics import mean, median
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Iterable
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Sized,
+                    Tuple, Union)
 
 import matplotlib.colors as mcol
 import numpy as np
@@ -418,7 +419,14 @@ class ThreadSafeList:
         return items
 
 
-def batch(iterable: Iterable, n: int = 1) -> Iterable:
+def detuple(arg1: Any, args: tuple) -> Any:
+    if len(args):
+        return tuple([arg1] + list(args))
+    else:
+        return arg1
+
+
+def batch(iterable: List, n: int = 1) -> Iterable:
     """Separates an interable into batches of maximum size `n`."""
     l = len(iterable)
     for ndx in range(0, l, n):

--- a/slideflow/util/__init__.py
+++ b/slideflow/util/__init__.py
@@ -13,7 +13,7 @@ from functools import partial
 from glob import glob
 from os.path import dirname, exists, isdir, join
 from statistics import mean, median
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Iterable
 
 import matplotlib.colors as mcol
 import numpy as np
@@ -415,6 +415,13 @@ class ThreadSafeList:
         with self.lock:
             items, self.items = self.items, []
         return items
+
+
+def batch(iterable: Iterable, n: int = 1) -> Iterable:
+    """Separates an interable into batches of maximum size `n`."""
+    l = len(iterable)
+    for ndx in range(0, l, n):
+        yield iterable[ndx:min(ndx + n, l)]
 
 
 def as_list(arg1: Any) -> List[Any]:


### PR DESCRIPTION
## Saliency maps

Saliency maps are available through a new submodule `slideflow.grad`. The `sf.grad.SaliencyMap` interface coordinates calculation and display of these maps with a variety of functions, using the saliency package backend. As this is an experimental functionality that has a new dependency, it is not imported by default, and must be imported separately.

`SaliencyMap` can be used directly:

``` python
from slideflow.grad import SaliencyMap

model = sf.keras.models.load_model('path')
smap = SaliencyMap(model, class_idx=0)
map_image = smap.integrated_gradients(image)
```

Or the plotting functions `saliency_map_comparison()`, `multi_plot()`, and `comparison_plot()` can be used to plot results. Several additional utility functions are also included to assist with flexible display.

## StyleGAN2 integration

The stylegan2-slideflow repository (https://github.com/jamesdolezal/stylegan2-slideflow) has now been implemented as a submodule in `slideflow.gan`. It is currently set to use the `pca_cond` branch, which will be switched to main once testing is complete. Right now, tools are included in the `slideflow.gan` submodule to assist with GAN output processing (so PyTorch GAN images can be used with Tensorflow models) and interpolation. GAN training is not yet implemented.

## `Heatmap` improvements
- Separates plotting and saving functions of heatmaps to enable plotting
without saving to disk, e.g. for use with Jupyter notebooks.
- New functions `.plot()`, `.plot_uncertainty()`, `.plot_with_logit_cmap()`, and `.plot_thumbnail()`
- Removes the `buffer` argument to `Heatmap` and `Project.generate_heatmaps()`
- `Heatmap.add_inset` will add a magnified display.
- New unrelated utility function `sf.util.get_tfrecord_by_location()`

## `SlideMap` improvements
- New functions `SlideMap.plot()` and `.plot_3d()`, which allow for
plotting a figure separate from saving, for use with Jupyter notebooks.
- `SlideMap.save_cache()` and `.load_cache()` now accept an optional `path` argument for specifying cache location.
- `SlideMap.export_to_csv()` -> `.to_csv()`
- `SlideMap.save_2d_plot()` -> `.save()`
- `SlideMap.save_3d_plot()` -> `.save_3d()`
- New `sf.stats.plot_roc()` and `sf.stats.plot_prc()` functions
- Allows specifying pre-generated UMAP with SlideMap, via `umap` argument to `SlideMap.from_features`
- Moves sf.stats.gen_umap -> sf.stats.SlideMap.gen_umap

## `Mosaic` updates
- `Mosaic.place_tiles()` -> `.plot()`
- Replaced `resolution` argument to `.plot()` with `figsize`, so the matplotlib figsize can be specified directly

## New functions for `DatasetFeatures`
- `DatasetFeatures.export_to_torch()` -> `to_torch()`
- New function `DatasetFeatures.load_cache()`
- New function `DatasetFeatures.save_cache()`
- New function `DatasetFeatures.to_df()` exports activations into a pandas dataframe

## Bug fixes and other changes
- Fix bug where `P.evaluate()` was incorrectly returning only the validation metrics
(accuracy/loss) instead of the full results (including AUC).
- Adds `sf.model.tensorflow.unwrap()`, which returns the input,
post-conv output, and model output tensors for the model,
for easier model surgery.
- New `Dataset.find_slide()` and `Dataset.find_tfrecord()` utility functions
