### PR TITLE
indicate that "slide" column does not include extensions

### DIFF
--- a/docs-source/source/tutorial1.rst
+++ b/docs-source/source/tutorial1.rst
@@ -42,9 +42,9 @@ With our project initialized, we can set up our annotations file. Use the downlo
 CSV file, with a column "patient" indicating patient name (in the case of TCGA, these are in the format
 TCGA-SS-XXXX, where SS indicates site of origin and XXXX is the patient identifier), and a column "er_status_by_ihc"
 containing our outcome of interest. Add a third column "slide" containing the name of the slide associated with the
-patient. If there are multiple slides per patient, list each slide on a separate row. Finally, add a column "dataset"
-to indicate whether the slide should be used for training or evaluation. Set aside somewhere around 10-30% of the
-dataset for evaluation.
+patient (without the file extension). If there are multiple slides per patient, list each slide on a separate row. 
+Finally, add a column "dataset" to indicate whether the slide should be used for training or evaluation. Set aside 
+somewhere around 10-30% of the dataset for evaluation.
 
 .. note::
 


### PR DESCRIPTION
this is my first time using slideflow and i had some trouble extracting tiles from slides. after debugging, i realized that the "slide" column in the annotations file must not include the file extension.

if you don't mind, i modified tutorial1 to indicate that the "slide" column must include file names without extensions.

Original:
```
Add a third column "slide" containing the name of the slide associated with the patient.
```

New:
```
Add a third column "slide" containing the name of the slide associated with the patient (without the file extension).
```

the next two lines also show as modified. i put that text on new lines to keep the line width consistent in that section.