### PR TITLE
Sorting bug

### DIFF
--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -3126,7 +3126,7 @@ class Project:
 
                 # Interpret results.
                 model_name = list(results.keys())[0]
-                last_epoch = sorted(list(results[model_name]['epochs'].keys()))[-1]
+                last_epoch = sorted(list(results[model_name]['epochs'].keys()), key=lambda x: int(x.replace("epoch", "")))[-1]
                 if len(results[model_name]['epochs']) > 1:
                     log.warning(f"Ambiguous epoch for SMAC. Using '{last_epoch}'.")
                 epoch_results = results[model_name]['epochs'][last_epoch]


### PR DESCRIPTION
There is a minor bug when sorting the names of the epochs.
Currently, if you have 10 epochs, the sorted list will be [epoch1, epoch10, epoch2, ..., epoch9]
This will return the last epoch as "epoch9", which is incorrect and will end up on a different bug when searching the metrics of the last epoch to be reported in Neptune.