### PR TITLE
Tile extraction & slide report updates

### DIFF
--- a/slideflow/__init__.py
+++ b/slideflow/__init__.py
@@ -10,7 +10,7 @@
 
 __author__ = 'James Dolezal'
 __license__ = 'GNU General Public License v3.0'
-__version__ = "1.2.2-dev2"
+__version__ = "1.2.2-dev3"
 
 import os
 

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -932,7 +932,7 @@ class Dataset:
         qc: Optional[str] = None,
         report: bool = True,
         **kwargs: Any
-    ) -> Optional[ExtractionReport]:
+    ) -> Dict[str, SlideReport]:
         """Extract tiles from a group of slides, saving extracted tiles to
         either loose image or in TFRecord binary format.
 
@@ -1040,7 +1040,7 @@ class Dataset:
             sources = sf.util.as_list(source)
         else:
             sources = list(self.sources.keys())
-        pdf_report = None
+        all_reports = []
         self.verify_annotations_slides()
 
         # Set up kwargs for tile extraction generator and quality control
@@ -1231,6 +1231,7 @@ class Dataset:
                 if report:
                     log.info('Generating PDF (this may take some time)...', )
                     rep_vals = list(reports.values())
+                    all_reports += rep_vals
                     num_slides = len(slide_list)
                     img_kwargs = defaultdict(lambda: None)  # type: Dict
                     img_kwargs.update(kwargs)
@@ -1266,7 +1267,7 @@ class Dataset:
         # Update manifest & rebuild indices
         self.update_manifest(force_update=True)
         self.build_index(True)
-        return pdf_report
+        return {report.path: report for report in all_reports}
 
     def extract_tiles_from_tfrecords(self, dest: str) -> None:
         """Extracts tiles from a set of TFRecords.

--- a/slideflow/model/tensorflow.py
+++ b/slideflow/model/tensorflow.py
@@ -613,7 +613,8 @@ class _PredictionAndEvaluationCallback(tf.keras.callbacks.Callback):
             num_tiles=self.cb_args.num_val_tiles,
             save_predictions=self.cb_args.save_predictions,
             reduce_method=self.cb_args.reduce_method,
-            pred_args=pred_args
+            pred_args=pred_args,
+            incl_loc=True,
         )
 
     def on_epoch_end(self, epoch: int, logs={}) -> None:
@@ -1256,6 +1257,7 @@ class Trainer:
             )
             tf_dts_w_slidenames = dataset.tensorflow(
                 incl_slidenames=True,
+                incl_loc=True,
                 **interleave_kwargs
             )
         # Generate predictions
@@ -1267,7 +1269,8 @@ class Trainer:
             model_type=self._model_type,
             pred_args=pred_args,
             num_tiles=dataset.num_tiles,
-            outcome_names=self.outcome_names
+            outcome_names=self.outcome_names,
+            incl_loc=True
         )
 
         # Save predictions
@@ -1352,6 +1355,7 @@ class Trainer:
             )
             tf_dts_w_slidenames = dataset.tensorflow(
                 incl_slidenames=True,
+                incl_loc=True,
                 **interleave_kwargs
             )
         # Generate performance metrics
@@ -1369,6 +1373,7 @@ class Trainer:
             save_predictions=save_predictions,
             pred_args=pred_args,
             reduce_method=reduce_method,
+            incl_loc=True,
             **metric_kwargs
         )
         results = {'eval': {}}  # type: Dict[str, Dict[str, float]]
@@ -1581,6 +1586,7 @@ class Trainer:
                     val_data = val_dts.tensorflow(**v_kwargs)
                     val_data_w_slidenames = val_dts.tensorflow(
                         incl_slidenames=True,
+                        incl_loc=True,
                         drop_last=True,
                         **v_kwargs
                     )

--- a/slideflow/model/tensorflow.py
+++ b/slideflow/model/tensorflow.py
@@ -2010,7 +2010,6 @@ class Features:
         features_grid *= -1
         generator = slide.build_generator(
             shuffle=False,
-            include_loc='grid',
             show_progress=True,
             img_format=img_format,
             **kwargs
@@ -2026,7 +2025,7 @@ class Features:
                 image = tf.image.decode_jpeg(image, channels=3)
             elif img_format.lower() in ('png',):
                 image = tf.image.decode_png(image, channels=3)
-            loc = record['loc']
+            loc = record['grid']
             if self.wsi_normalizer:
                 image = self.wsi_normalizer.tf_to_tf(image)
             parsed_image = tf.image.per_image_standardization(image)
@@ -2037,7 +2036,7 @@ class Features:
         with tf.name_scope('dataset_input'):
             output_signature = {
                 'image': tf.TensorSpec(shape=(), dtype=tf.string),
-                'loc': tf.TensorSpec(shape=(2), dtype=tf.uint32)
+                'grid': tf.TensorSpec(shape=(2), dtype=tf.uint32)
             }
             tile_dataset = tf.data.Dataset.from_generator(
                 generator,

--- a/slideflow/model/tensorflow.py
+++ b/slideflow/model/tensorflow.py
@@ -2018,6 +2018,13 @@ class Features:
             log.error(f"No tiles extracted from slide {col.green(slide.name)}")
             return
 
+        def tile_generator():
+            for image_dict in generator():
+                yield {
+                    'grid': image_dict['grid'],
+                    'image': image_dict['image']
+                }
+
         @tf.function
         def _parse_function(record):
             image = record['image']
@@ -2039,7 +2046,7 @@ class Features:
                 'grid': tf.TensorSpec(shape=(2), dtype=tf.uint32)
             }
             tile_dataset = tf.data.Dataset.from_generator(
-                generator,
+                tile_generator,
                 output_signature=output_signature
             )
             tile_dataset = tile_dataset.map(

--- a/slideflow/model/torch.py
+++ b/slideflow/model/torch.py
@@ -734,6 +734,7 @@ class Trainer:
             outcome_names=self.outcome_names,
             neptune_run=self.neptune_run,
             pred_args=pred_args,
+            incl_loc=True,
             **kwargs
         )
         loss_and_acc = {'loss': loss}
@@ -974,9 +975,7 @@ class Trainer:
         running_val_correct = self._empty_corrects()
 
         for _ in range(self.validation_steps):
-            (val_img,
-             val_label,
-             slides) = next(self.mid_train_val_dts)  # type: ignore
+            val_img, val_label, slides, *_ = next(self.mid_train_val_dts)
             val_img = val_img.to(self.device)
 
             with torch.no_grad():
@@ -1140,6 +1139,7 @@ class Trainer:
                 infinite=False,
                 batch_size=validation_batch_size,
                 augment=False,
+                incl_loc=True,
                 **vars(interleave_args)
             )
             # Mid-training validation dataset
