### PR TITLE
Robust check for empty array in missing slides screen

### DIFF
--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -251,7 +251,7 @@ class DatasetFeatures:
         for slide in self.slides:
             if slide not in self.activations:
                 missing += [slide]
-            elif self.activations[slide] == []:
+            elif len(self.activations[slide]) == 0:
                 missing += [slide]
         num_loaded = len(self.slides)-len(missing)
         log.debug(


### PR DESCRIPTION
When I was playing around with slideflow on feature extraction, this line of code would always raise errors like `ValueError: operands could not be broadcast together with shapes (4641,2048) (0,)`. This is because the left side could be either numpy array or tensor or just list (I guess). It would be good to check it in a more robust way. But I'm not sure if the modification in the PR is the best way to do it.