### PR TITLE
Add support for XML-formatted ROIs

### DIFF
--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -557,7 +557,7 @@ class Dataset:
             ))
             sources = ['dataset']
 
-        if self.convert_xml_rois is True:
+        if self.convert_xml is True:
             convert_xml_rois(self)
 
         if isinstance(config, str):

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -93,7 +93,6 @@ import types
 import tempfile
 import warnings
 import signal
-import xml.etree.ElementTree as ET
 from collections import defaultdict
 from datetime import datetime
 from glob import glob
@@ -2340,31 +2339,6 @@ class Dataset:
                 tfr+'.transformed',
                 resize=tile_px
             )
-
-    def xml_to_csv(path):
-        """ Creates a QuPath format csv ROI file from 
-            an ImageScope format xml ROI file.
-        
-        Args:
-            path (str): ImageScope xml ROI file path
-        
-        Returns:
-            new_csv_file (str): path to the newly created
-            csv ROI file
-        """
-        tree = ET.parse(path)
-        root = tree.getroot()
-        new_csv_file = path[:-4] + 'csv'
-        with open(new_csv_file, 'w', newline='') as csvfile:
-            csvwriter = csv.writer(csvfile)
-            csvwriter.writerow(['ROI_name', 'X_base', 'Y_base'])
-            for region in root.finall('.//Region'):
-                roi_name = 'ROI_' + str(region.get('Id'))
-                for vertex in region.finall('.//Vertex'):
-                    x_base = vertex.get('X')
-                    y_base = vertex.get('Y')
-                    csvwriter.writerow([roi_name, x_base, y_base])
-        return new_csv_file
 
     def rois(self) -> List[str]:
         """Return a list of all ROIs."""

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -93,6 +93,7 @@ import types
 import tempfile
 import warnings
 import signal
+import xml.etree.ElementTree as ET
 from collections import defaultdict
 from datetime import datetime
 from glob import glob
@@ -2340,12 +2341,41 @@ class Dataset:
                 resize=tile_px
             )
 
+    def xml_to_csv(path):
+        """ Creates a QuPath format csv ROI file from 
+            an ImageScope format xml ROI file.
+        
+        Args:
+            path (str): ImageScope xml ROI file path
+        
+        Returns:
+            new_csv_file (str): path to the newly created
+            csv ROI file
+        """
+        tree = ET.parse(path)
+        root = tree.getroot()
+        new_csv_file = path[:-4] + 'csv'
+        with open(new_csv_file, 'w', newline='') as csvfile:
+            csvwriter = csv.writer(csvfile)
+            csvwriter.writerow(['ROI_name', 'X_base', 'Y_base'])
+            for region in root.finall('.//Region'):
+                roi_name = 'ROI_' + str(region.get('Id'))
+                for vertex in region.finall('.//Vertex'):
+                    x_base = vertex.get('X')
+                    y_base = vertex.get('Y')
+                    csvwriter.writerow([roi_name, x_base, y_base])
+        return new_csv_file
+
     def rois(self) -> List[str]:
         """Return a list of all ROIs."""
         rois_list = []
         for source in self.sources:
             if self._roi_set(source):
                 rois_list += glob(join(self.sources[source]['roi'], "*.csv"))
+                xml_rois_list += glob(join(self.sources[source]['roi'], "*.xml"))
+                if len(xml_rois_list) > 0:
+                    for xml in xml_rois_list:
+                        rois_list += xml_to_csv(xml)
             else:
                 log.warning(f"roi path not set for source {source}")
         slides = self.slides()

--- a/slideflow/slide/utils.py
+++ b/slideflow/slide/utils.py
@@ -119,13 +119,16 @@ def roi_coords_from_image(
     return coords, boxes, yolo_anns
 
 def xml_to_csv(path):
-    """Creates a QuPath format csv ROI file from an ImageScope format xml ROI file.
+    """Creates a QuPath format CSV ROI file from an ImageScope format XML ROI file.
 
     Args:
-        path (str): ImageScope xml ROI file path
+        path (str): ImageScope XML ROI file path
 
     Returns:
-        bool: True indicates that 
+        bool: True indicates that the XML file was converted to a CSV. 
+        False indicates that the XML file was not converted to a CSV
+        due to improper formatting. XML files must be in ImageScope ROI
+        export XML format. 
     """
     tree = ET.parse(path)
     root = tree.getroot()


### PR DESCRIPTION
The xml_to_csv() function looks for any xml files and converts them to csv inside the user-specified ROI folder. The csv files are saved in the same folder. Then, rois() has been modified to look for xml files. If they exit, it will convert the xmls to csv and add the new csv file paths to the roi list. 