### PR TITLE
Custom loss

### DIFF
--- a/slideflow/model/base.py
+++ b/slideflow/model/base.py
@@ -19,6 +19,7 @@ class _ModelParams:
 
     ModelDict = {}  # type: Dict
     LinearLossDict = {}  # type: Dict
+    AllLossDict = {}  # type: Dict
 
     def __init__(
         self,
@@ -29,7 +30,7 @@ class _ModelParams:
         toplayer_epochs: int = 0,
         model: str = 'xception',
         pooling: str = 'max',
-        loss: str = 'sparse_categorical_crossentropy',
+        loss: Union[str, Dict] = 'sparse_categorical_crossentropy',
         learning_rate: float = 0.0001,
         learning_rate_decay: float = 0,
         learning_rate_decay_steps: float = 100000,
@@ -192,6 +193,22 @@ class _ModelParams:
             self.ModelDict.update({'custom': m})
             self._model = 'custom'
 
+    @property
+    def loss(self) -> str:
+        return self._loss
+    
+    @loss.setter
+    def loss(self, l: Union[str, Dict])  -> None:
+        if isinstance(l, dict):
+            assert l['type'] in ('cph', 'linear', 'categorical')
+            loss_name = 'custom_' + l['type']
+            loss_function = l['fun']
+            self.AllLossDict.update({loss_name: loss_function})
+            self._loss = loss_name
+        elif isinstance(l, str):
+            assert l in self.AllLossDict
+            self._loss = l
+
     def _get_args(self) -> List[str]:
         to_ignore = [
             'get_opt',
@@ -347,7 +364,10 @@ class _ModelParams:
 
     def model_type(self) -> str:
         """Returns either 'linear', 'categorical', or 'cph' depending on the loss type."""
-        if self.loss == 'negative_log_likelihood':
+        #check if loss is custom_[type] and returns type
+        if (self.loss[:6] == 'custom'):
+            return self.loss[7:]
+        elif self.loss == 'negative_log_likelihood':
             return 'cph'
         elif self.loss in self.LinearLossDict:
             return 'linear'

--- a/slideflow/model/tensorflow.py
+++ b/slideflow/model/tensorflow.py
@@ -604,7 +604,10 @@ class ModelParams(_base._ModelParams):
 
     def model_type(self) -> str:
         """Returns 'linear', 'categorical', or 'cph', reflecting the loss."""
-        if self.loss == 'negative_log_likelihood':
+        #check if loss is custom_[type] and returns type
+        if self.loss.startswith('custom'):
+            return self.loss[7:]
+        elif self.loss == 'negative_log_likelihood':
             return 'cph'
         elif self.loss in self.LinearLossDict:
             return 'linear'

--- a/slideflow/model/torch.py
+++ b/slideflow/model/torch.py
@@ -384,7 +384,11 @@ class ModelParams(_base._ModelParams):
         return model
 
     def model_type(self) -> str:
-        if self.loss == 'NLL':
+        """Returns 'linear', 'categorical', or 'cph', reflecting the loss."""
+        #check if loss is custom_[type] and returns type
+        if self.loss.startswith('custom'):
+            return self.loss[7:]
+        elif self.loss == 'NLL':
             return 'cph'
         elif self.loss in self.LinearLossDict:
             return 'linear'

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -850,7 +850,8 @@ class Project:
             'neptune_workspace': self.neptune_workspace,
             'load_method': s_args.load_method
         }
-        if hp.model != 'custom':
+        if hp.model != 'custom' and not hp.loss.startswith('custom'):
+            # Do not use process isolation if using a custom model or loss
             process = s_args.ctx.Process(target=project_utils._train_worker,
                                         args=((train_dts, val_dts),
                                             model_kwargs,


### PR DESCRIPTION
Adds custom loss support for both Tensorflow/Keras and PyTorch, as discussed in #200.

Use by supplying a dictionary to the `loss` argument in `sf.ModelParams`, with the keys `type` and `fn`. `type` must be either `'categorical'`, `'linear'`, or `'cph'`, and 'fn' is a callable loss function.

Gists for testing the below functionality are available [here](https://gist.github.com/jamesdolezal/994e60d7a570c70fabb22a0eef5c388e) (TF/Keras) and [here](https://gist.github.com/jamesdolezal/cce6a25731abd88894c93789b8bf17a7) (PyTorch)

## Tensorflow/Keras
For Tensorflow/Keras, the loss function must accept arguments `y_true, y_pred`. `y_true` will not be one-hot encoded. For linear losses, `y_true` may need to be cast to `tf.float32`. An example custom linear loss is given below:

```python
def custom_linear_loss(y_true, y_pred):
    y_true = tf.cast(y_true, tf.float32)
    squared_difference = tf.square(y_true - y_pred)
    return tf.reduce_mean(squared_difference, axis=-1)
```

This loss would be applied as follows:

```python
hp = sf.ModelParams(..., loss={'type': 'linear', 'fn': custom_linear_loss})
```

## PyTorch
For PyTorch, the loss function must return a nested loss function with arguments `output, target`. An example linear loss is given below:

```python
def custom_linear_loss():
    def loss_fn(output, target):
        return torch.mean((target - output) ** 2)
    return loss_fn
```

This would be applied as follow:

```python
hp = sf.ModelParams(..., loss={'type': 'linear', 'fn': custom_linear_loss})
```