### PR TITLE
Small fix: flip mask in outsu if `roi_method == outside`

### DIFF
--- a/slideflow/slide/qc/otsu.py
+++ b/slideflow/slide/qc/otsu.py
@@ -134,6 +134,8 @@ class Otsu:
                 scaled_polys,
                 out_shape=thumb.shape[:2]
             )
+            if wsi.roi_method == 'outside':
+                roi_mask = ~roi_mask
             thumb = cv2.bitwise_or(
                 thumb,
                 thumb,


### PR DESCRIPTION
This is a tiny fix but I still opened a PR in case @jamesdolezal you want to use this branch to add other related fixes. I looked around the code and to me it looks like only Otsu needs this fix.