@@ -1339,7 +1339,8 @@ class Trainer:
             dataset=self.dataloaders['val'],
             model_type=self._model_type,
             pred_args=pred_args,
-            outcome_names=self.outcome_names
+            outcome_names=self.outcome_names,
+            incl_loc=True
         )
 
         # Save predictions

--- a/slideflow/model/torch.py
+++ b/slideflow/model/torch.py
@@ -1847,7 +1847,6 @@ class Features:
         features_grid = np.zeros(zeros_shape, dtype=dtype)
         generator = slide.build_generator(
             shuffle=False,
-            include_loc='grid',
             show_progress=True,
             img_format=img_format,
             **kwargs)
@@ -1872,7 +1871,7 @@ class Features:
                             self.parent.wsi_normalizer.rgb_to_rgb(img.numpy())
                         )
                         img = img.permute(2, 0, 1)  # WHC => CWH
-                    loc = np.array(image_dict['loc'])
+                    loc = np.array(image_dict['grid'])
                     img = img / 127.5 - 1
                     yield img, loc
 

--- a/slideflow/slide/__init__.py
+++ b/slideflow/slide/__init__.py
@@ -1143,9 +1143,9 @@ class _BaseLoader:
             location = tile_dict['loc']
             locations += [location]
             if 'ws_fraction' in tile_dict:
-                ws_fractions += tile_dict['ws_fraction']
+                ws_fractions += [tile_dict['ws_fraction']]
             if 'gs_fraction' in tile_dict:
-                gs_fractions += tile_dict['gs_fraction']
+                gs_fractions += [tile_dict['gs_fraction']]
 
             if dry_run:
                 continue
@@ -1214,7 +1214,7 @@ class _BaseLoader:
                 blur_burden=self.blur_burden,
                 num_tiles=len(locations),
                 qc_mask=self.qc_mask,
-                locations=df_dict
+                locations=df
             )
             slide_report = SlideReport(
                 sample_tiles,

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -81,6 +81,15 @@ class SlideReport:
         else:
             return None
 
+    @property
+    def qc_mask(self) -> np.ndarray:
+        if self.data is None:
+            return None
+        if 'qc_mask' in self.data:
+            return self.data['qc_mask']
+        else:
+            return None
+
     def _compress(self, img: bytes) -> bytes:
         with io.BytesIO() as output:
             Image.open(io.BytesIO(img)).save(output, format="JPEG", quality=75)

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -8,7 +8,7 @@ import tempfile
 from datetime import datetime
 from os.path import join
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
 from fpdf import FPDF
@@ -17,6 +17,8 @@ from PIL import Image
 import slideflow as sf
 from slideflow.util import log, path_to_name  # noqa F401
 
+if TYPE_CHECKING:
+    import pandas as pd
 
 class SlideReport:
     '''Report to summarize tile extraction from a slide, including
@@ -67,6 +69,15 @@ class SlideReport:
             return None
         if 'num_tiles' in self.data:
             return self.data['num_tiles']
+        else:
+            return None
+
+    @property
+    def locations(self) -> "pd.DataFrame":
+        if self.data is None:
+            return None
+        if 'locations' in self.data:
+            return self.data['locations']
         else:
             return None
 
@@ -159,6 +170,7 @@ class ExtractionReport:
         import matplotlib.pyplot as plt
 
         self.bb_threshold = bb_threshold
+        self.reports = reports
         pdf = ExtractionPDF(title=title)
         pdf.alias_nb_pages()
         pdf.add_page()


### PR DESCRIPTION
- SlideReports now include grayspace/whitespace fraction for each extracted image, in the DataFrame `SlideReport.locations`
- `include_loc` argument removed from `.extract_tiles()` functions, as location information is now always included in the returned dict
- Performance improvements in ROI calculations and slide verification
- Previously, `.extract_tiles()` returned an `ExtractionReport` summarizing what tiles were extracted. Thus report is saved as a PDF in the tile extraction directory. The returned report, however, only summarized tile extraction of the last dataset source. If multiple dataset sources had tiles extracted, on the last source was reflected in this report. Now, for simplicity, this function returns a Dict mapping slide paths to `SlideReport` for each slide, including slides from all dataset sources.