### PR TITLE
JPG slide wrapper fix

### DIFF
--- a/slideflow/slide/__init__.py
+++ b/slideflow/slide/__init__.py
@@ -544,14 +544,17 @@ class _JPGslideToVIPS(_VIPSWrapper):
         self.level_dimensions = [(width, height)]
 
         # MPP data
-        with Image.open(path) as img:
-            if TIF_EXIF_KEY_MPP in img.tag.keys():
-                mpp = img.tag[TIF_EXIF_KEY_MPP][0]
-                log.info(f"Using MPP {mpp} per EXIF field {TIF_EXIF_KEY_MPP}")
-                self.properties[OPS_MPP_X] = mpp
-            else:
-                log.info(f"Setting MPP to default {DEFAULT_JPG_MPP}")
-                self.properties[OPS_MPP_X] = DEFAULT_JPG_MPP
+        try:
+            with Image.open(path) as img:
+                if TIF_EXIF_KEY_MPP in img.tag.keys():
+                    mpp = img.tag[TIF_EXIF_KEY_MPP][0]
+                    log.info(f"Using MPP {mpp} per EXIF field {TIF_EXIF_KEY_MPP}")
+                    self.properties[OPS_MPP_X] = mpp
+                else:
+                    log.info(f"Setting MPP to default {DEFAULT_JPG_MPP}")
+                    self.properties[OPS_MPP_X] = DEFAULT_JPG_MPP
+        except AttributeError:
+            self.properties[OPS_MPP_X] = DEFAULT_JPG_MPP
 
 
 class ROI:

--- a/slideflow/slide/__init__.py
+++ b/slideflow/slide/__init__.py
@@ -397,36 +397,39 @@ class _VIPSWrapper:
                 )
             try:
                 with Image.open(path) as img:
-                    if TIF_EXIF_KEY_MPP in img.tag.keys():
-                        mpp = img.tag[TIF_EXIF_KEY_MPP][0]
-                        if not silent:
-                            log.debug(
-                                f"Using MPP {mpp} per EXIF {TIF_EXIF_KEY_MPP}"
-                            )
-                        self.properties[OPS_MPP_X] = mpp
-                    elif (sf.util.path_to_ext(path).lower() in ('tif', 'tiff')
-                          and 'xres' in loaded_image.get_fields()):
-                        xres = loaded_image.get('xres')  # 4000.0
-                        if (xres == 4000.0
-                           and loaded_image.get('resolution-unit') == 'cm'):
-                            # xres = xres # though resolution from tiffinfo
-                            # says 40000 pixels/cm, for some reason the xres
-                            # val is 4000.0, so multipley by 10.
-                            # Convert from pixels/cm to cm/pixels, then convert
-                            # to microns by multiplying by 1000
-                            mpp_x = (1/xres) * 1000
-                            self.properties[OPS_MPP_X] = str(mpp_x)
+                    try:
+                        if TIF_EXIF_KEY_MPP in img.tag.keys():
+                            mpp = img.tag[TIF_EXIF_KEY_MPP][0]
                             if not silent:
                                 log.debug(
-                                    f"Using MPP {mpp_x} per TIFF 'xres' field"
-                                    f" {loaded_image.get('xres')} and "
-                                    f"{loaded_image.get('resolution-unit')}"
+                                    f"Using MPP {mpp} per EXIF {TIF_EXIF_KEY_MPP}"
                                 )
-                    else:
-                        name = path_to_name(path)
-                        log.warning(
-                            f"Missing Microns-Per-Pixel (MPP) for {name}"
-                        )
+                            self.properties[OPS_MPP_X] = mpp
+                        elif (sf.util.path_to_ext(path).lower() in ('tif', 'tiff')
+                            and 'xres' in loaded_image.get_fields()):
+                            xres = loaded_image.get('xres')  # 4000.0
+                            if (xres == 4000.0
+                            and loaded_image.get('resolution-unit') == 'cm'):
+                                # xres = xres # though resolution from tiffinfo
+                                # says 40000 pixels/cm, for some reason the xres
+                                # val is 4000.0, so multipley by 10.
+                                # Convert from pixels/cm to cm/pixels, then convert
+                                # to microns by multiplying by 1000
+                                mpp_x = (1/xres) * 1000
+                                self.properties[OPS_MPP_X] = str(mpp_x)
+                                if not silent:
+                                    log.debug(
+                                        f"Using MPP {mpp_x} per TIFF 'xres' field"
+                                        f" {loaded_image.get('xres')} and "
+                                        f"{loaded_image.get('resolution-unit')}"
+                                    )
+                        else:
+                            name = path_to_name(path)
+                            log.warning(
+                                f"Missing Microns-Per-Pixel (MPP) for {name}"
+                            )
+                    except AttributeError:
+                        self.properties[OPS_MPP_X] = DEFAULT_JPG_MPP
             except UnidentifiedImageError:
                 log.error(
                     f"PIL error; unable to read slide {path_to_name(path)}."


### PR DESCRIPTION
Runtime AttributeError was encountered when reading in slides in JPG format.  Added try/except blocks.