### PR TITLE
Neptune in mil sf consistent

### DIFF
--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -29,7 +29,7 @@ def train_mil(
     outdir: str = 'mil',
     exp_label: Optional[str] = None,
     use_neptune=False,
-    nep_args=None,
+    neptune_args=None,
     **kwargs
 ):
     """Train a multiple-instance learning (MIL) model.
@@ -63,7 +63,7 @@ def train_mil(
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
         use_neptune (bool,optional): Log training to neptune.ai
-        nep_args (dict): Keyword arguments to specify neptune project data.
+        neptune_args (dict): Keyword arguments to specify neptune project data.
     """
     log.info("Training FastAI MIL model with config:")
     log.info(f"{config}")
@@ -103,7 +103,7 @@ def train_mil(
         bags,
         outdir=outdir,
         use_neptune=use_neptune,
-        nep_args=nep_args,
+        neptune_args=neptune_args,
         **kwargs
     )
 
@@ -379,7 +379,7 @@ def train_fastai(
     outdir: str = 'mil',
     attention_heatmaps: bool = False,
     use_neptune=False,
-    nep_args=None,
+    neptune_args=None,
     **heatmap_kwargs
 ) -> None:
     """Train an aMIL model using FastAI.
@@ -414,7 +414,7 @@ def train_fastai(
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
         use_neptune (bool,optional): Log training to neptune.ai
-        nep_args (dict): Keyword arguments to specify neptune project data.
+        neptune_args (dict): Keyword arguments to specify neptune project data.
 
     Returns:
         fastai.learner.Learner
@@ -454,7 +454,7 @@ def train_fastai(
     _log_mil_params(config, outcomes, unique, bags, n_in, n_out, outdir)
 
     # Train.
-    _fastai.train(learner, config,use_neptune=use_neptune,nep_args=nep_args)
+    _fastai.train(learner, config,use_neptune=use_neptune,neptune_args=neptune_args)
 
     # Generate validation predictions.
     df, attention = predict_from_model(

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -28,6 +28,8 @@ def train_mil(
     *,
     outdir: str = 'mil',
     exp_label: Optional[str] = None,
+    use_neptune=False,
+    nep_args=None,
     **kwargs
 ):
     """Train a multiple-instance learning (MIL) model.
