### PR TITLE
TFRecord index files without ZIP archive format

### DIFF
--- a/slideflow/mil/eval.py
+++ b/slideflow/mil/eval.py
@@ -282,16 +282,21 @@ def generate_attention_heatmaps(
             slidename = sf.util.path_to_name(bag)
             slide_path = dataset.find_slide(slide=slidename)
             locations_file = join(dirname(bag), f'{slidename}.index.npz')
+            npy_loc_file = locations_file[:-1] + 'y'
             if slide_path is None:
                 log.info(f"Unable to find slide {slidename}")
                 continue
-            if not exists(locations_file):
+            if exists(locations_file):
+                locations = np.load(locations_file)['arr_0']
+            elif exists(npy_loc_file):
+                locations = np.load(npy_loc_file)
+            else:
                 log.info(
                     f"Unable to find locations index file for {slidename}"
                 )
                 continue
             sf.util.location_heatmap(
-                locations=np.load(locations_file)['arr_0'],
+                locations=locations,
                 values=attention[i],
                 slide=slide_path,
                 tile_px=dataset.tile_px,

--- a/slideflow/util/tfrecord2idx.py
+++ b/slideflow/util/tfrecord2idx.py
@@ -55,7 +55,12 @@ def create_index(tfrecord_file: str, index_file: str) -> None:
             print("Failed to parse TFRecord.")
             break
     infile.close()
-    np.savez(index_file, np.array(out_array))
+    out_array = np.array(out_array)
+    try:
+        np.savez(index_file, out_array)
+    except OSError:
+        # Raised for storage device that do not allow *.zip files
+        np.save(index_file + '.npy', out_array)
 
 
 def find_index(tfrecord: str) -> Optional[str]:
@@ -64,6 +69,8 @@ def find_index(tfrecord: str) -> Optional[str]:
         return join(dirname(tfrecord), name+'.index')
     elif exists(join(dirname(tfrecord), name+'.index.npz')):
         return join(dirname(tfrecord), name+'.index.npz')
+    elif exists(join(dirname(tfrecord), name+'.index.npy')):
+        return join(dirname(tfrecord), name+'.index.npy')
     else:
         return None
 
@@ -76,6 +83,8 @@ def load_index(tfrecord: str) -> Optional[np.ndarray]:
         return None
     elif index_path.endswith('npz'):
         return np.load(index_path)['arr_0']
+    elif index_path.endswith('npy'):
+        return np.load(index_path)
     else:
         return np.loadtxt(index_path, dtype=np.int64)
 
@@ -99,7 +108,11 @@ def get_tfrecord_length(tfrecord: str) -> int:
     if os.stat(index_path).st_size == 0:
         return 0
     else:
-        return load_index(tfrecord).shape[0]
+        index_array = load_index(tfrecord)
+        if index_array is None:
+            return 0
+        else:
+            return index_array.shape[0]
 
 
 def read_tfrecord_length(tfrecord: str) -> int:

--- a/slideflow/util/tfrecord2idx.py
+++ b/slideflow/util/tfrecord2idx.py
@@ -12,9 +12,6 @@ from os.path import dirname, join, exists
 from slideflow import errors
 
 
-__allow_zip__ = False
-
-
 TYPENAME_MAPPING = {
     "byte": "bytes_list",
     "float": "float_list",
@@ -63,10 +60,10 @@ def create_index(tfrecord_file: str, index_file: str) -> None:
             break
     infile.close()
     out_array = np.array(out_array)
-    if __allow_zip__:
-        np.savez(index_file, out_array)
-    else:
+    if 'SF_ALLOW_ZIP' in os.environ and os.environ['SF_ALLOW_ZIP'] == '0':
         np.save(index_file + '.npy', out_array)
+    else:
+        np.savez(index_file, out_array)
 
 
 def find_index(tfrecord: str) -> Optional[str]:

--- a/slideflow/util/tfrecord2idx.py
+++ b/slideflow/util/tfrecord2idx.py
@@ -11,17 +11,24 @@ from typing import Optional, Dict
 from os.path import dirname, join, exists
 from slideflow import errors
 
+
+__allow_zip__ = False
+
+
 TYPENAME_MAPPING = {
     "byte": "bytes_list",
     "float": "float_list",
     "int": "int64_list"
 }
+
 FEATURE_DESCRIPTION = {
-        'image_raw': 'byte',
-        'slide': 'byte',
-        'loc_x': 'int',
-        'loc_y': 'int'
-    }
+    'image_raw': 'byte',
+    'slide': 'byte',
+    'loc_x': 'int',
+    'loc_y': 'int'
+}
+
+# -----------------------------------------------------------------------------
 
 def create_index(tfrecord_file: str, index_file: str) -> None:
     """Create index from the tfrecords file.
@@ -56,10 +63,9 @@ def create_index(tfrecord_file: str, index_file: str) -> None:
             break
     infile.close()
     out_array = np.array(out_array)
-    try:
+    if __allow_zip__:
         np.savez(index_file, out_array)
-    except OSError:
-        # Raised for storage device that do not allow *.zip files
+    else:
         np.save(index_file + '.npy', out_array)
 
 


### PR DESCRIPTION
On databricks with dbfs file storage, *.zip files are not supported. TFRecord index files are written by default as *zip files (using numpy.savez). This PR adds ability to save the index files as non-zip numpy arrays (using numpy.save), if the environmental variable `SF_ALLOW_ZIP` is set to `0`. This needs to be controlled via environmental variable to ensure the setting is propagated to all child processes in multiprocessing pools.

See #245 