### PR TITLE
Fix url to tutorials in website

### DIFF
--- a/docs-source/pytorch_sphinx_theme/pytorch_sphinx_theme/theme_variables.jinja
+++ b/docs-source/pytorch_sphinx_theme/pytorch_sphinx_theme/theme_variables.jinja
@@ -7,7 +7,7 @@
   'facebook': 'https://www.facebook.com/pytorch',
   'slack': 'https://pytorch.slack.com',
   'discuss': 'https://discuss.pytorch.org',
-  'tutorials': 'https://slideflow.dev/tutorial1.html',
+  'tutorials': 'https://slideflow.dev/tutorial1/',
   'previous_pytorch_versions': 'https://pytorch.org/previous-versions/',
   'home': 'https://pytorch.org/',
   'get_started': 'https://pytorch.org/get-started',


### PR DESCRIPTION
When I click "Tutorials" in the header of the slideflow website, I am led to a 404 page. I am hoping this pull request fixes this. Please let me know if other changes are needed. 

This replaces the url https://slideflow.dev/tutorial1.html with https://slideflow.dev/tutorial1/ . The former URL leads to a 404 error.

Thanks for the comprehensive software!! I am looking forward to using this.