### PR TITLE
Unexpected keyword argument "save_checkpoints"

### DIFF
--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -3222,7 +3222,7 @@ class Project:
              'runcount-limit': smac_limit,  # Max # of function evaluations
              'cs': smac_configspace},
             {'output_dir': self.models_dir})
-        train_kwargs['save_checkpoints'] = save_checkpoints
+
         train_kwargs['save_model'] = save_model
         train_kwargs['save_predictions'] = save_predictions
         smac = SMAC4BB(


### PR DESCRIPTION
The keyword argument "save_checkpoints" set up in the method smac_search is unknown to the training method.
If this functionality is intended I think it also needs to be implemented then.