### PR TITLE
cuCIM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,27 @@ Slideflow has been used by:
 Full documentation with example tutorials can be found at [slideflow.dev](https://www.slideflow.dev/).
 
 ## Requirements
-- Python >= 3.7
-- [Libvips](https://libvips.github.io/libvips/) >= 8.9.
-- [OpenSlide](https://openslide.org/download/)
+- Python >= 3.7 (<3.10 if using [cuCIM](https://docs.rapids.ai/api/cucim/stable/))
 - [Tensorflow](https://www.tensorflow.org/) 2.5-2.9 _or_ [PyTorch](https://pytorch.org/) 1.9-1.12
-- [QuPath](https://qupath.github.io/) [_optional_] - Used for pathologist ROIs
-- Linear solver [_optional_] - Used for preserved-site cross-validation
+
+### Optional
+- [Libvips](https://libvips.github.io/libvips/) >= 8.9 (alternative slide reader, adds support for *.scn, *.mrxs, *.ndpi, *.vms, and *.vmu files).
+- [QuPath](https://qupath.github.io/) (for pathologist ROIs)
+- Linear solver (for preserved-site cross-validation)
   - [CPLEX](https://www.ibm.com/docs/en/icos/12.10.0?topic=v12100-installing-cplex-optimization-studio) 20.1.0 with [Python API](https://www.ibm.com/docs/en/icos/12.10.0?topic=cplex-setting-up-python-api)
   - _or_ [Pyomo](http://www.pyomo.org/installation) with [Bonmin](https://anaconda.org/conda-forge/coinbonmin) solver
 
-## Updates (1.3.3)
-Please see the [Version 1.3.3 Release Notes](https://github.com/jamesdolezal/slideflow/releases/tag/1.3.3) for a summary of the latest updates and fixes in the latest release.
 
 ## Installation
-Slideflow can be installed with PyPI, as a Docker container, or run from source. 
+Slideflow can be installed with PyPI, as a Docker container, or run from source.
 
 ### Method 1: Install via pip
 
 ```
 pip3 install --upgrade setuptools pip wheel
-pip3 install slideflow
+pip3 install slideflow cupy-cuda11x
 ```
-
+The `cupy` package name depends on the installed CUDA version; [see here](https://docs.cupy.dev/en/stable/install.html#installing-cupy) for installation instructions. `cupy` is not required if using Libvips.
 ### Method 2: Docker image
 
 Alternatively, pre-configured [docker images](https://hub.docker.com/repository/docker/jamesdolezal/slideflow) are available with OpenSlide/Libvips and the latest version of either Tensorflow and PyTorch. To install with the Tensorflow backend:
@@ -75,6 +74,25 @@ conda activate slideflow
 python setup.py bdist_wheel
 pip install dist/slideflow*
 ```
+
+## Configuration
+
+### Deep learning (Tensorflow vs. PyTorch)
+
+Slideflow supports both Tensorflow and PyTorch, defaulting to Tensorflow if both are available. You can specify the backend to use with the environmental variable `SF_BACKEND`. For example:
+
+```
+export SF_BACKEND=torch
+```
+
+### Slide reading (cuCIM vs. Libvips)
+
+By default, Slideflow reads whole-slide images using [cuCIM](https://docs.rapids.ai/api/cucim/stable/). Although much faster than other openslide-based frameworks, it supports fewer slide scanner formats. Slideflow also includes a [Libvips](https://libvips.github.io/libvips/) backend, which adds support for *.scn, *.mrxs, *.ndpi, *.vms, and *.vmu files. You can set the active slide backend with the environmental variable `SF_SLIDE_BACKEND`:
+
+```
+export SF_SLIDE_BACKEND=libvips
+```
+
 
 ## Getting started
 Slideflow experiments are organized into [Projects](https://slideflow.dev/project_setup.html), which supervise storage of whole-slide images, extracted tiles, and patient-level annotations. To create a new project, create an instance of the `slideflow.Project` class, supplying a pre-configured set of patient-level annotations in CSV format:
@@ -164,7 +182,7 @@ James Dolezal, Sara Kochanny, & Frederick Howard. (2022). Slideflow: A Unified D
   author       = {James Dolezal and
                   Sara Kochanny and
                   Frederick Howard},
-  title        = {{Slideflow: A Unified Deep Learning Pipeline for 
+  title        = {{Slideflow: A Unified Deep Learning Pipeline for
                    Digital Histology}},
   month        = oct,
   year         = 2022,

--- a/docs/_modules/slideflow/slide.html
+++ b/docs/_modules/slideflow/slide.html
@@ -665,7 +665,7 @@
         <span class="n">log</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="sa">f</span><span class="s1">&#39;Grayspace defined as HSV avg &lt; </span><span class="si">{</span><span class="n">gs_t</span><span class="si">}</span><span class="s1"> </span><span class="si">{</span><span class="n">excl</span><span class="si">}</span><span class="s1">&#39;</span><span class="p">)</span>
 
 
-<span class="k">class</span> <span class="nc">_VIPSWrapper</span><span class="p">:</span>
+<span class="k">class</span> <span class="nc">_VIPSReader</span><span class="p">:</span>
 
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
@@ -896,7 +896,7 @@
         <span class="k">else</span><span class="p">:</span>
             <span class="k">return</span> <span class="n">image</span>
 
-<span class="k">class</span> <span class="nc">_JPGslideToVIPS</span><span class="p">(</span><span class="n">_VIPSWrapper</span><span class="p">):</span>
+<span class="k">class</span> <span class="nc">_JPGVIPSReader</span><span class="p">(</span><span class="n">_VIPSReader</span><span class="p">):</span>
     <span class="sd">&#39;&#39;&#39;Wrapper for JPG files, which do not possess separate levels, to</span>
 <span class="sd">    preserve openslide-like functions.&#39;&#39;&#39;</span>
 
@@ -1088,11 +1088,11 @@
         <span class="bp">self</span><span class="o">.</span><span class="vm">__dict__</span><span class="o">.</span><span class="n">update</span><span class="p">(</span><span class="n">state</span><span class="p">)</span>
 
     <span class="nd">@property</span>
-    <span class="k">def</span> <span class="nf">_vips_wrapper</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Any</span><span class="p">:</span>
+    <span class="k">def</span> <span class="nf">_slide_reader</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Any</span><span class="p">:</span>
         <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">filetype</span><span class="o">.</span><span class="n">lower</span><span class="p">()</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;jpg&#39;</span><span class="p">,</span> <span class="s1">&#39;jpeg&#39;</span><span class="p">):</span>
-            <span class="k">return</span> <span class="n">_JPGslideToVIPS</span>
+            <span class="k">return</span> <span class="n">_JPGVIPSReader</span>
         <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">_VIPSWrapper</span>
+            <span class="k">return</span> <span class="n">_VIPSReader</span>
 
     <span class="nd">@property</span>
     <span class="k">def</span> <span class="nf">dimensions</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="nb">int</span><span class="p">,</span> <span class="nb">int</span><span class="p">]:</span>
@@ -1110,12 +1110,12 @@
             <span class="k">return</span> <span class="kc">None</span>
 
     <span class="nd">@property</span>
-    <span class="k">def</span> <span class="nf">slide</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">_VIPSWrapper</span><span class="p">:</span>
+    <span class="k">def</span> <span class="nf">slide</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">_VIPSReader</span><span class="p">:</span>
         <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">__slide</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__slide</span>
 
         <span class="k">try</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">__slide</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_vips_wrapper</span><span class="p">(</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">__slide</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_slide_reader</span><span class="p">(</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">path</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">_mpp_override</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">_vips_cache_kw</span><span class="p">)</span>
@@ -1197,7 +1197,7 @@
         <span class="c1"># Otsu&#39;s thresholding can be done on the lowest downsample level</span>
         <span class="k">if</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;otsu&#39;</span><span class="p">,</span> <span class="s1">&#39;both&#39;</span><span class="p">):</span>
             <span class="n">lev</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">slide</span><span class="o">.</span><span class="n">level_count</span> <span class="o">-</span> <span class="mi">1</span>
-            <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_vips_wrapper</span> <span class="o">==</span> <span class="n">_JPGslideToVIPS</span><span class="p">:</span>
+            <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_slide_reader</span> <span class="o">==</span> <span class="n">_JPGVIPSReader</span><span class="p">:</span>
                 <span class="n">otsu_thumb</span> <span class="o">=</span> <span class="n">vips</span><span class="o">.</span><span class="n">Image</span><span class="o">.</span><span class="n">new_from_file</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">path</span><span class="p">,</span> <span class="n">fail</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
             <span class="k">else</span><span class="p">:</span>
                 <span class="n">otsu_thumb</span> <span class="o">=</span> <span class="n">vips</span><span class="o">.</span><span class="n">Image</span><span class="o">.</span><span class="n">new_from_file</span><span class="p">(</span>
@@ -1849,7 +1849,7 @@
             <span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">,</span> <span class="n">grid_x</span><span class="p">,</span> <span class="n">grid_y</span><span class="p">),</span>
             <span class="n">SimpleNamespace</span><span class="p">(</span>
                 <span class="n">full_extract_px</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">full_extract_px</span><span class="p">,</span>
-                <span class="n">vips_wrapper</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">_vips_wrapper</span><span class="p">,</span>
+                <span class="n">vips_wrapper</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">_slide_reader</span><span class="p">,</span>
                 <span class="n">mpp_override</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">_mpp_override</span><span class="p">,</span>
                 <span class="n">vips_cache</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">_vips_cache_kw</span><span class="p">,</span>
                 <span class="n">roi_scale</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">roi_scale</span><span class="p">,</span>
@@ -2126,7 +2126,7 @@
 
         <span class="n">w_args</span> <span class="o">=</span> <span class="n">SimpleNamespace</span><span class="p">(</span><span class="o">**</span><span class="p">{</span>
             <span class="s1">&#39;full_extract_px&#39;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">full_extract_px</span><span class="p">,</span>
-            <span class="s1">&#39;vips_wrapper&#39;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">_vips_wrapper</span><span class="p">,</span>
+            <span class="s1">&#39;vips_wrapper&#39;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">_slide_reader</span><span class="p">,</span>
             <span class="s1">&#39;mpp_override&#39;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">_mpp_override</span><span class="p">,</span>
             <span class="s1">&#39;vips_cache&#39;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">_vips_cache_kw</span><span class="p">,</span>
             <span class="s1">&#39;roi_scale&#39;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">roi_scale</span><span class="p">,</span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ smac
 ConfigSpace
 pyarrow
 ninja
-tensorflow_probability
+tensorflow_probability<0.18
 rich
 pillow>=6.0.0
 imgui

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ saliency
 parameterized
 pyperclip
 requests
+cucim

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setuptools.setup(
         'glfw',
         'saliency',
         'pyperclip',
-        'requests'
+        'requests',
+        'cucim'
     ],
     extras_require={
         'tf': [

--- a/setup.py
+++ b/setup.py
@@ -88,12 +88,12 @@ setuptools.setup(
         'saliency',
         'pyperclip',
         'requests',
-        'cucim'
+        'cucim',
     ],
     extras_require={
         'tf': [
             'tensorflow>=2.7,<2.10',
-            'tensorflow_probability'
+            'tensorflow_probability<0.18'
         ],
         'torch': [
             'torch',

--- a/slideflow/__init__.py
+++ b/slideflow/__init__.py
@@ -9,6 +9,8 @@
 # GNU General Public License for more details.
 
 from ._version import get_versions
+import os
+import importlib
 
 __author__ = 'James Dolezal'
 __license__ = 'GNU General Public License v3.0'
@@ -16,15 +18,46 @@ __version__ = get_versions()['version']
 __gitcommit__ = get_versions()['full-revisionid']
 __github__ = 'https://github.com/jamesdolezal/slideflow'
 
-# -----------------------------------------------------------------------------
+# --- Backend configuration ---------------------------------------------------
 
-import os
-
+# Deep learning backend - use Tensorflow if available.
+_valid_backends = ('tensorflow', 'torch')
 if 'SF_BACKEND' not in os.environ:
-    os.environ['SF_BACKEND'] = 'tensorflow'
+    if importlib.util.find_spec('tensorflow'):
+        os.environ['SF_BACKEND'] = 'tensorflow'
+    elif importlib.util.find_spec('torch'):
+        os.environ['SF_BACKEND'] = 'torch'
+    else:
+        os.environ['SF_BACKEND'] = 'tensorflow'
+elif os.environ['SF_BACKEND'] not in _valid_backends:
+    raise ValueError("Unrecognized backend set via environmental variable "
+                     "SF_BACKEND: {}. Expected one of: {}".format(
+                        os.environ['SF_BACKEND'],
+                        ', '.join(_valid_backends)
+                     ))
+
+# Slide backend - use cuCIM if available.
+_valid_slide_backends = ('cucim', 'libvips')
+if 'SF_SLIDE_BACKEND' not in os.environ:
+    os.environ['SF_SLIDE_BACKEND'] = 'libvips'
+    if importlib.util.find_spec('cucim'):
+        import cucim
+        if cucim.is_available():
+            os.environ['SF_SLIDE_BACKEND'] = 'cucim'
+elif os.environ['SF_SLIDE_BACKEND'] not in _valid_slide_backends:
+    raise ValueError("Unrecognized slide backend set via environmental variable"
+                     " SF_SLIDE_BACKEND: {}. Expected one of: {}".format(
+                        os.environ['SF_SLIDE_BACKEND'],
+                        ', '.join(_valid_slide_backends)
+                     ))
 
 def backend():
     return os.environ['SF_BACKEND']
+
+def slide_backend():
+    return os.environ['SF_SLIDE_BACKEND']
+
+# -----------------------------------------------------------------------------
 
 # Import logging functions required for other submodules
 from slideflow.util import getLoggingLevel, log, setLoggingLevel, header

--- a/slideflow/io/tensorflow.py
+++ b/slideflow/io/tensorflow.py
@@ -483,7 +483,11 @@ def interleave(
                 return tuple([record[f] for f in features_to_return])
 
             # Load slides and apply Otsu's thresholding
-            pool = mp.Pool(16 if os.cpu_count is None else os.cpu_count())
+            ctx = mp.get_context('spawn')
+            if sf.slide_backend() == 'cucim':
+                pool = ctx.Pool(8 if os.cpu_count is None else os.cpu_count())
+            else:
+                pool = ctx.Pool(16 if os.cpu_count is None else os.cpu_count())
             wsi_list = []
             to_remove = []
             otsu_list = []

--- a/slideflow/io/tensorflow.py
+++ b/slideflow/io/tensorflow.py
@@ -385,6 +385,7 @@ def interleave(
     tile_um: Optional[int] = None,
     rois: Optional[List[str]] = None,
     roi_method: str = 'auto',
+    pool: Optional["mp.pool.Pool"] = None,
     **decode_kwargs: Any
 ) -> Iterable:
 
@@ -483,11 +484,10 @@ def interleave(
                 return tuple([record[f] for f in features_to_return])
 
             # Load slides and apply Otsu's thresholding
-            ctx = mp.get_context('spawn')
-            if sf.slide_backend() == 'cucim':
-                pool = ctx.Pool(8 if os.cpu_count is None else os.cpu_count())
-            else:
-                pool = ctx.Pool(16 if os.cpu_count is None else os.cpu_count())
+            if pool is None and sf.slide_backend() == 'cucim':
+                pool = mp.Pool(8 if os.cpu_count is None else os.cpu_count())
+            elif pool is None:
+                pool = mp.dummy.Pool(16 if os.cpu_count is None else os.cpu_count())
             wsi_list = []
             to_remove = []
             otsu_list = []

--- a/slideflow/model/torch.py
+++ b/slideflow/model/torch.py
@@ -1428,8 +1428,10 @@ class Trainer:
         self.model.eval()
         self._log_manifest(None, dataset, labels=None)
 
-        if from_wsi:
+        if from_wsi and sf.slide_backend() == 'libvips':
             pool = mp.Pool(os.cpu_count() if os.cpu_count() else 8)
+        elif from_wsi:
+            pool = mp.dummy.Pool(os.cpu_count() if os.cpu_count() else 8)
         else:
             pool = None
         if not batch_size:
@@ -1441,7 +1443,7 @@ class Trainer:
             incl_labels=False,
             from_wsi=from_wsi,
             roi_method=roi_method,
-            pool=pool,)
+            pool=pool)
 
         log.info('Generating predictions...')
         torch_args = types.SimpleNamespace(
@@ -1520,8 +1522,10 @@ class Trainer:
             self.validation_batch_size = batch_size
         if not self.model:
             raise errors.ModelNotLoadedError
-        if from_wsi:
+        if from_wsi and sf.slide_backend() == 'libvips':
             pool = mp.Pool(os.cpu_count() if os.cpu_count() else 8)
+        elif from_wsi:
+            pool = mp.dummy.Pool(os.cpu_count() if os.cpu_count() else 8)
         else:
             pool = None
 
@@ -1668,8 +1672,10 @@ class Trainer:
         self.use_tensorboard = use_tensorboard
         self.log_frequency = log_frequency
 
-        if from_wsi:
+        if from_wsi and sf.slide_backend() == 'libvips':
             pool = mp.Pool(os.cpu_count() if os.cpu_count() else 8)
+        elif from_wsi:
+            pool = mp.dummy.Pool(os.cpu_count() if os.cpu_count() else 8)
         else:
             pool = None
 

--- a/slideflow/slide/backends/__init__.py
+++ b/slideflow/slide/backends/__init__.py
@@ -1,0 +1,22 @@
+"""Abstraction to support both Libvips and cuCIM backends."""
+
+import slideflow as sf
+
+
+def tile_worker(*args, **kwargs):
+    if sf.slide_backend() == 'libvips':
+        from .vips import tile_worker
+    elif sf.slide_backend() == 'cucim':
+        from .cucim import tile_worker
+    return tile_worker(*args, **kwargs)
+
+
+def wsi_reader(path: str, *args, **kwargs):
+    """Get a slide image reader from the current backend."""
+    if sf.slide_backend() == 'libvips':
+        from .vips import get_libvips_reader
+        return get_libvips_reader(path, *args, **kwargs)
+
+    elif sf.slide_backend() == 'cucim':
+        from .cucim import get_cucim_reader
+        return get_cucim_reader(path, *args, **kwargs)

--- a/slideflow/slide/backends/cucim.py
+++ b/slideflow/slide/backends/cucim.py
@@ -1,0 +1,374 @@
+"""cuCIM slide-reading backend.
+
+Requires: cuCIM (...)
+"""
+
+import cv2
+import numpy as np
+import cupy as cp
+import slideflow as sf
+
+from types import SimpleNamespace
+from typing import Optional, Dict, Any, Tuple, List
+from slideflow.util import log
+from cucim import CuImage
+from cucim.skimage.transform import resize
+from cucim.skimage.color import rgb2hsv
+from cucim.skimage.util import img_as_float
+from slideflow.slide.utils import *
+
+
+__cv2_resize__ = True
+
+
+def get_cucim_reader(path: str, *args, **kwargs):
+    return _cuCIMReader(path, *args, **kwargs)
+
+
+def cucim2numpy(img: "CuImage") -> np.ndarray:
+    return ((img_as_float(cp.asarray(img)).get()) * 255).astype(np.uint8)
+
+
+def cucim2jpg(img: "CuImage") -> str:
+    img = cucim2numpy(img)
+    if img.shape[-1] == 4:
+        img = img[:, :, 0:3]
+    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+    return cv2.imencode(".jpg", img)[1].tobytes()
+
+
+def cucim2png(img: "CuImage") -> str:
+    img = cucim2numpy(img)
+    if img.shape[-1] == 4:
+        img = img[:, :, 0:3]
+    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+    return cv2.imencode(".png", img)[1].tobytes()
+
+
+def tile_worker(
+    c: List[int],
+    args: SimpleNamespace
+) -> Optional[Union[str, Dict]]:
+    '''Multiprocessing worker for WSI. Extracts tile at given coordinates.'''
+
+    x, y, grid_x, grid_y = c
+    x_coord = int((x + args.full_extract_px / 2) / args.roi_scale)
+    y_coord = int((y + args.full_extract_px / 2) / args.roi_scale)
+
+    # If downsampling is enabled, read image from highest level
+    # to perform filtering; otherwise filter from our target level
+    slide = get_cucim_reader(args.path, args.mpp_override, **args.reader_kwargs)
+    if args.whitespace_fraction < 1 or args.grayspace_fraction < 1:
+        if args.filter_downsample_ratio > 1:
+            filter_extract_px = args.extract_px // args.filter_downsample_ratio
+            filter_region = slide.read_region(
+                (x, y),
+                args.filter_downsample_level,
+                (filter_extract_px, filter_extract_px)
+            )
+        else:
+            # Read the region and resize to target size
+            filter_region = slide.read_region(
+                (x, y),
+                args.downsample_level,
+                (args.extract_px, args.extract_px)
+            )
+        # Perform whitespace filtering [Libvips]
+        if args.whitespace_fraction < 1:
+            ws_fraction = np.mean((np.mean(cucim2numpy(filter_region), axis=-1) > args.whitespace_threshold))
+            if (ws_fraction > args.whitespace_fraction
+               and args.whitespace_fraction != FORCE_CALCULATE_WHITESPACE):
+                return None
+
+        # Perform grayspace filtering [Libvips]
+        if args.grayspace_fraction < 1:
+            hsv_region = rgb2hsv(cp.asarray(filter_region)).get()
+            gs_fraction = np.mean(hsv_region[:, :, 1] < args.grayspace_threshold)
+            if (gs_fraction > args.grayspace_fraction
+               and args.whitespace_fraction != FORCE_CALCULATE_WHITESPACE):
+                return None
+
+    # Prepare return dict with WS/GS fraction
+    return_dict = {'loc': [x_coord, y_coord]}  # type: Dict[str, Any]
+    return_dict.update({'grid': [grid_x, grid_y]})
+
+    # If dry run, return without the image
+    if args.dry_run:
+        return_dict.update({'loc': [x_coord, y_coord]})
+        return return_dict
+
+    # Normalizer
+    if not args.normalizer:
+        normalizer = None
+    else:
+        normalizer = sf.norm.autoselect(
+            method=args.normalizer,
+            source=args.normalizer_source
+        )
+
+    # Read the target downsample region now, if we were
+    # filtering at a different level
+    region = slide.read_region(
+        (x, y),
+        args.downsample_level,
+        (args.extract_px, args.extract_px)
+    )
+
+    # cuCIM resize
+    if not __cv2_resize__:
+        if int(args.tile_px) != int(args.extract_px):
+            region = resize(cp.asarray(region), (args.tile_px, args.tile_px))
+
+    region = cucim2numpy(region)
+
+    # cv2 resize
+    if __cv2_resize__:
+        if int(args.tile_px) != int(args.extract_px):
+            region = cv2.resize(region, (args.tile_px, args.tile_px))
+
+    assert(region.shape[0] == region.shape[1] == args.tile_px)
+
+    # Remove the alpha channel and convert to RGB
+    if region.shape[-1] == 4:
+        region = region[:, :, 0:3]
+
+    # Apply normalization
+    if normalizer:
+        try:
+            region = normalizer.rgb_to_rgb(region)
+        except Exception:
+            # The image could not be normalized,
+            # which happens when a tile is primarily one solid color
+            return None
+
+    if args.img_format != 'numpy':
+        image = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
+        image = cv2.imencode("."+args.img_format, image)[1].tobytes()
+    else:
+        image = region
+
+    # Include ROI / bounding box processing.
+    # Used to visualize ROIs on extracted tiles, or to generate YoloV5 labels.
+    if args.yolo or args.draw_roi:
+        coords, boxes, yolo_anns = roi_coords_from_image(c, args)
+    if args.draw_roi:
+        image = draw_roi(image, coords)
+
+    return_dict.update({'image': image})
+    if args.yolo:
+        return_dict.update({'yolo': yolo_anns})
+    return return_dict
+
+
+class _cuCIMReader:
+
+    has_levels = True
+
+    def __init__(
+        self,
+        path: str,
+        mpp: Optional[float] = None,
+        cache_kw: Optional[Dict[str, Any]] = None,
+        num_workers: int = 0
+    ):
+        '''Wrapper for cuCIM reader to preserve cross-compatible functionality.'''
+
+        self.path = path
+        self.cache_kw = cache_kw if cache_kw else {}
+        self.loaded_downsample_levels = {}  # type: Dict[int, "CuImage"]
+        self.reader = CuImage(path)
+        self.num_workers = num_workers
+        self._mpp = None
+
+        # Check for Microns-per-pixel (MPP)
+        if mpp is not None:
+            log.debug(f"Setting MPP to {mpp}")
+            self._mpp = mpp
+        for prop_key in self.metadata:
+            if 'MPP' in self.metadata[prop_key]:
+                self._mpp = self.metadata[prop_key]['MPP']
+        if not self.mpp:
+            log.warn("Unable to auto-detect microns-per-pixel (MPP).")
+
+        # Pyramid layers
+        self.dimensions = tuple(self.properties['shape'][0:2][::-1])
+        self.levels = []
+        for lev in range(self.level_count):
+            self.levels.append({
+                'dimensions': self.level_dimensions[lev],
+                'width': self.level_dimensions[lev][0],
+                'height': self.level_dimensions[lev][1],
+                'downsample': self.level_downsamples[lev]
+            })
+
+    @property
+    def mpp(self):
+        return self._mpp
+
+    @property
+    def metadata(self):
+        return self.reader.metadata
+
+    @property
+    def properties(self):
+        return self.reader.metadata['cucim']
+
+    @property
+    def resolutions(self):
+        return self.properties['resolutions']
+
+    @property
+    def level_count(self):
+        return self.resolutions['level_count']
+
+    @property
+    def level_dimensions(self):
+        return self.resolutions['level_dimensions']
+
+    @property
+    def level_downsamples(self):
+        return self.resolutions['level_downsamples']
+
+    @property
+    def level_tile_sizes(self):
+        return self.resolutions['level_tile_sizes']
+
+    def best_level_for_downsample(
+        self,
+        downsample: float,
+    ) -> int:
+        '''Return lowest magnification level with a downsample level lower than
+        the given target.
+
+        Args:
+            downsample (float): Ratio of target resolution to resolution
+                at the highest magnification level. The downsample level of the
+                highest magnification layer is equal to 1.
+            levels (list(int), optional): Valid levels to search. Defaults to
+                None (search all levels).
+
+        Returns:
+            int:    Optimal downsample level.
+        '''
+        max_downsample = 0
+        for d in self.level_downsamples:
+            if d < downsample:
+                max_downsample = d
+        try:
+            max_level = self.level_downsamples.index(max_downsample)
+        except Exception:
+            log.debug(f"Error attempting to read level {max_downsample}")
+            return 0
+        return max_level
+
+    def read_level(self, level: int, to_numpy: bool = False):
+        """Read a pyramid level."""
+        image = self.reader.read_region(level=level)
+        if to_numpy:
+            return cucim2numpy(image)
+        else:
+            return image
+
+    def read_region(
+        self,
+        base_level_dim: Tuple[int, int],
+        downsample_level: int,
+        extract_size: Tuple[int, int],
+        convert: Optional[str] = None,
+        flatten: bool = False,
+        resize_factor: Optional[float] = None
+    ) -> "CuImage":
+        region = self.reader.read_region(
+            location=base_level_dim,
+            size=(int(extract_size[0]), int(extract_size[1])),
+            level=downsample_level,
+            num_workers=self.num_workers,
+        )
+        if resize_factor:
+            target_size = (int(extract_size[0] * resize_factor),
+                           int(extract_size[1] * resize_factor))
+            if __cv2_resize__:
+                region = resize(cp.asarray(region), target_size)
+        # Final conversions
+        if flatten and region.shape[-1] == 4:
+            region = region[:, :, 0:3]
+        if convert and convert.lower() in ('jpg', 'jpeg'):
+            region = cucim2jpg(region)
+        elif convert and convert.lower() == 'png':
+            region = cucim2png(region)
+        elif convert == 'numpy':
+            region = cucim2numpy(region)
+        else:
+            region = region
+        if resize_factor and __cv2_resize__:
+            return cv2.resize(region, target_size)
+        else:
+            return region
+
+    def read_from_pyramid(
+        self,
+        top_left: Tuple[int, int],
+        window_size: Tuple[int, int],
+        target_size: Tuple[int, int],
+        convert: Optional[str] = None,
+        flatten: bool = False,
+    ) -> "CuImage":
+        """Reads a region from the image using base layer coordinates.
+        Performance is accelerated by pyramid downsample layers, if available.
+
+        Args:
+            top_left (Tuple[int, int]): Top-left location of the region to
+                extract, using base layer coordinates (x, y).
+            window_size (Tuple[int, int]): Size of the region to read (width,
+                height) using base layer coordinates.
+            target_size (Tuple[int, int]): Resize the region to this target
+                size (width, height).
+
+        Returns:
+            CuImage: Image. Dimensions will equal target_size unless
+            the window includes an area of the image which is out of bounds.
+            In this case, the returned image will be cropped.
+        """
+        target_downsample = window_size[0] / target_size[0]
+        ds_level = self.best_level_for_downsample(target_downsample)
+        ds = self.level_downsamples[ds_level]
+        region = self.read_region(
+            top_left,
+            ds_level,
+            (int(window_size[0] / ds), int(window_size[1] / ds))
+        )
+        if not __cv2_resize__:
+            region = resize(cp.asarray(region), (target_size[1], target_size[0]))
+        # Final conversions
+        if flatten and region.shape[-1] == 4:
+            region = region[:, :, 0:3]
+        if convert and convert.lower() in ('jpg', 'jpeg'):
+            region = cucim2jpg(region)
+        elif convert and convert.lower() == 'png':
+            region = cucim2png(region)
+        elif convert == 'numpy':
+            region = cucim2numpy(region)
+        else:
+            region = region
+        if __cv2_resize__:
+            return cv2.resize(region, target_size)
+        else:
+            return region
+
+    def thumbnail(
+        self,
+        width: int = 512,
+        level: Optional[int] = None
+    ) -> np.ndarray:
+        """Return thumbnail of slide as numpy array."""
+        if level is None:
+            level = self.level_count - 1
+        w, h = self.dimensions
+        height = int((width * h) / w)
+        img = self.read_level(level=level)
+        if __cv2_resize__:
+            img = cucim2numpy(img)
+            return cv2.resize(img, (width, height))
+        else:
+            img = resize(cp.asarray(img), (width, height))
+            return cucim2numpy(img)

--- a/slideflow/slide/qc/otsu.py
+++ b/slideflow/slide/qc/otsu.py
@@ -2,7 +2,6 @@
 
 import cv2
 import numpy as np
-import pyvips as vips
 import slideflow as sf
 import rasterio
 import shapely.affinity as sa
@@ -38,20 +37,15 @@ class Otsu:
             level = wsi.slide.level_count - 1
         else:
             level = self.level
-        if wsi._slide_reader == sf.slide._JPGVIPSReader:
-            thumb = vips.Image.new_from_file(wsi.path, fail=True)
-        else:
-            thumb = vips.Image.new_from_file(
-                wsi.path,
-                fail=True,
-                access=vips.enums.Access.RANDOM,
-                level=level
-            )
+
         try:
-            thumb = sf.slide.vips2numpy(thumb)
-        except vips.error.Error:
+            if wsi.slide.has_levels:
+                thumb = wsi.slide.read_level(level=level, to_numpy=True)
+            else:
+                thumb = wsi.slide.read_level(to_numpy=True)
+        except Exception as e:
             raise errors.QCError(
-                f"Thumbnail error for slide {wsi.shortname}, QC failed"
+                f"Thumbnail error for slide {wsi.shortname}, QC failed: {e}"
             )
         if thumb.shape[-1] == 4:
             thumb = thumb[:, :, :3]

--- a/slideflow/slide/qc/otsu.py
+++ b/slideflow/slide/qc/otsu.py
@@ -38,7 +38,7 @@ class Otsu:
             level = wsi.slide.level_count - 1
         else:
             level = self.level
-        if wsi._vips_wrapper == sf.slide._JPGslideToVIPS:
+        if wsi._slide_reader == sf.slide._JPGVIPSReader:
             thumb = vips.Image.new_from_file(wsi.path, fail=True)
         else:
             thumb = vips.Image.new_from_file(

--- a/slideflow/slide/readers/vips.py
+++ b/slideflow/slide/readers/vips.py
@@ -1,0 +1,371 @@
+"""Libvips slide-reading backend.
+
+Requires: libvips (https://libvips.github.io/libvips/)
+"""
+
+import re
+from typing import (Any, Dict, List, Optional, Tuple)
+
+import numpy as np
+import slideflow as sf
+from PIL import Image, UnidentifiedImageError
+from slideflow.util import log, path_to_name  # noqa F401
+from slideflow.slide.utils import *
+
+from rich.progress import Progress
+
+
+try:
+    import pyvips as vips
+except (ModuleNotFoundError, OSError) as e:
+    log.error("Unable to load vips; slide processing will be unavailable. "
+              f"Error raised: {e}")
+
+
+VIPS_FORMAT_TO_DTYPE = {
+    'uchar': np.uint8,
+    'char': np.int8,
+    'ushort': np.uint16,
+    'short': np.int16,
+    'uint': np.uint32,
+    'int': np.int32,
+    'float': np.float32,
+    'double': np.float64,
+    'complex': np.complex64,
+    'dpcomplex': np.complex128,
+}
+
+
+def vips2numpy(vi: "vips.Image") -> np.ndarray:
+    '''Converts a VIPS image into a numpy array'''
+    return np.ndarray(buffer=vi.write_to_memory(),
+                      dtype=VIPS_FORMAT_TO_DTYPE[vi.format],
+                      shape=[vi.height, vi.width, vi.bands])
+
+
+def vips_resize(
+    img: np.ndarray,
+    crop_width: int,
+    target_px: int
+) -> np.ndarray:
+    """Resizes and crops an image using libvips.resize()
+
+    Args:
+        img (np.ndarray): Image.
+        crop_width (int): Height/width of image crop (before resize).
+        target_px (int): Target size of final image after resizing.
+
+    Returns:
+        np.ndarray: Resized image.
+    """
+    img_data = np.ascontiguousarray(img).data
+    vips_image = vips.Image.new_from_memory(
+        img_data,
+        crop_width,
+        crop_width,
+        bands=3,
+        format="uchar"
+    )
+    vips_image = vips_image.resize(target_px/crop_width)
+    return vips2numpy(vips_image)
+
+
+def vips_thumbnail(
+    path: str,
+    width: int = 512,
+    fail: bool = True,
+    leica_scn: bool = False,
+    access = vips.enums.Access.RANDOM,
+    **kwargs
+) -> np.ndarray:
+
+    if leica_scn:
+        thumbnail = vips.Image.new_from_file(path, fail=fail, access=access, **kwargs)
+    else:
+        thumbnail = vips.Image.thumbnail(path, width)
+    try:
+        return vips2numpy(thumbnail)
+    except vips.error.Error as e:
+        raise sf.errors.SlideLoadError(f"Error loading slide thumbnail: {e}")
+
+
+class _VIPSReader:
+
+    def __init__(
+        self,
+        path: str,
+        mpp: Optional[float] = None,
+        cache_kw: Optional[Dict[str, Any]] = None
+    ) -> None:
+        '''Wrapper for VIPS to preserve openslide-like functions.'''
+        self.path = path
+        self.cache_kw = cache_kw if cache_kw else {}
+        self.loaded_downsample_levels = {}  # type: Dict[int, "vips.Image"]
+        loaded_image = self.load_downsample_level(0)
+
+        # Load image properties
+        self.properties = {}
+        for field in loaded_image.get_fields():
+            self.properties.update({field: loaded_image.get(field)})
+        self.dimensions = (
+            int(self.properties[OPS_WIDTH]),
+            int(self.properties[OPS_HEIGHT])
+        )
+        # If Openslide MPP is not available, try reading from metadata
+        if mpp is not None:
+            log.debug(f"Setting MPP to {mpp}")
+            self.properties[OPS_MPP_X] = mpp
+        elif OPS_MPP_X not in self.properties.keys():
+            log.debug(
+                "Microns-Per-Pixel (MPP) not found, Searching EXIF"
+            )
+            try:
+                with Image.open(path) as img:
+                    if TIF_EXIF_KEY_MPP in img.tag.keys():
+                        _mpp = img.tag[TIF_EXIF_KEY_MPP][0]
+                        log.debug(
+                            f"Using MPP {_mpp} per EXIF {TIF_EXIF_KEY_MPP}"
+                        )
+                        self.properties[OPS_MPP_X] = _mpp
+                    elif (sf.util.path_to_ext(path).lower() == 'svs'
+                          and 'image-description' in loaded_image.get_fields()):
+                          img_des = loaded_image.get('image-description')
+                          _mpp = re.findall(r'(?<=MPP\s\=\s)0\.\d+', img_des)
+                          if _mpp is not None:
+                            log.debug(
+                                f"Using MPP {_mpp} from 'image-description' for SCN"
+                                "-converted SVS format"
+                            )
+                            self.properties[OPS_MPP_X] = _mpp[0]
+                    elif (sf.util.path_to_ext(path).lower() in ('tif', 'tiff')
+                          and 'xres' in loaded_image.get_fields()):
+                        xres = loaded_image.get('xres')  # 4000.0
+                        if (xres == 4000.0
+                           and loaded_image.get('resolution-unit') == 'cm'):
+                            # xres = xres # though resolution from tiffinfo
+                            # says 40000 pixels/cm, for some reason the xres
+                            # val is 4000.0, so multipley by 10.
+                            # Convert from pixels/cm to cm/pixels, then convert
+                            # to microns by multiplying by 1000
+                            mpp_x = (1/xres) * 1000
+                            self.properties[OPS_MPP_X] = str(mpp_x)
+                            log.debug(
+                                f"Using MPP {mpp_x} per TIFF 'xres' field"
+                                f" {loaded_image.get('xres')} and "
+                                f"{loaded_image.get('resolution-unit')}"
+                            )
+                    else:
+                        name = path_to_name(path)
+                        log.warning(
+                            f"Missing Microns-Per-Pixel (MPP) for {name}"
+                        )
+            except AttributeError:
+                mpp = DEFAULT_JPG_MPP
+                log.debug(f"Could not detect microns-per-pixel; using default {mpp}")
+                self.properties[OPS_MPP_X] = mpp
+            except UnidentifiedImageError:
+                log.error(
+                    f"PIL error; unable to read slide {path_to_name(path)}."
+                )
+
+        if OPS_LEVEL_COUNT in self.properties:
+            self.level_count = int(self.properties[OPS_LEVEL_COUNT])
+            # Calculate level metadata
+            self.levels = []   # type: List[Dict[str, Any]]
+            for lev in range(self.level_count):
+                width = int(loaded_image.get(OPS_LEVEL_WIDTH(lev)))
+                height = int(loaded_image.get(OPS_LEVEL_HEIGHT(lev)))
+                downsample = float(loaded_image.get(OPS_LEVEL_DOWNSAMPLE(lev)))
+                self.levels += [{
+                    'dimensions': (width, height),
+                    'width': width,
+                    'height': height,
+                    'downsample': downsample
+                }]
+        else:
+            self.level_count = 1
+            self.levels = [{
+                    'dimensions': self.dimensions,
+                    'width': self.dimensions[0],
+                    'height': self.dimensions[1],
+                    'downsample': 1
+                }]
+        self.level_downsamples = [lev['downsample'] for lev in self.levels]
+        self.level_dimensions = [lev['dimensions'] for lev in self.levels]
+
+    def best_level_for_downsample(
+        self,
+        downsample: float,
+    ) -> int:
+        '''Return lowest magnification level with a downsample level lower than
+        the given target.
+
+        Args:
+            downsample (float): Ratio of target resolution to resolution
+                at the highest magnification level. The downsample level of the
+                highest magnification layer is equal to 1.
+            levels (list(int), optional): Valid levels to search. Defaults to
+                None (search all levels).
+
+        Returns:
+            int:    Optimal downsample level.'''
+        max_downsample = 0
+        for d in self.level_downsamples:
+            if d < downsample:
+                max_downsample = d
+        try:
+            max_level = self.level_downsamples.index(max_downsample)
+        except Exception:
+            log.debug(f"Error attempting to read level {max_downsample}")
+            return 0
+        return max_level
+
+    def load_downsample_level(self, level: int) -> "vips.Image":
+        downsampled_image = vips.Image.new_from_file(
+            self.path,
+            level=level,
+            fail=True,
+            access=vips.enums.Access.RANDOM
+        )
+        if self.cache_kw:
+            downsampled_image = downsampled_image.tilecache(**self.cache_kw)
+        self.loaded_downsample_levels.update({
+            level: downsampled_image
+        })
+        return downsampled_image
+
+    def get_downsampled_image(self, level: int) -> "vips.Image":
+        '''Returns a VIPS image of a given downsample.'''
+        if level in range(len(self.levels)):
+            if level in self.loaded_downsample_levels:
+                return self.loaded_downsample_levels[level]
+            else:
+                return self.load_downsample_level(level)
+        else:
+            return False
+
+    def read_region(
+        self,
+        base_level_dim: Tuple[int, int],
+        downsample_level: int,
+        extract_size: Tuple[int, int]
+    ) -> "vips.Image":
+        """Extracts a region from the image at the given downsample level.
+
+        Args:
+            base_level_dim (Tuple[int, int]): Top-left location of the region
+                to extract, using downsample layer coordinates (x, y)
+            downsample_level (int): Downsample level to read.
+            extract_size (Tuple[int, int]): Size of the region to read
+                (width, height) using base layer coordinates.
+
+        Returns:
+            vips.Image: VIPS image.
+        """
+        base_level_x, base_level_y = base_level_dim
+        extract_width, extract_height = extract_size
+        downsample_factor = self.level_downsamples[downsample_level]
+        downsample_x = int(base_level_x / downsample_factor)
+        downsample_y = int(base_level_y / downsample_factor)
+        image = self.get_downsampled_image(downsample_level)
+        region = image.crop(
+            downsample_x,
+            downsample_y,
+            extract_width,
+            extract_height
+        )
+        return region
+
+    def read_from_pyramid(
+        self,
+        top_left: Tuple[int, int],
+        window_size: Tuple[int, int],
+        target_size: Optional[Tuple[int, int]] = None,
+        target_downsample: Optional[float] = None,
+    ) -> "vips.Image":
+        """Reads a region from the image. Performance is accelerated by
+        pyramid downsample layers, if available.
+
+        Args:
+            top_left (Tuple[int, int]): Top-left location of the region to
+                extract, using base layer coordinates (x, y).
+            window_size (Tuple[int, int]): Size of the region to read (width,
+                height) using base layer coordinates.
+            target_size (Tuple[int, int]): Resize the region to this target
+                size (width, height).
+
+        Returns:
+            vips.Image: VIPS image. Dimensions will equal target_size unless
+            the window includes an area of the image which is out of bounds.
+            In this case, the returned image will be cropped.
+        """
+        if target_size is None and target_downsample is None:
+            raise ValueError("Must supply either target_size or "
+                             "target_downsample to read_from_pyramid()")
+        if target_downsample is None:
+            target_downsample = window_size[0] / target_size[0]
+
+        ds_level = self.best_level_for_downsample(target_downsample)
+        image = self.get_downsampled_image(ds_level)
+        resize_factor = self.level_downsamples[ds_level] / target_downsample
+        image = image.resize(resize_factor)
+
+        if target_size is not None:
+            return image.crop(
+                int(top_left[0] / target_downsample),
+                int(top_left[1] / target_downsample),
+                min(target_size[0], image.width),
+                min(target_size[1], image.height)
+            )
+        else:
+            return image
+
+
+class _JPGVIPSReader(_VIPSReader):
+    '''Wrapper for JPG files, which do not possess separate levels, to
+    preserve openslide-like functions.'''
+
+    def __init__(self, path: str, mpp: Optional[float] = None, cache_kw = None) -> None:
+        self.path = path
+        self.full_image = vips.Image.new_from_file(path)
+        self.cache_kw = cache_kw if cache_kw else {}
+        if not self.full_image.hasalpha():
+            self.full_image = self.full_image.addalpha()
+        self.properties = {}
+        for field in self.full_image.get_fields():
+            self.properties.update({field: self.full_image.get(field)})
+        width = int(self.properties[OPS_WIDTH])
+        height = int(self.properties[OPS_HEIGHT])
+        self.dimensions = (width, height)
+        self.level_count = 1
+        self.loaded_downsample_levels = {
+            0: self.full_image
+        }
+        # Calculate level metadata
+        self.levels = [{
+            'dimensions': (width, height),
+            'width': width,
+            'height': height,
+            'downsample': 1,
+        }]
+        self.level_downsamples = [1]
+        self.level_dimensions = [(width, height)]
+
+        # MPP data
+        if mpp is not None:
+            log.debug(f"Setting MPP to {mpp}")
+            self.properties[OPS_MPP_X] = mpp
+        else:
+            try:
+                with Image.open(path) as img:
+                    exif_data = img.getexif()
+                    if TIF_EXIF_KEY_MPP in exif_data.keys():
+                        _mpp = exif_data[TIF_EXIF_KEY_MPP]
+                        log.debug(f"Using MPP {_mpp} per EXIF field {TIF_EXIF_KEY_MPP}")
+                        self.properties[OPS_MPP_X] = _mpp
+                    else:
+                        raise AttributeError
+            except AttributeError:
+                mpp = DEFAULT_JPG_MPP
+                log.debug(f"Could not detect microns-per-pixel; using default {mpp}")
+                self.properties[OPS_MPP_X] = mpp

--- a/slideflow/slide/utils.py
+++ b/slideflow/slide/utils.py
@@ -1,5 +1,13 @@
 """Utility functions and constants for slide reading."""
 
+import io
+import numpy as np
+import shapely.geometry as sg
+
+from PIL import Image, ImageDraw
+from types import SimpleNamespace
+from typing import Union, List, Tuple
+
 DEFAULT_JPG_MPP = 1
 OPS_LEVEL_COUNT = 'openslide.level-count'
 OPS_MPP_X = 'openslide.mpp-x'
@@ -25,3 +33,83 @@ def OPS_LEVEL_WIDTH(level: int) -> str:
 
 def OPS_LEVEL_DOWNSAMPLE(level: int) -> str:
     return f'openslide.level[{level}].downsample'
+
+
+def draw_roi(
+    img: Union[np.ndarray, str],
+    coords: List[int]
+) -> np.ndarray:
+    """Draw ROIs on image.
+
+    Args:
+        img (Union[np.ndarray, str]): Image.
+        coords (List[List[int]]): ROI coordinates.
+
+    Returns:
+        np.ndarray: Image as numpy array.
+    """
+    annPolys = [sg.Polygon(b) for b in coords]
+    if isinstance(img, np.ndarray):
+        annotated_img = Image.fromarray(img)
+    elif isinstance(img, str):
+        annotated_img = Image.open(io.BytesIO(img))  # type: ignore
+    draw = ImageDraw.Draw(annotated_img)
+    for poly in annPolys:
+        x, y = poly.exterior.coords.xy
+        zipped = list(zip(x.tolist(), y.tolist()))
+        draw.line(zipped, joint='curve', fill='red', width=5)
+    return np.asarray(annotated_img)
+
+
+def roi_coords_from_image(
+    c: List[int],
+    args: SimpleNamespace
+) -> Tuple[List[int], List[np.ndarray], List[List[int]]]:
+    # Scale ROI according to downsample level
+    extract_scale = (args.extract_px / args.full_extract_px)
+
+    # Scale ROI according to image resizing
+    resize_scale = (args.tile_px / args.extract_px)
+
+    def proc_ann(ann):
+        # Scale to full image size
+        coord = ann.coordinates
+        # Offset coordinates to extraction window
+        coord = np.add(coord, np.array([-1 * c[0], -1 * c[1]]))
+        # Rescale according to downsampling and resizing
+        coord = np.multiply(coord, (extract_scale * resize_scale))
+        return coord
+
+    # Filter out ROIs not in this tile
+    coords = []
+    ll = np.array([0, 0])
+    ur = np.array([args.tile_px, args.tile_px])
+    for roi in args.rois:
+        coord = proc_ann(roi)
+        idx = np.all(np.logical_and(ll <= coord, coord <= ur), axis=1)
+        coords_in_tile = coord[idx]
+        if len(coords_in_tile) > 3:
+            coords += [coords_in_tile]
+
+    # Convert ROI to bounding box that fits within tile
+    boxes = []
+    yolo_anns = []
+    for coord in coords:
+        max_vals = np.max(coord, axis=0)
+        min_vals = np.min(coord, axis=0)
+        max_x = min(max_vals[0], args.tile_px)
+        max_y = min(max_vals[1], args.tile_px)
+        min_x = max(min_vals[0], 0)
+        min_y = max(0, min_vals[1])
+        width = (max_x - min_x) / args.tile_px
+        height = (max_y - min_y) / args.tile_px
+        x_center = ((max_x + min_x) / 2) / args.tile_px
+        y_center = ((max_y + min_y) / 2) / args.tile_px
+        yolo_anns += [[x_center, y_center, width, height]]
+        boxes += [np.array([
+            [min_x, min_y],
+            [min_x, max_y],
+            [max_x, max_y],
+            [max_x, min_y]
+        ])]
+    return coords, boxes, yolo_anns

--- a/slideflow/slide/utils.py
+++ b/slideflow/slide/utils.py
@@ -1,0 +1,27 @@
+"""Utility functions and constants for slide reading."""
+
+DEFAULT_JPG_MPP = 1
+OPS_LEVEL_COUNT = 'openslide.level-count'
+OPS_MPP_X = 'openslide.mpp-x'
+OPS_VENDOR = 'openslide.vendor'
+TIF_EXIF_KEY_MPP = 65326
+OPS_WIDTH = 'width'
+OPS_HEIGHT = 'height'
+DEFAULT_WHITESPACE_THRESHOLD = 230
+DEFAULT_WHITESPACE_FRACTION = 1.0
+DEFAULT_GRAYSPACE_THRESHOLD = 0.05
+DEFAULT_GRAYSPACE_FRACTION = 0.6
+FORCE_CALCULATE_WHITESPACE = -1
+FORCE_CALCULATE_GRAYSPACE = -1
+
+
+def OPS_LEVEL_HEIGHT(level: int) -> str:
+    return f'openslide.level[{level}].height'
+
+
+def OPS_LEVEL_WIDTH(level: int) -> str:
+    return f'openslide.level[{level}].width'
+
+
+def OPS_LEVEL_DOWNSAMPLE(level: int) -> str:
+    return f'openslide.level[{level}].downsample'

--- a/slideflow/stats/metrics.py
+++ b/slideflow/stats/metrics.py
@@ -581,7 +581,9 @@ def group_reduce(
                 _df[f'{outcome}-y_pred{i}'] = (outcome_pred_cat == i).astype(int)
 
     for group in groups:
-        group_dfs.update({group: _df.groupby(group, as_index=False).mean()})
+        group_dfs.update({
+            group: _df.groupby(group, as_index=False).mean(numeric_only=True)
+        })
 
     return group_dfs
 

--- a/slideflow/util/__init__.py
+++ b/slideflow/util/__init__.py
@@ -163,11 +163,13 @@ class TileExtractionProgress(Progress):
 def header(console=None):
     if console is None:
         console = Console()
-    color = 'yellow' if sf.backend() == 'tensorflow' else 'purple'
+    col1 = 'yellow' if sf.backend() == 'tensorflow' else 'purple'
+    col2 = 'green' if sf.slide_backend() == 'cucim' else 'cyan'
     console.print(
         Panel(f"[white bold]Slideflow[/]"
               f"\nVersion: {sf.__version__}"
-              f"\nBackend: [{color}]{sf.backend()}[/]"
+              f"\nBackend: [{col1}]{sf.backend()}[/]"
+              f"\nSlide Backend: [{col2}]{sf.slide_backend()}[/]"
               "\n[blue]https://slideflow.dev[/]",
               border_style='purple'),
         justify='center')

--- a/slideflow/workbench/heatmap_widget.py
+++ b/slideflow/workbench/heatmap_widget.py
@@ -56,8 +56,10 @@ class HeatmapWidget:
     def _create_heatmap(self):
         viz = self.viz
         self.reset()
-        mp_key = 'num_threads' if viz.low_memory else 'num_processes'
-        mp_kw = {mp_key: os.cpu_count()}
+        if viz.low_memory or sf.slide_backend() == 'cucim':
+            mp_kw = dict(num_threads=os.cpu_count())
+        else:
+            mp_kw = dict(num_processes=os.cpu_count())
         viz.heatmap = sf.heatmap.ModelHeatmap(
             viz.wsi,
             viz.model,

--- a/slideflow/workbench/slide_widget.py
+++ b/slideflow/workbench/slide_widget.py
@@ -81,8 +81,10 @@ class SlideWidget:
     def _filter_thread_worker(self):
         if self.viz.wsi is not None:
             self.viz.set_message(self._rendering_message)
-            mp_key = 'num_threads' if self.viz.low_memory else 'num_processes'
-            mp_kw = {mp_key: os.cpu_count()}
+            if self.viz.low_memory or sf.slide_backend() == 'cucim':
+                mp_kw = dict(num_threads=os.cpu_count())
+            else:
+                mp_kw = dict(num_processes=os.cpu_count())
             generator = self.viz.wsi.build_generator(
                 img_format='numpy',
                 grayspace_fraction=sf.slide.FORCE_CALCULATE_GRAYSPACE,
@@ -371,7 +373,7 @@ class SlideWidget:
 
                 # Slide properties (sub-child). -----------------------------------
                 if viz.wsi is not None:
-                    prop = viz.wsi.properties
+                    width, height = viz.wsi.dimensions
                     if self._filter_grid is not None and self.show_tile_filter:
                         est_tiles = int(self._filter_grid.sum())
                     elif self.show_slide_filter:
@@ -379,7 +381,7 @@ class SlideWidget:
                     else:
                         est_tiles = viz.wsi.grid.shape[0] * viz.wsi.grid.shape[1]
                     vals = [
-                        f"{prop['width']} x {prop['height']}",
+                        f"{width} x {height}",
                         f'{viz.wsi.mpp:.4f} ({int(10 / (viz.wsi.slide.level_downsamples[0] * viz.wsi.mpp)):d}x)',
                         viz.wsi.vendor if viz.wsi.vendor is not None else '-',
                         str(est_tiles),


### PR DESCRIPTION
Adds [cuCIM](https://github.com/rapidsai/cucim) support as a slide reading backend.

## Summary
cuCIM is 2-3x faster for whole-slide image reading, with lighter CPU utilization and about half the memory footprint. On a 24-core CPU, this permits training directly from whole-slide images (without TFRecords) at around 1100 img/s. It is also much easier to install, requiring only pip:

```
pip install slideflow cupy-cuda11x
```

Libvips functionality has been isolated into `sf.slide.backends.vips`, with cuCIM support in `sf.slide.backends.cucim`. The backend is set via the environmental variable `SF_SLIDE_BACKEND`. If this has not been set, Slideflow will default to using cuCIM if available, falling back to libvips otherwise. Both cannot be imported simultaneously due to memory conflicts resulting in segfaults.



## Known issues
- cuCIM only supports SVS and TIFF images. Thus, users working with other slide formats should opt to continue using libvips.
- May require CUDA (NVIDIA GPU only)
- Reading from whole-slide images is fairly light on memory utilization (< 20 GB), but memory utilization increases significantly (50+ GB) once training has started.