### PR TITLE
Small fixes

### DIFF
--- a/slideflow/mil/models/transmil.py
+++ b/slideflow/mil/models/transmil.py
@@ -47,10 +47,18 @@ class TransMIL(nn.Module):
     def relocate(self):
         self.to(get_device())
 
-    def forward(self, h):
-        h = self.get_last_layer_activations(h) # [B, n, 1024] -> [B, 512]
-        logits = self._fc2(h) #[B, n_classes]
-        return logits
+    def forward(self, h, return_attention=False):
+        if return_attention:
+            # FIXME: compute attention
+            B, n, _ = h.shape
+            h = self.get_last_layer_activations(h)  # [B, n, 1024] -> [B, 512]
+            logits = self._fc2(h)  # [B, n_classes]
+            temp_attention = torch.ones(B, n, 1) / n
+            return logits, temp_attention # WARNING this is a placeholder to fix a bug
+        else:
+            h = self.get_last_layer_activations(h)  # [B, n, 1024] -> [B, 512]
+            logits = self._fc2(h)  # [B, n_classes]
+            return logits
 
     def get_last_layer_activations(self, h):
         h = self._fc1(h)  # [B, n, 1024] -> [B, n, 512]

--- a/slideflow/mil/models/transmil.py
+++ b/slideflow/mil/models/transmil.py
@@ -47,18 +47,10 @@ class TransMIL(nn.Module):
     def relocate(self):
         self.to(get_device())
 
-    def forward(self, h, return_attention=False):
-        if return_attention:
-            # FIXME: compute attention
-            B, n, _ = h.shape
-            h = self.get_last_layer_activations(h)  # [B, n, 1024] -> [B, 512]
-            logits = self._fc2(h)  # [B, n_classes]
-            temp_attention = torch.ones(B, n, 1) / n
-            return logits, temp_attention # WARNING this is a placeholder to fix a bug
-        else:
-            h = self.get_last_layer_activations(h)  # [B, n, 1024] -> [B, 512]
-            logits = self._fc2(h)  # [B, n_classes]
-            return logits
+    def forward(self, h):
+        h = self.get_last_layer_activations(h) # [B, n, 1024] -> [B, 512]
+        logits = self._fc2(h) #[B, n_classes]
+        return logits
 
     def get_last_layer_activations(self, h):
         h = self._fc1(h)  # [B, n, 1024] -> [B, n, 512]

--- a/slideflow/slide/wsi.py
+++ b/slideflow/slide/wsi.py
@@ -1256,8 +1256,9 @@ class WSI:
             qc_x = int(np.round(x * qc_ratio))
             qc_y = int(np.round(y * qc_ratio))
             submask = mask.mask[qc_y:(qc_y+qc_width), qc_x:(qc_x+qc_width)]
-            if np.mean(submask) > filter_threshold:
-                self.grid[xi, yi] = 0
+            if submask.size > 0:
+                if np.mean(submask) > filter_threshold:
+                    self.grid[xi, yi] = 0
 
         # Update the estimated number of tiles.
         self.estimated_num_tiles = int(self.grid.sum())

--- a/slideflow/slide/wsi.py
+++ b/slideflow/slide/wsi.py
@@ -1256,8 +1256,7 @@ class WSI:
             qc_x = int(np.round(x * qc_ratio))
             qc_y = int(np.round(y * qc_ratio))
             submask = mask.mask[qc_y:(qc_y+qc_width), qc_x:(qc_x+qc_width)]
-            if submask.size > 0:
-                if np.mean(submask) > filter_threshold:
+            if (submask.size > 0) and (np.mean(submask) > filter_threshold):
                     self.grid[xi, yi] = 0
 
         # Update the estimated number of tiles.


### PR DESCRIPTION
`b29abea` Fix a warning in slideflow studio that happens when a remainder is 0
`4a6a8db` is a temporary fix for `TransMIL` which would not work because it does not currently implement `return_attention`