### PR TITLE
316 mil slide aggregate

### DIFF
--- a/slideflow/mil/_params.py
+++ b/slideflow/mil/_params.py
@@ -103,6 +103,7 @@ class TrainerConfigFastAI(_TrainerConfig):
         self,
         model: Union[str, Callable] = 'attention_mil',
         *,
+        aggregation_level: str = 'slide',
         lr: Optional[float] = None,
         wd: float = 1e-5,
         bag_size: int = 512,
@@ -124,6 +125,9 @@ class TrainerConfigFastAI(_TrainerConfig):
                 ``"transmil"``.
 
         Keyword args:
+            aggregation_level (str): When equal to ``'slide'`` each bag
+                contains tiles from a single slide. When equal to ``'patient'``
+                tiles from all slides of a patient are grouped together.
             lr (float, optional): Learning rate. If ``fit_one_cycle=True``,
                 this is the maximum learning rate. If None, uses the Leslie
                 Smith `LR Range test <https://arxiv.org/abs/1506.01186>`_ to
@@ -140,6 +144,7 @@ class TrainerConfigFastAI(_TrainerConfig):
                 :class:`slideflow.mil.ModelConfigFastAI` for all other models.
 
         """
+        self.aggregation_level = aggregation_level
         self.lr = lr
         self.wd = wd
         self.bag_size = bag_size

--- a/slideflow/mil/data.py
+++ b/slideflow/mil/data.py
@@ -68,13 +68,18 @@ def _to_fixed_size_bag(
 class BagDataset(Dataset):
     """A dataset of bags of instances."""
 
-    bags: List[Path]
-    """The `.h5` files containing the bags.
-    Each bag consists of the features taken from one or multiple h5 files.
-    Each of the h5 files needs to have a dataset called `feats` of shape N x
-    F, where N is the number of instances and F the number of features per
-    instance.
+    bags: Union[List[Path], List[np.ndarray], List[torch.Tensor], List[List[str]]]
+    """Bags for each slide.
+
+    This can either be a list of `.pt` files, a list of numpy arrays, a list
+    of Tensors, or a list of lists of strings (where each item in the list is
+    a patient, and nested items are slides for that patient).
+
+    Each bag consists of features taken from all images from a slide. Data
+    should be of shape N x F, where N is the number of instances and F is the
+    number of features per instance/slide.
     """
+
     bag_size: Optional[int] = None
     """The number of instances in each bag.
     For bags containing more instances, a random sample of `bag_size`
@@ -89,6 +94,10 @@ class BagDataset(Dataset):
         # collect all the features
         if isinstance(self.bags[index], str):
             feats = torch.load(self.bags[index])
+        elif isinstance(self.bags[index], np.ndarray):
+            feats = torch.from_numpy(self.bags[index])
+        elif isinstance(self.bags[index], torch.Tensor):
+            feats = self.bags[index]
         else:
             feats = torch.cat([torch.load(slide) for slide in self.bags[index]])
 

--- a/slideflow/mil/data.py
+++ b/slideflow/mil/data.py
@@ -87,7 +87,10 @@ class BagDataset(Dataset):
 
     def __getitem__(self, index: int) -> Tuple[torch.Tensor, int]:
         # collect all the features
-        feats = torch.load(self.bags[index])
+        if isinstance(self.bags[index], str):
+            feats = torch.load(self.bags[index])
+        else:
+            feats = torch.cat([torch.load(slide) for slide in self.bags[index]])
 
         # sample a subset, if required
         if self.bag_size:

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -299,6 +299,7 @@ def build_fastai_learner(
             of paths to individual \*.pt files. Each file should contain
             exported feature vectors, with each file containing all tile
             features for one patient.
+            # FIXME: at this point bags is never still a string, it is always a list of strings
 
     Keyword args:
         outdir (str): Directory in which to save model and results.
@@ -328,14 +329,15 @@ def build_fastai_learner(
     else:
         bags = np.array(bags)
 
+    train_slides = train_dataset.slides()
+    val_slides = val_dataset.slides()
+
     if config.aggregation_level == 'slide':
         targets = np.array([labels[path_to_name(f)] for f in bags])
 
-            # Prepare training/validation indices
-        train_slides = train_dataset.slides()
+        # Prepare training/validation indices
         train_idx = np.array([i for i, bag in enumerate(bags)
                                 if path_to_name(bag) in train_slides])
-        val_slides = val_dataset.slides()
         val_idx = np.array([i for i, bag in enumerate(bags)
                                 if path_to_name(bag) in val_slides])
         
@@ -390,7 +392,6 @@ def build_fastai_learner(
             labels=patients_labels,
             filename=join(outdir, 'slide_manifest.csv')
         )
-
 
     # Build FastAI Learner
     learner, (n_in, n_out) = _fastai.build_learner(

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -94,6 +94,7 @@ def _build_clam_learner(
 
     Args:
         config (``TrainerConfigFastAI``): Trainer and model configuration.
+        bags (list(str)): Path to .pt files (bags) with features, one per patient.
         targets (np.ndarray): Category labels for each patient, in the same
             order as ``bags``.
         train_idx (np.ndarray, int): Indices of bags/targets that constitutes

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -94,7 +94,6 @@ def _build_clam_learner(
 
     Args:
         config (``TrainerConfigFastAI``): Trainer and model configuration.
-        bags (list(str)): Path to .pt files (bags) with features, one per patient.
         targets (np.ndarray): Category labels for each patient, in the same
             order as ``bags``.
         train_idx (np.ndarray, int): Indices of bags/targets that constitutes


### PR DESCRIPTION
`TrainerConfigFastAI` now has a new argument called `aggregation_level` which defaults to `'slide'`. 

New behaviour `aggregation_level='patient`:

`build_fastai_learner`
• saves `slide_manifest.csv` where each row is a patient
• the variable bags it creates is an array of lists where each element of the array represent a patient and each element a list is a slide from that patient

`BagDataset:__getitem__` now supports this new type of bag. When it recognizes that an item is a list it concatenates the tiles from different slides as if they all came from the same slide (according to the previous implementation)