### PR TITLE
Change seaborn pin to <0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ imageio
 opencv-python-headless
 shapely
 umap-learn
-seaborn<0.12
+seaborn<=0.13
 pandas<2
 pyvips>=2.1.11
 fpdf2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ imageio
 opencv-python-headless
 shapely
 umap-learn
-seaborn<=0.13
+seaborn<0.14
 pandas<2
 pyvips>=2.1.11
 fpdf2

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setuptools.setup(
         'opencv-python-headless',
         'shapely',
         'umap-learn',
-        'seaborn<=0.13',
+        'seaborn<0.14',
         'pandas<2',
         'pyvips',
         'fpdf2',

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setuptools.setup(
         'opencv-python-headless',
         'shapely',
         'umap-learn',
-        'seaborn<0.12',
+        'seaborn<=0.13',
         'pandas<2',
         'pyvips',
         'fpdf2',


### PR DESCRIPTION
Other libraries have updated to pin >=0.13. 

Based on the [seaborn changelog](https://seaborn.pydata.org/whatsnew/index.html) I can't see any obvious reason for the strict pin.