### PR TITLE
Fix `sf.mil.get_mil_tile_predictions` for CLAM models

### DIFF
--- a/slideflow/mil/eval.py
+++ b/slideflow/mil/eval.py
@@ -966,9 +966,11 @@ def run_inference(
     else:
         kw = forward_kwargs
 
-    # First, handle CLAM, which returns instance loss as well as logits/attention
+    # Check if the model can return attention during inference. 
+    # If so, this saves us a forward pass through the model.
     if attention and 'return_attention' in inspect.signature(model.forward).parameters:
         model_out, y_att = model(*model_args, return_attention=True, **kw)
+    # Otherwise, use the model's `calculate_attention` function directly.
     elif attention:
         model_out = model(*model_args, **kw)
         y_att = model.calculate_attention(*model_args)

--- a/slideflow/mil/eval.py
+++ b/slideflow/mil/eval.py
@@ -503,6 +503,8 @@ def get_mil_tile_predictions(
     is_clam = (isinstance(config, TrainerConfigCLAM)
                 or isinstance(config.model_config, ModelConfigCLAM))
     
+    log.info("Generating predictions for {} slides and {} bags.".format(len(slides), len(bags)))
+    
     # First, start with slide-level inference and attention.
     if (isinstance(config, TrainerConfigCLAM)
        or isinstance(config.model_config, ModelConfigCLAM)):
@@ -1139,6 +1141,8 @@ def _predict_mil_tiles(
 
     # Inference.
     with torch.inference_mode():
+        # CLAM models do not support inference with batch_size > 1, 
+        # and thus require a different, less efficient pipeline.
         if "CLAM" in model.__class__.__name__:
             y_pred, y_att = _predict_clam(
                 model,

--- a/slideflow/mil/models/clam.py
+++ b/slideflow/mil/models/clam.py
@@ -269,6 +269,7 @@ class _CLAM_Base(nn.Module):
         label=None,
         instance_eval=False,
         return_attention=False,
+        return_instance_loss=True
     ):
         """Forward pass.
 
@@ -277,10 +278,12 @@ class _CLAM_Base(nn.Module):
             label: ground truth label
             instance_eval: whether to perform instance-level evaluation
             return_attention: whether to return attention weights
+            return_instance_loss: whether to return instance loss.
+                Defaults to True.
 
         Returns:
             logits: logits
-            inst_loss_dict: instance loss dictionary
+            inst_loss_dict: instance loss dictionary (if ``return_instance_loss=True``)
             A_raw: attention weights
 
         """
@@ -307,10 +310,14 @@ class _CLAM_Base(nn.Module):
         M = torch.mm(A, h)
         logits = self._logits_from_m(M)
 
-        if return_attention:
+        if return_attention and return_instance_loss:
             return logits, A_raw, inst_loss_dict
-        else:
+        elif return_attention:
+            return logits, A_raw
+        elif return_instance_loss:
             return logits, inst_loss_dict
+        else:
+            return logits
 
     def calculate_attention(self, h):
         """Calculate attention weights.


### PR DESCRIPTION
This fix addresses issue #348, fixing the `get_mil_tile_predictions()` function for CLAM models.

This also fixes improper usage of the `inspect.signature` function.