### PR TITLE
Loading slides without 'levels'

### DIFF
--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1278,6 +1278,7 @@ class Dataset:
     def convert_xml_rois(self):
         """Convert ImageScope XML ROI files to QuPath format CSV ROI files."""
         n_converted = 0
+        xml_list = []
         for source in self.sources:
             if self._roi_set(source):
                 xml_list = glob(join(self.sources[source]['roi'], "*.xml"))

--- a/slideflow/slide/qc/otsu.py
+++ b/slideflow/slide/qc/otsu.py
@@ -94,7 +94,10 @@ class Otsu:
 
         try:
             if wsi.slide.has_levels:
-                thumb = wsi.slide.read_level(level=level, to_numpy=True)
+                try:   
+                    thumb = wsi.slide.read_level(level=level, to_numpy=True)
+                except KeyError:
+                    thumb = wsi.slide.read_level(page=level, to_numpy=True)
             else:
                 thumb = wsi.slide.read_level(to_numpy=True)
         except Exception as e:

--- a/slideflow/slide/utils.py
+++ b/slideflow/slide/utils.py
@@ -137,7 +137,7 @@ def xml_to_csv(path: str) -> str:
     """
     tree = ET.parse(path)
     root = tree.getroot()
-    new_csv_file = path[:-4] + 'csv'
+    new_csv_file = path[:-4] + '.csv'
     required_attributes = ['.//Region', './/Vertex']
     if not all(root.findall(a) for a in required_attributes):
         raise errors.ROIError(


### PR DESCRIPTION
These modifications check if an image has the 'slide-levels' meta-data field, and if it does not, it loads the image without this data. This does not make any major code changes; the _JPGVIPSReader() achieves the functionality needed to load images without 'slide-levels', therefore, this modification renames this function to _ALTVIPSReader() to indicate that any image that is not being read with the _VIPSReader will be read with the alternate reader that is not reliant upon image levels. 