@@ -60,7 +62,8 @@ def train_mil(
             for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
-
+        use_neptune (bool,optional): Log training to neptune.ai
+        nep_args (dict): Keyword arguments to specify neptune project data.
     """
     log.info("Training FastAI MIL model with config:")
     log.info(f"{config}")
@@ -99,6 +102,8 @@ def train_mil(
         outcomes,
         bags,
         outdir=outdir,
+        use_neptune=use_neptune,
+        nep_args=nep_args,
         **kwargs
     )
 
@@ -373,6 +378,8 @@ def train_fastai(
     *,
     outdir: str = 'mil',
     attention_heatmaps: bool = False,
+    use_neptune=False,
+    nep_args=None,
     **heatmap_kwargs
 ) -> None:
     """Train an aMIL model using FastAI.
@@ -406,6 +413,8 @@ def train_fastai(
             for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
+        use_neptune (bool,optional): Log training to neptune.ai
+        nep_args (dict): Keyword arguments to specify neptune project data.
 
     Returns:
         fastai.learner.Learner
@@ -445,7 +454,7 @@ def train_fastai(
     _log_mil_params(config, outcomes, unique, bags, n_in, n_out, outdir)
 
     # Train.
-    _fastai.train(learner, config)
+    _fastai.train(learner, config,use_neptune=use_neptune,nep_args=nep_args)
 
     # Generate validation predictions.
     df, attention = predict_from_model(

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -28,7 +28,10 @@ def train_mil(
     *,
     outdir: str = 'mil',
     exp_label: Optional[str] = None,
-    neptune_args=None,
+    use_neptune: Optional[bool] = False,
+    neptune_workspace: Optional[str] = None,
+    neptune_api: Optional[str] = None,
+    neptune_name: Optional[str] = None,
     **kwargs
 ):
     """Train a multiple-instance learning (MIL) model.
@@ -50,6 +53,14 @@ def train_mil(
         exp_label (str): Experiment label, used for naming the subdirectory
             in the ``{project root}/mil`` folder, where training history
             and the model will be saved.
+        use_neptune (bool, optional): Use Neptune API logging.
+            Defaults to False
+        neptune_api (str, optional): Neptune API token, used for logging.
+            Defaults to None.
+        neptune_workspace (str, optional): Neptune workspace.
+            Defaults to None.
+        neptune_name (str, optional): Custom Name for neptune run.
+            Defaults to None.
         attention_heatmaps (bool): Generate attention heatmaps for slides.
             Defaults to False.
         interpolation (str, optional): Interpolation strategy for smoothing
@@ -61,7 +72,6 @@ def train_mil(
             for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
-        neptune_args (dict): Keyword arguments to specify neptune project data.
     """
     log.info("Training FastAI MIL model with config:")
     log.info(f"{config}")
@@ -100,7 +110,10 @@ def train_mil(
         outcomes,
         bags,
         outdir=outdir,
-        neptune_args=neptune_args,
+        use_neptune=use_neptune,
+        neptune_workspace=neptune_workspace,
+        neptune_api=neptune_api,
+        neptune_name=neptune_name,
         **kwargs
     )
 
@@ -375,7 +388,10 @@ def train_fastai(
     *,
     outdir: str = 'mil',
     attention_heatmaps: bool = False,
-    neptune_args=None,
+    use_neptune: Optional[bool] = False,
+    neptune_workspace: Optional[str] = None,
+    neptune_api: Optional[str] = None,
+    neptune_name: Optional[str] = None,
     **heatmap_kwargs
 ) -> None:
     """Train an aMIL model using FastAI.
@@ -409,7 +425,12 @@ def train_fastai(
             for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
-        neptune_args (dict): Keyword arguments to specify neptune project data.
+        use_neptune (bool, optional): Use Neptune API logging.
+            Defaults to False.
+        neptune_api (str, optional): Neptune API token, used for logging.
+            Defaults to None.
+        neptune_workspace (str, optional): Neptune workspace.
+            Defaults to None.
 
     Returns:
         fastai.learner.Learner
@@ -449,7 +470,8 @@ def train_fastai(
     _log_mil_params(config, outcomes, unique, bags, n_in, n_out, outdir)
 
     # Train.
-    _fastai.train(learner, config,neptune_args=neptune_args)
+    _fastai.train(learner, config, use_neptune=use_neptune,neptune_workspace=neptune_workspace,
+                  neptune_api=neptune_api,neptune_name=neptune_name)
 
     # Generate validation predictions.
     df, attention = predict_from_model(

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -28,7 +28,6 @@ def train_mil(
     *,
     outdir: str = 'mil',
     exp_label: Optional[str] = None,
-    use_neptune=False,
     neptune_args=None,
     **kwargs
 ):
@@ -62,7 +61,6 @@ def train_mil(
             for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
-        use_neptune (bool,optional): Log training to neptune.ai
         neptune_args (dict): Keyword arguments to specify neptune project data.
     """
     log.info("Training FastAI MIL model with config:")
@@ -102,7 +100,6 @@ def train_mil(
         outcomes,
         bags,
         outdir=outdir,
-        use_neptune=use_neptune,
         neptune_args=neptune_args,
         **kwargs
     )
@@ -378,7 +375,6 @@ def train_fastai(
     *,
     outdir: str = 'mil',
     attention_heatmaps: bool = False,
-    use_neptune=False,
     neptune_args=None,
     **heatmap_kwargs
 ) -> None:
@@ -413,7 +409,6 @@ def train_fastai(
             for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
             If 'two_slope', normalizes values less than 0 and greater than 0
             separately. Defaults to None.
-        use_neptune (bool,optional): Log training to neptune.ai
         neptune_args (dict): Keyword arguments to specify neptune project data.
 
     Returns:
@@ -454,7 +449,7 @@ def train_fastai(
     _log_mil_params(config, outcomes, unique, bags, n_in, n_out, outdir)
 
     # Train.
-    _fastai.train(learner, config,use_neptune=use_neptune,neptune_args=neptune_args)
+    _fastai.train(learner, config,neptune_args=neptune_args)
 
     # Generate validation predictions.
     df, attention = predict_from_model(

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -21,7 +21,7 @@ from .._params import TrainerConfigFastAI, ModelConfigCLAM
 
 # -----------------------------------------------------------------------------
 
-def train(learner, config, callbacks=None, use_neptune=False, neptune_args=None):
+def train(learner, config, callbacks=None, neptune_args=None):
     """Train an attention-based multi-instance learning model with FastAI.
 
     Args:
@@ -30,7 +30,6 @@ def train(learner, config, callbacks=None, use_neptune=False, neptune_args=None)
 
     Keyword args:
         callbacks (list(fastai.Callback)): FastAI callbacks. Defaults to None.
-        use_neptune (bool,optional): Log training to neptune.ai
         neptune_args (dict): Keyword arguments to specify neptune project data.
     """
 
@@ -39,7 +38,7 @@ def train(learner, config, callbacks=None, use_neptune=False, neptune_args=None)
         CSVLogger()
     ]
 
-    if use_neptune:
+    if neptune_args is not None:
         run = neptune.init_run(**neptune_args)
         cbs.append(NeptuneCallback(run=run))
     if callbacks:
@@ -58,7 +57,7 @@ def train(learner, config, callbacks=None, use_neptune=False, neptune_args=None)
         else:
             lr = config.lr
         learner.fit(n_epoch=config.epochs, lr=lr, wd=config.wd, cbs=cbs)
-    if use_neptune:
+    if neptune_args is not None:
         run.stop()
     return learner
 

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -21,7 +21,8 @@ from .._params import TrainerConfigFastAI, ModelConfigCLAM
 
 # -----------------------------------------------------------------------------
 
-def train(learner, config, callbacks=None, neptune_args=None):
+def train(learner, config, callbacks=None, use_neptune=False, 
+          neptune_workspace=None, neptune_api=None, neptune_name=None):
     """Train an attention-based multi-instance learning model with FastAI.
 
     Args:
@@ -30,7 +31,12 @@ def train(learner, config, callbacks=None, neptune_args=None):
 
     Keyword args:
         callbacks (list(fastai.Callback)): FastAI callbacks. Defaults to None.
-        neptune_args (dict): Keyword arguments to specify neptune project data.
+        use_neptune (bool, optional): Use Neptune API logging.
+            Defaults to False.
+        neptune_api (str, optional): Neptune API token, used for logging.
+            Defaults to None.
+        neptune_workspace (str, optional): Neptune workspace.
+            Defaults to None.
     """
 
     cbs = [
@@ -38,8 +44,8 @@ def train(learner, config, callbacks=None, neptune_args=None):
         CSVLogger()
     ]
 
-    if neptune_args is not None:
-        run = neptune.init_run(**neptune_args)
+    if use_neptune:
+        run = neptune.init_run(project=neptune_workspace,api_token=neptune_api,name=neptune_name)
         cbs.append(NeptuneCallback(run=run))
     if callbacks:
         cbs += callbacks
@@ -57,7 +63,7 @@ def train(learner, config, callbacks=None, neptune_args=None):
         else:
             lr = config.lr
         learner.fit(n_epoch=config.epochs, lr=lr, wd=config.wd, cbs=cbs)
-    if neptune_args is not None:
+    if use_neptune:
         run.stop()
     return learner
 

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -21,7 +21,7 @@ from .._params import TrainerConfigFastAI, ModelConfigCLAM
 
 # -----------------------------------------------------------------------------
 
-def train(learner, config, callbacks=None, use_neptune=False, nep_args=None):
+def train(learner, config, callbacks=None, use_neptune=False, neptune_args=None):
     """Train an attention-based multi-instance learning model with FastAI.
 
     Args:
@@ -31,7 +31,7 @@ def train(learner, config, callbacks=None, use_neptune=False, nep_args=None):
     Keyword args:
         callbacks (list(fastai.Callback)): FastAI callbacks. Defaults to None.
         use_neptune (bool,optional): Log training to neptune.ai
-        nep_args (dict): Keyword arguments to specify neptune project data.
+        neptune_args (dict): Keyword arguments to specify neptune project data.
     """
 
     cbs = [
@@ -40,7 +40,7 @@ def train(learner, config, callbacks=None, use_neptune=False, nep_args=None):
     ]
 
     if use_neptune:
-        run = neptune.init_run(**nep_args)
+        run = neptune.init_run(**neptune_args)
         cbs.append(NeptuneCallback(run=run))
     if callbacks:
         cbs += callbacks

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -3798,7 +3798,7 @@ class Project:
         bags: Union[str, List[str]],
         *,
         exp_label: Optional[str] = None,
-        neptune_args=None,
+        neptune_name: Optional[str] = None,
         **kwargs
     ):
         r"""Train a multi-instance learning model.
@@ -3831,8 +3831,7 @@ class Project:
                 for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
                 If 'two_slope', normalizes values less than 0 and greater than 0
                 separately. Defaults to None.
-            neptune_args (dict): Keyword arguments to specify neptune project data.
-
+            neptune_name (str, optional): Custom Name for neptune run. Defaults to None.
         """
         from .mil import train_mil
 
@@ -3844,7 +3843,10 @@ class Project:
             bags,
             outdir=join(self.root, 'mil'),
             exp_label=exp_label,
-            neptune_args=neptune_args,
+            use_neptune=self.use_neptune,
+            neptune_workspace=self.neptune_workspace,
+            neptune_api=self.neptune_api,
+            neptune_name=neptune_name,
             **kwargs
         )
 

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -3799,7 +3799,7 @@ class Project:
         *,
         exp_label: Optional[str] = None,
         use_neptune=False,
-        nep_args=None,
+        neptune_args=None,
         **kwargs
     ):
         r"""Train a multi-instance learning model.
@@ -3833,7 +3833,7 @@ class Project:
                 If 'two_slope', normalizes values less than 0 and greater than 0
                 separately. Defaults to None.
             use_neptune (bool,optional): Log training to neptune.ai
-            nep_args (dict): Keyword arguments to specify neptune project data.
+            neptune_args (dict): Keyword arguments to specify neptune project data.
 
         """
         from .mil import train_mil
@@ -3847,7 +3847,7 @@ class Project:
             outdir=join(self.root, 'mil'),
             exp_label=exp_label,
             use_neptune=use_neptune,
-            nep_args=nep_args,
+            neptune_args=neptune_args,
             **kwargs
         )
 

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -3798,7 +3798,6 @@ class Project:
         bags: Union[str, List[str]],
         *,
         exp_label: Optional[str] = None,
-        use_neptune=False,
         neptune_args=None,
         **kwargs
     ):
@@ -3832,7 +3831,6 @@ class Project:
                 for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
                 If 'two_slope', normalizes values less than 0 and greater than 0
                 separately. Defaults to None.
-            use_neptune (bool,optional): Log training to neptune.ai
             neptune_args (dict): Keyword arguments to specify neptune project data.
 
         """
@@ -3846,7 +3844,6 @@ class Project:
             bags,
             outdir=join(self.root, 'mil'),
             exp_label=exp_label,
-            use_neptune=use_neptune,
             neptune_args=neptune_args,
             **kwargs
         )

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -3798,6 +3798,8 @@ class Project:
         bags: Union[str, List[str]],
         *,
         exp_label: Optional[str] = None,
+        use_neptune=False,
+        nep_args=None,
         **kwargs
     ):
         r"""Train a multi-instance learning model.
@@ -3830,6 +3832,8 @@ class Project:
                 for the ``norm`` argument of ``matplotlib.pyplot.imshow``.
                 If 'two_slope', normalizes values less than 0 and greater than 0
                 separately. Defaults to None.
+            use_neptune (bool,optional): Log training to neptune.ai
+            nep_args (dict): Keyword arguments to specify neptune project data.
 
         """
         from .mil import train_mil
@@ -3842,6 +3846,8 @@ class Project:
             bags,
             outdir=join(self.root, 'mil'),
             exp_label=exp_label,
+            use_neptune=use_neptune,
+            nep_args=nep_args,
             **kwargs
         )
 

--- a/torch-dev.Dockerfile
+++ b/torch-dev.Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
+RUN apt update
+
+# Install necessary packages
+RUN apt update && \
+    apt install -y liblapack-dev libblas-dev libgl1-mesa-glx libsm6 libxext6 wget vim g++ pkg-config libglib2.0-dev expat libexpat-dev libexif-dev libtiff-dev libgsf-1-dev openslide-tools libopenjp2-tools libpng-dev libtiff5-dev libjpeg-turbo8-dev libopenslide-dev && \
+    sed -i '/^#\sdeb-src /s/^# *//' "/etc/apt/sources.list" && \
+    apt update
+
+# Build libvips 8.12 from source [slideflow requires 8.9+, latest deb in Ubuntu 18.04 is 8.4]
+RUN apt install build-essential devscripts -y && \
+    mkdir libvips && \
+    mkdir scripts
+WORKDIR "/libvips"
+RUN wget https://github.com/libvips/libvips/releases/download/v8.12.2/vips-8.12.2.tar.gz && \
+    tar zxf vips-8.12.2.tar.gz
+WORKDIR "/libvips/vips-8.12.2"
+RUN ./configure && make && make install
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+# Repair pixman
+WORKDIR "/scripts"
+RUN wget https://raw.githubusercontent.com/jamesdolezal/slideflow/2.0.1/scripts/pixman_repair.sh && \
+    chmod +x pixman_repair.sh
+
+# Install missing requirements
+
+RUN pip3 install jupyterlab && \
+    pip3 install huggingface_hub && \
+    pip3 install "timm<0.9" && \
+    pip3 install fastai && \
+    pip3 install versioneer

--- a/torch-dev.Dockerfile
+++ b/torch-dev.Dockerfile
@@ -30,4 +30,5 @@ RUN pip3 install jupyterlab && \
     pip3 install huggingface_hub && \
     pip3 install "timm<0.9" && \
     pip3 install fastai && \
-    pip3 install versioneer
+    pip3 install versioneer ?? \
+    pip3 install neptune-fastai

--- a/torch-dev.Dockerfile
+++ b/torch-dev.Dockerfile
@@ -30,5 +30,5 @@ RUN pip3 install jupyterlab && \
     pip3 install huggingface_hub && \
     pip3 install "timm<0.9" && \
     pip3 install fastai && \
-    pip3 install versioneer ?? \
+    pip3 install versioneer && \
     pip3 install neptune-fastai


### PR DESCRIPTION
Updated changes made to MIL model training tools with neptune logging support, making them consistent with how neptune is handled in other training modules, namely utilizing `Project` properties `use_neptune`, `neptune_workspace` and `neptune_api` with an added possibility to give runs custom names through `neptune_name` argument passed to the `train_mil` method.