### PR TITLE
Add dual magnification tile extraction functionality

### DIFF
--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1893,14 +1893,14 @@ class Dataset:
         all_reports = [r for r in all_reports if r is not None]
         return {report.path: report for report in all_reports}
 
-    def _validate_lower_mag_params(self, mag_ratio: int) -> str:
+    def _validate_lower_mag_params(self, mag_ratio: int) -> int:
         """Validate magnification ratio and calculate target magnification.
 
         Args:
             mag_ratio: Magnification ratio (how many source tiles per target tile)
 
         Returns:
-            target_tile_um: Calculated target magnification as a string (e.g. "5x")
+            target_tile_um: Calculated target magnification as an integer (in um)
 
         Raises:
             DatasetError: If magnification parameters are invalid or ratio doesn't form a perfect square
@@ -1911,13 +1911,6 @@ class Dataset:
 
         # Get source tile_um from dataset
         source_tile_um = self.tile_um
-
-        # Convert source_tile_um to magnification if it's in microns (int)
-        if isinstance(source_tile_um, int):
-            source_tile_um = sf.util.um_to_mag(source_tile_um)
-
-        # Ensure source_tile_um is a magnification string
-        sf.util.assert_is_mag(source_tile_um)
 
         # Validate mag_ratio
         if not isinstance(mag_ratio, int) or mag_ratio < 1:
@@ -1931,27 +1924,20 @@ class Dataset:
             raise errors.DatasetError(
                 f"Invalid mag_ratio: {mag_ratio}. "
                 f"Ratio must be a perfect square for tile concatenation (e.g., 1, 4, 9, 16). "
-                f"Valid examples: 20x with ratio=4 → 5x (4×4 grid), 40x with ratio=16 → 2.5x (16×16 grid)"
+                f"Valid examples: 20um with ratio=4 → 80um (4×4 grid), 10um with ratio=16 → 160um (16×16 grid)"
             )
-
-        # Convert to numeric magnification value
-        source_mag = sf.util.to_mag(source_tile_um)
 
         # Calculate target magnification
-        target_mag = source_mag / mag_ratio
+        target_um = source_tile_um * mag_ratio
 
-        # Validate that target_mag is reasonable
-        if target_mag <= 0:
+        # Validate that target_um is reasonable (positive integer)
+        if not isinstance(target_um, int) or target_um <= 0:
             raise errors.DatasetError(
-                f"Invalid result: {source_tile_um} with ratio {mag_ratio} produces "
-                f"target magnification {target_mag}x"
+                f"Invalid result: {source_tile_um}um with ratio {mag_ratio} produces "
+                f"target magnification {target_um}um"
             )
 
-        # Return as magnification string
-        if target_mag == int(target_mag):
-            return f"{int(target_mag)}x"
-        else:
-            return f"{target_mag}x"
+        return target_um
 
     def _get_lower_mag_tfrecords(self, source: Optional[str] = None) -> List[str]:
         """Get source TFRecords for processing.
@@ -2367,13 +2353,13 @@ class Dataset:
                         base_suffix = f"{px}px_{target_tile_um.lower()}"
                     else:
                         base_suffix = f"{px}px_{target_tile_um}um"
-                    
+
                     # Include source magnification in directory name
                     if source_tile_um is not None:
                         if isinstance(source_tile_um, str):
                             source_mag = source_tile_um.lower()
                         else:
-                            source_mag = f"{source_tile_um}x"
+                            source_mag = f"{source_tile_um}um"
                         mag_suffix = f"{base_suffix}_from_{source_mag}"
                     else:
                         mag_suffix = base_suffix
@@ -2487,8 +2473,8 @@ class Dataset:
                     import traceback
                     log.debug(f"Full traceback: {traceback.format_exc()}")
                     continue
-            else:
-                log.debug(f"Skipping incomplete group at {group_loc} with {len(tile_indices)} tiles (need {mag_ratio*mag_ratio})")
+            # else:
+            #     log.debug(f"Skipping incomplete group at {group_loc} with {len(tile_indices)} tiles (need {mag_ratio*mag_ratio})")
                     
         writer.close()
         

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1972,43 +1972,83 @@ class Dataset:
             mag_ratio = int(mag_ratio)
         else:
             mag_ratio = None
-            
         # Get source TFRecords
         source_tfrecords = self.tfrecords(source=source)
         if not source_tfrecords:
             raise ValueError("No TFRecords found for processing")
-            
         # Process each TFRecord
         all_reports = []
         all_tile_combinations = []
 
-        for tfrecord_path in source_tfrecords:
-            if skip_extracted:
-                # Check if output already exists
-                output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
-                if output_path and exists(output_path):
-                    log.info(f"Skipping {tfrecord_path} - already processed")
-                    continue
+        # --- Progress bar setup (added) ---
+        try:
+            pb = TileExtractionProgress()
+            pb.add_task("Speed: ", progress_type="speed", total=None)
+            tfr_task = pb.add_task(
+                f"Processing TFRecords...",
+                progress_type="slide_progress",
+                total=len(source_tfrecords)
+            )
+            pb.start()
+        except Exception:
+            # If progress bar can't be created for any reason, continue without it.
+            pb = None
+            tfr_task = None
 
-            try:
-                report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
-                    tfrecord_path=tfrecord_path,
-                    source_tile_um=source_tile_um,
-                    target_tile_um=target_tile_um,
-                    mag_ratio=mag_ratio,
-                    **kwargs
-                )
-                all_reports.append(report)
-                if tile_combinations:
-                    all_tile_combinations.extend(tile_combinations)
-            except Exception as e:
-                log.error(f"Error processing {tfrecord_path}: {str(e)}")
-                continue
-                
+        # Ensure cleanup context matches other uses
+        with sf.util.cleanup_progress(pb) if pb is not None else contextlib.nullcontext():
+            for tfrecord_path in source_tfrecords:
+                # Advance the progress even if we skip so the bar stays accurate.
+                try:
+                    if skip_extracted:
+                        # Check if output already exists
+                        output_path = self._get_output_tfrecord_path(
+                            tfrecord_path,
+                            target_tile_um,
+                            target_tile_px=target_tile_px,
+                            source_tile_um=source_tile_um
+                        )
+                        if output_path and exists(output_path):
+                            log.info(f"Skipping {tfrecord_path} - already processed")
+                            if pb is not None:
+                                pb.advance(tfr_task)
+                            continue
+
+                    try:
+                        report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
+                            tfrecord_path=tfrecord_path,
+                            source_tile_um=source_tile_um,
+                            target_tile_um=target_tile_um,
+                            mag_ratio=mag_ratio,
+                            **kwargs
+                        )
+                        all_reports.append(report)
+                        if tile_combinations:
+                            all_tile_combinations.extend(tile_combinations)
+                    except Exception as e:
+                        log.error(f"Error processing {tfrecord_path}: {str(e)}")
+                        # still advance progress bar
+                    finally:
+                        if pb is not None:
+                            pb.advance(tfr_task)
+                except KeyboardInterrupt:
+                    log.info("Interrupted by user during lower-mag processing")
+                    break
+                except Exception as e:
+                    # Catch any unexpected error per-record so the loop continues
+                    log.error(f"Unexpected error while handling {tfrecord_path}: {str(e)}")
+                    if pb is not None:
+                        try:
+                            pb.advance(tfr_task)
+                        except Exception:
+                            pass
+                    continue
+        # --- End progress bar loop ---
+
         # Update manifest after processing
         self.update_manifest(force_update=True)
         self.build_index(False)
-        
+
         # Build index files and create manifest for the new TFRecords
         if all_reports:
             try:
@@ -2019,14 +2059,14 @@ class Dataset:
                     if output_dir and os.path.exists(output_dir):
                         # Find all TFRecord files in the output directory
                         tfrecord_files = glob(os.path.join(output_dir, "*.tfrecords"))
-                        
+
                         log.info(f"Building index files for {len(tfrecord_files)} TFRecord files")
                         for tfr_path in tfrecord_files:
                             try:
                                 _create_index(tfr_path, force=True)
                             except Exception as e:
                                 log.warning(f"Failed to create index for {tfr_path}: {str(e)}")
-                        
+
                         # Create manifest for the new TFRecord directory
                         try:
                             log.info(f"Creating manifest for {output_dir}")
@@ -2034,7 +2074,7 @@ class Dataset:
                             log.info(f"Successfully created manifest for {target_tile_um} magnification")
                         except Exception as e:
                             log.warning(f"Failed to create manifest for {output_dir}: {str(e)}")
-                        
+
                         log.info(f"Built index files for {target_tile_um} magnification")
                     else:
                         log.warning(f"Could not find output directory for {target_tile_um}")
@@ -2042,18 +2082,18 @@ class Dataset:
                     log.warning(f"Could not determine output directory for {target_tile_um}")
             except Exception as e:
                 log.warning(f"Failed to build index files for {target_tile_um}: {str(e)}")
-        
+
         # Filter out None reports
         all_reports = [r for r in all_reports if r is not None]
-        
+
         # Generate PDF report if requested (even if some slides had 0 tiles)
         if report:
             log.info(f'Generating lower magnification tile extraction PDF report...')
             log.info(f'Found {len(all_reports)} reports to include in PDF')
-            
+
             # Read source extraction parameters from the source TFRecords directory
             source_params = self._get_source_extraction_parameters(source_tfrecords[0] if source_tfrecords else None)
-            
+
             # Create metadata for lower mag extraction
             from types import SimpleNamespace
             from datetime import datetime
@@ -2067,14 +2107,14 @@ class Dataset:
                 stride=source_params.get('stride', 1),
                 gs_frac=source_params.get('gs_fraction', 'N/A'),
                 gs_thresh=source_params.get('gs_threshold', 'N/A'),
-                ws_frac=source_params.get('ws_fraction', 'N/A'), 
+                ws_frac=source_params.get('ws_fraction', 'N/A'),
                 ws_thresh=source_params.get('ws_threshold', 'N/A'),
                 normalizer=source_params.get('normalizer', ''),
                 img_format=source_params.get('img_format', kwargs.get('img_format', 'jpg')),
                 source_tile_um=source_tile_um,  # Additional metadata specific to lower mag
                 mag_ratio=mag_ratio if mag_ratio else "calculated"
             )
-            
+
             # Generate ExtractionReport PDF (handle empty reports case)
             if all_reports:
                 pdf_report = LowerMagExtractionReport(
@@ -2102,12 +2142,12 @@ class Dataset:
                     meta=report_meta,
                     title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um}) - No Results'
                 )
-            
+
             # Save PDF and CSV with specific naming for lower mag
             _time = datetime.now().strftime('%Y%m%d-%H%M%S')
             source_name = source_tile_um if isinstance(source_tile_um, str) else f"{source_tile_um}um"
             target_name = target_tile_um if isinstance(target_tile_um, str) else f"{target_tile_um}um"
-            
+
             # Determine output directory (use target magnification directory)
             if all_reports:
                 sample_output_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=kwargs.get('target_tile_px', self.tile_px), source_tile_um=source_tile_um)
@@ -2117,10 +2157,10 @@ class Dataset:
                     pdf_dir = ''
             else:
                 pdf_dir = ''
-            
+
             pdf_filename = join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}-{_time}.pdf')
             csv_filename = join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}.csv')
-            
+
             try:
                 pdf_report.save(pdf_filename)
                 pdf_report.update_csv(csv_filename)
@@ -2236,13 +2276,7 @@ class Dataset:
         # Group tiles by spatial regions that can form target tiles
         tile_groups = self._group_tiles_for_combination(locations, mag_ratio)
         target_tile_px = int(kwargs.get('target_tile_px', 224))
-
-        log.info(f"Processing {slide_name}: found {len(tile_groups)} potential tile groups from {total_tiles} source tiles")
-        log.info(f"  Source tiles: {self.tile_px}px @ {source_tile_um}")
-        log.info(f"  Target tiles: {target_tile_px}px @ {target_tile_um}")
-        log.info(f"  Mag ratio: {mag_ratio}x (need {mag_ratio}x{mag_ratio}={mag_ratio*mag_ratio} source tiles per target)")
         complete_groups = sum(1 for indices in tile_groups.values() if len(indices) == mag_ratio * mag_ratio)
-        log.info(f"  {complete_groups} complete groups (each requiring {mag_ratio}x{mag_ratio}={mag_ratio*mag_ratio} tiles)")
         
         # Generate output path
         output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
@@ -2260,7 +2294,6 @@ class Dataset:
         for group_loc, tile_indices in tile_groups.items():
             if len(tile_indices) == mag_ratio * mag_ratio:  # Complete grid
                 try:
-                    log.info(f"Attempting to combine tile group at {group_loc} with {len(tile_indices)} tiles: {tile_indices}")
                     combined_tile = self._combine_tiles_from_group(
                         tfrecord_path, tile_indices, mag_ratio
                     )
@@ -2298,10 +2331,6 @@ class Dataset:
                                     'source_y': source_coord[1],
                                     'group_position': idx  # Position within the mag_ratio x mag_ratio grid
                                 })
-                        
-                        log.info(f"✓ Successfully combined tile group {combined_count} at location {group_loc}")
-                    else:
-                        log.warning(f"✗ Failed to combine tiles at {group_loc} - _combine_tiles_from_group returned None")
                 except Exception as e:
                     log.warning(f"✗ Error combining tile group at {group_loc}: {str(e)}")
                     import traceback
@@ -2375,11 +2404,6 @@ class Dataset:
             source_tile_px=self.tile_px,       # pass your source tile px (e.g., 512)
             mag_ratio=mag_ratio,
             target_tfrecord_path=output_path,  # Pass target TFRecord path for coordinate reading
-        )
-                
-        log.info(
-            f"✓ Processed {slide_name}: combined {total_tiles} source tiles into "
-            f"{combined_count} target tiles ({report_data['discarded_tiles']} discarded)"
         )
 
         return slide_report, tile_combinations
@@ -2747,8 +2771,6 @@ class Dataset:
             slide_report.source_tile_px = int(source_box_px_draw)
             slide_report.target_tile_px = int(target_box_px_draw)
 
-            log.info(f"LowerMagSlideReport created for {slide_name}:")
-            log.info(f"  Source box @draw: {source_box_px_draw}px  | Target box @draw: {target_box_px_draw}px  | r={r}")
             return slide_report
 
         except Exception as e:

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2113,7 +2113,7 @@ class Dataset:
 
         return SimpleNamespace(
             tile_px=kwargs.get('target_tile_px', self.tile_px),
-            tile_um=target_tile_um,
+            tile_um=target_tile_um,  # Keep as integer (microns) - Dataset can handle both formats
             qc=source_params.get('qc', 'None'),
             total_slides=len(source_tfrecords),
             slides_skipped=len(source_tfrecords) - len(all_reports),

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1958,31 +1958,16 @@ class Dataset:
             - Each combined tile's coordinates (loc_x, loc_y) will correspond to the
               upper-left tile's coordinates from the original source TFRecords grid.
         """
-        # Validate inputs
-        if isinstance(source_tile_um, str):
-            sf.util.assert_is_mag(source_tile_um)
-            source_mag = sf.util.to_mag(source_tile_um)
-        else:
-            source_mag = None
-            
-        if isinstance(target_tile_um, str):
-            sf.util.assert_is_mag(target_tile_um)
-            target_mag = sf.util.to_mag(target_tile_um)
-        else:
-            target_mag = None
-            
-        # Calculate magnification ratio for validation
-        if source_mag is not None and target_mag is not None:
+        # Validate and calculate magnification ratio
+        source_mag = sf.util.to_mag(source_tile_um) if isinstance(source_tile_um, str) else None
+        target_mag = sf.util.to_mag(target_tile_um) if isinstance(target_tile_um, str) else None
+        
+        if source_mag and target_mag:
             mag_ratio = source_mag / target_mag
             if not mag_ratio.is_integer() or mag_ratio < 1:
-                raise errors.DatasetError(
-                    f"Cannot combine {source_tile_um} tiles to create {target_tile_um} tiles. "
-                    f"Magnification ratio must be a positive integer (got {mag_ratio})"
-                )
+                raise errors.DatasetError(f"Invalid magnification ratio: {source_tile_um} to {target_tile_um}")
             mag_ratio = int(mag_ratio)
         else:
-            # TODO
-            # For micron-based sizes, we'll need to calculate this later per slide
             mag_ratio = None
             
         # Get source TFRecords
@@ -2048,67 +2033,8 @@ class Dataset:
         # Filter out None reports
         all_reports = [r for r in all_reports if r is not None]
         
-        # Generate ExtractionReport PDF if requested
-        if all_reports and report:
-            try:
-                self._generate_tile_combination_report(
-                    all_reports, 
-                    source_tile_um, 
-                    target_tile_um, 
-                    mag_ratio
-                )
-            except Exception as e:
-                log.warning(f'Failed to generate extraction report: {str(e)}')
-        
         return {report.path: report for report in all_reports}
     
-    def _generate_tile_combination_report(
-        self, 
-        slide_reports: List["SlideReport"], 
-        source_tile_um: Union[int, str], 
-        target_tile_um: Union[int, str], 
-        mag_ratio: int
-    ) -> "ExtractionReport":
-        """Generate an ExtractionReport PDF showing combined tile locations."""
-        from datetime import datetime
-        from slideflow.slide.report import ExtractionReport
-        from types import SimpleNamespace
-        from os.path import dirname, join
-        
-        log.info('Generating tile combination extraction report...')
-        
-        timestring = datetime.now().strftime('%Y%m%d-%H%M%S')
-        
-        # Generate PDF report filename 
-        filename = f'tile_combination_report-{source_tile_um}_to_{target_tile_um}-{timestring}.pdf'
-        
-        # Get the output directory by using the same logic as TFRecord paths
-        dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um)
-        if dummy_tfrecord_path:
-            report_dir = dirname(dummy_tfrecord_path)
-            report_path = join(report_dir, filename)
-        else:
-            # Fallback to current directory
-            report_path = filename
-        
-        # Create metadata for the extraction report
-        meta = SimpleNamespace()
-        meta.tile_px = self.tile_px
-        meta.tile_um = target_tile_um
-        meta.source_mag = source_tile_um
-        meta.target_mag = target_tile_um
-        meta.mag_ratio = mag_ratio
-        # Log summary of results
-        successful_reports = [r for r in slide_reports if r.data and r.data.get('num_tiles', 0) > 0]
-        log.info(f"Successfully processed {len(successful_reports)} out of {len(slide_reports)} slides")
-        
-        if successful_reports:
-            total_combined = sum(r.data['num_tiles'] for r in successful_reports)
-            total_source = sum(r.data['total_source_tiles'] for r in successful_reports)
-            log.info(f"Combined {total_source} source tiles into {total_combined} target tiles")
-        
-        return slide_reports
-        
     def _get_output_tfrecord_path(self, input_path: str, target_tile_um: Union[int, str]) -> Optional[str]:
         """Generate output path for lower magnification TFRecord."""
         try:
@@ -2162,7 +2088,6 @@ class Dataset:
         if mag_ratio is None:
             # TODO
             # This would require accessing slide metadata to calculate the ratio
-            # For now, assume a 4:1 ratio (20x to 5x)
             log.error(f"mag_ratio is None")
             
         # Group tiles by spatial regions that can form target tiles
@@ -2240,74 +2165,158 @@ class Dataset:
         # Find the original slide path for thumbnail generation
         slide_path = self.find_slide(slide=slide_name)
         
-        # Scale coordinates from target magnification to source magnification for thumbnail
-        if len(combined_locations) > 0:
-            try:
-                # combined_locations are in target mag space, but thumbnail will be at source mag
-                # Scale by mag_ratio: source_mag / target_mag = mag_ratio
-                scaled_locations_int = [(int(x * mag_ratio), int(y * mag_ratio)) for x, y in combined_locations]
-                
-                # Ensure we have valid coordinates before creating array
-                if len(scaled_locations_int) > 0:
-                    thumb_coords = np.array(scaled_locations_int, dtype=np.int64)
-                    log.debug(f"Created thumb_coords numpy array: shape {thumb_coords.shape}, dtype {thumb_coords.dtype}")
-                    log.debug(f"Sample scaled coordinates (int): {scaled_locations_int[:3] if len(scaled_locations_int) >= 3 else scaled_locations_int}")
-                    
-                    # Final safety check - if array is malformed, set to None
-                    if thumb_coords.size == 0 or thumb_coords.ndim != 2 or thumb_coords.shape[1] != 2:
-                        log.warning(f"Malformed thumb_coords array: shape {thumb_coords.shape}, setting to empty array")
-                        thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
-                else:
-                    log.debug("No coordinates to scale, thumb_coords set to empty array")
-                    thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
-            except Exception as e:
-                log.warning(f"Error creating scaled thumb_coords: {e}, using empty array")
-                thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
+        # Scale coordinates for thumbnail  
+        if combined_locations:
+            scaled_coords = [(int(x * mag_ratio), int(y * mag_ratio)) for x, y in combined_locations]
+            thumb_coords = np.array(scaled_coords, dtype=np.int64)
         else:
-            thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
-            log.debug("No combined locations, thumb_coords set to empty array")
+            thumb_coords = np.empty((0, 2), dtype=np.int64)
         
-        # Create the SlideReport - it will automatically create thumbnail with overlays
-        # Use source magnification for thumbnail since target may not exist in original slide
+        # Create SlideReport with thumbnail
         try:
-            log.debug(f"Creating SlideReport with:")
-            log.debug(f"  slide_path: {slide_path}")
-            log.debug(f"  source_tile_um: {source_tile_um}")
-            log.debug(f"  thumb_coords shape: {thumb_coords.shape if thumb_coords is not None else 'None'}")
-            log.debug(f"  example_tiles count: {len(example_tiles)}")
-            
-            # Create thumbnail at source magnification (which exists in original slide)
-            # The coordinates have been scaled to source magnification space
             slide_report = SlideReport(
                 images=example_tiles,
-                path=slide_path if slide_path else slide_name,
+                path=slide_path or slide_name,
                 tile_px=self.tile_px,
-                tile_um=source_tile_um,  # Use source magnification for thumbnail generation
+                tile_um=source_tile_um,
                 data=report_data,
-                thumb_coords=thumb_coords,  # Properly formatted scaled coordinates
-                ignore_thumb_errors=False  # Don't ignore errors so we can see what's happening
+                thumb_coords=thumb_coords,
+                ignore_thumb_errors=True
             )
-            log.debug("SlideReport created successfully with source magnification thumbnail")
         except Exception as e:
-            log.error(f"Error creating SlideReport with thumbnail: {e}")
-            import traceback
-            log.debug(f"Full traceback: {traceback.format_exc()}")
-            # Fallback: create report without thumbnail
+            log.warning(f"Error creating SlideReport: {e}")
             slide_report = SlideReport(
                 images=example_tiles,
-                path=slide_name,  # Use name only to skip thumbnail
+                path=slide_name,
                 tile_px=self.tile_px,
-                tile_um=source_tile_um,  # Keep consistent with main path
+                tile_um=source_tile_um,
                 data=report_data,
                 ignore_thumb_errors=True
             )
         
+        # Create alignment visualization
+        if combined_locations:
+            # Convert source locations to grid coordinates for visualization
+            source_grid_coords = self._coords_to_grid_indices(locations)
+            
+            viz_path = self._create_alignment_visualization(
+                slide_name=slide_name,
+                source_locations=source_grid_coords,  # Grid coordinates of source tiles
+                combined_locations=combined_locations,  # Grid coordinates of combined tiles  
+                mag_ratio=mag_ratio,
+                source_mag=source_tile_um,
+                target_mag=target_tile_um
+            )
+            if viz_path:
+                log.info(f"Created alignment visualization: {viz_path}")
+
         log.info(
             f"✓ Processed {slide_name}: combined {total_tiles} source tiles into "
             f"{combined_count} target tiles ({report_data['discarded_tiles']} discarded)"
         )
         
         return slide_report
+    
+    def _create_alignment_visualization(
+        self, 
+        slide_name: str,
+        source_locations: List[Tuple[int, int]],  # Grid coordinates of source tiles
+        combined_locations: List[Tuple[int, int]],  # Grid coordinates of combined tiles
+        mag_ratio: int,
+        source_mag: str,
+        target_mag: str
+    ) -> Optional[str]:
+        """Create visualization showing source tile grid with combined tiles overlaid."""
+        try:
+            log.debug(f"Creating alignment viz for {slide_name}:")
+            log.debug(f"  Source locations: {len(source_locations)} tiles")
+            log.debug(f"  Combined locations: {len(combined_locations)} tiles")
+            log.debug(f"  Sample source: {source_locations[:3] if source_locations else 'none'}")
+            log.debug(f"  Sample combined: {combined_locations[:3] if combined_locations else 'none'}")
+            
+            if not source_locations:
+                log.warning(f"No source locations for {slide_name}, skipping visualization")
+                return None
+                
+            # Create figure
+            import matplotlib.pyplot as plt
+            import matplotlib.patches as patches
+            fig, ax = plt.subplots(1, 1, figsize=(15, 12))
+            
+            # Get coordinate bounds
+            min_x = min(x for x, y in source_locations)
+            max_x = max(x for x, y in source_locations)
+            min_y = min(y for x, y in source_locations) 
+            max_y = max(y for x, y in source_locations)
+            
+            
+            # Plot source tiles as small squares
+            log.debug(f"Drawing {len(source_locations)} source tile rectangles")
+            for i, (x, y) in enumerate(source_locations):
+                rect = patches.Rectangle(
+                    (x, y), 1, 1,  # Unit size for each source tile
+                    linewidth=0.5, edgecolor='blue', facecolor='lightblue', alpha=0.4
+                )
+                ax.add_patch(rect)
+                if i < 3:  # Debug first few
+                    log.debug(f"  Source tile {i}: rectangle at ({x}, {y}) size (1, 1)")
+            
+            # Plot combined tiles as larger squares
+            log.debug(f"Drawing {len(combined_locations)} combined tile rectangles")
+            for i, (x, y) in enumerate(combined_locations):
+                rect = patches.Rectangle(
+                    (x, y), mag_ratio, mag_ratio,  # mag_ratio x mag_ratio size
+                    linewidth=2, edgecolor='red', facecolor='none', alpha=0.8
+                )
+                ax.add_patch(rect)
+                if i < 3:  # Debug first few  
+                    log.debug(f"  Combined tile {i}: rectangle at ({x}, {y}) size ({mag_ratio}, {mag_ratio})")
+            
+            # Set up the plot
+            ax.set_xlim(min_x - 1, max_x + mag_ratio + 1)
+            ax.set_ylim(min_y - 1, max_y + mag_ratio + 1)
+            ax.set_aspect('equal')
+            ax.invert_yaxis()  # Match image coordinate system
+            
+            # Set grid ticks to match mag_ratio for easy alignment verification
+            x_ticks = np.arange(min_x, max_x + mag_ratio + 1, mag_ratio)
+            y_ticks = np.arange(min_y, max_y + mag_ratio + 1, mag_ratio)
+            ax.set_xticks(x_ticks)
+            ax.set_yticks(y_ticks)
+            ax.grid(True, alpha=0.5, linewidth=1)  # Make grid more visible
+            
+            # Add minor ticks for individual source tiles
+            x_minor_ticks = np.arange(min_x, max_x + mag_ratio + 1, 1)
+            y_minor_ticks = np.arange(min_y, max_y + mag_ratio + 1, 1)
+            ax.set_xticks(x_minor_ticks, minor=True)
+            ax.set_yticks(y_minor_ticks, minor=True)
+            ax.grid(True, which='minor', alpha=0.2, linewidth=0.5)
+            
+            ax.set_title(f'Tile Alignment Check: {slide_name}\n'
+                        f'Blue: {source_mag} source tiles ({len(source_locations)}), '
+                        f'Red: {target_mag} combined tiles ({len(combined_locations)})\n'
+                        f'Major grid: {mag_ratio}x{mag_ratio} groups, Minor grid: individual tiles')
+            ax.set_xlabel('Grid X')
+            ax.set_ylabel('Grid Y')
+            
+            # Add legend
+            blue_patch = patches.Patch(color='lightblue', alpha=0.4, label=f'{source_mag} source tiles')
+            red_patch = patches.Patch(color='red', alpha=0.8, label=f'{target_mag} combined tiles') 
+            ax.legend(handles=[blue_patch, red_patch])
+            
+            # Save visualization
+            clean_slide_name = os.path.splitext(os.path.basename(slide_name))[0]
+            viz_filename = f"data/slides/thumbs/alignment_{clean_slide_name}_{source_mag}_to_{target_mag}.png"
+            os.makedirs(os.path.dirname(viz_filename), exist_ok=True)
+            
+            plt.savefig(viz_filename, dpi=150, bbox_inches='tight')
+            plt.close()
+            
+            return viz_filename
+            
+        except Exception as e:
+            log.warning(f"Failed to create alignment visualization for {slide_name}: {e}")
+            return None
         
     def _group_tiles_for_combination(self, locations: List[Tuple[int, int]], mag_ratio: int) -> Dict[Tuple[int, int], List[int]]:
         """Group tile locations into spatial regions for combination using grid coordinates."""
@@ -2770,7 +2779,7 @@ class Dataset:
                 skip_p = f'{to_skip}/{len(all_slides)}'
                 log.info(f"Skipping {skip_p} finished slides.")
             if not slides_to_generate:
-                log.warn("No slides for which to generate features.")
+                log.warning("No slides for which to generate features.")
                 return outdir
             dataset = dataset.filter(filters={'slide': slides_to_generate})
             filtered_slides_to_generate = dataset.slides()
@@ -3231,7 +3240,7 @@ class Dataset:
         else:
             return results, unique_labels
 
-    def load_indices(self, verbose=False) -> Dict[str, np.ndarray]:
+    def load_indices(self) -> Dict[str, np.ndarray]:
         """Return TFRecord indices."""
         pool = DPool(8)
         tfrecords = self.tfrecords()
@@ -4592,7 +4601,7 @@ class Dataset:
             tfrecord_dir = join(config['tfrecords'], config['label'])
             tiles_dir = join(config['tiles'], config['label'])
             if not exists(tiles_dir):
-                log.warn(f'No tiles found for source [bold]{source}')
+                log.warning(f'No tiles found for source [bold]{source}')
                 continue
             sf.io.write_tfrecords_multi(tiles_dir, tfrecord_dir)
             self.update_manifest()
@@ -4987,7 +4996,7 @@ class Dataset:
     def verify_annotations_slides(self) -> None:
         """Verify that annotations are correctly loaded."""
         if self.annotations is None:
-            log.warn("Annotations not loaded.")
+            log.warning("Annotations not loaded.")
             return
 
         # Verify no duplicate slide names are found
@@ -5020,9 +5029,9 @@ class Dataset:
              | self.annotations.slide.isna())
         ])
         if n_missing == 1:
-            log.warn("1 patient does not have a slide assigned.")
+            log.warning("1 patient does not have a slide assigned.")
         if n_missing > 1:
-            log.warn(f"{n_missing} patients do not have a slide assigned.")
+            log.warning(f"{n_missing} patients do not have a slide assigned.")
 
     def verify_img_format(self, *, progress: bool = True) -> Optional[str]:
         """Verify that all tfrecords have the same image format (PNG/JPG).

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -518,6 +518,7 @@ class Dataset:
         filter_blank: Optional[Union[List[str], str]] = None,
         annotations: Optional[Union[str, pd.DataFrame]] = None,
         min_tiles: int = 0,
+        source_um: Optional[Union[str, int]] = None,
     ) -> None:
         """Initialize a Dataset to organize processed images.
 
@@ -570,6 +571,8 @@ class Dataset:
             annotations (str or pd.DataFrame, optional): Path
                 to annotations file or pandas DataFrame with slide-level
                 annotations. Defaults to None.
+            source_um (str or int, optional): Source magnification for tiles
+                extracted from a higher magnification. Defaults to None.
 
         Raises:
             errors.SourceNotFoundError: If provided source does not exist
@@ -630,9 +633,12 @@ class Dataset:
                 "The following sources were not found in the dataset "
                 f"configuration: {', '.join(missing_sources)}"
             )
+        # Store source_um for use in filtering
+        self._source_um = source_um
+        
         # Create labels for each source based on tile size
         if (tile_px is not None) and (tile_um is not None):
-            label = sf.util.tile_size_label(tile_px, tile_um)
+            label = sf.util.tile_size_label(tile_px, tile_um, source_um)
         else:
             label = None
         for source in self.sources:
@@ -1918,9 +1924,6 @@ class Dataset:
                 default to all sources in project.
             skip_extracted (bool): Skip TFRecords that have already been processed
                 for the target magnification. Defaults to True.
-            img_format (str, optional): 'png' or 'jpg'. Image format to use in 
-                output TFRecords. PNG (lossless) for fidelity, JPG (lossy) for 
-                efficiency. Defaults to 'jpg'.
             report (bool): Generate a PDF report of the tile combination process
                 showing spatial coverage, combination statistics, and quality metrics.
                 Defaults to True.
@@ -1977,7 +1980,8 @@ class Dataset:
             
         # Process each TFRecord
         all_reports = []
-        
+        all_tile_combinations = []
+
         for tfrecord_path in source_tfrecords:
             if skip_extracted:
                 # Check if output already exists
@@ -1985,9 +1989,9 @@ class Dataset:
                 if output_path and exists(output_path):
                     log.info(f"Skipping {tfrecord_path} - already processed")
                     continue
-                    
+
             try:
-                report = self._process_single_tfrecord_for_lower_mag(
+                report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
                     tfrecord_path=tfrecord_path,
                     source_tile_um=source_tile_um,
                     target_tile_um=target_tile_um,
@@ -1995,6 +1999,8 @@ class Dataset:
                     **kwargs
                 )
                 all_reports.append(report)
+                if tile_combinations:
+                    all_tile_combinations.extend(tile_combinations)
             except Exception as e:
                 log.error(f"Error processing {tfrecord_path}: {str(e)}")
                 continue
@@ -2003,7 +2009,7 @@ class Dataset:
         self.update_manifest(force_update=True)
         self.build_index(False)
         
-        # Build index files for the new TFRecords
+        # Build index files and create manifest for the new TFRecords
         if all_reports:
             try:
                 # Get the output directory path
@@ -2020,6 +2026,14 @@ class Dataset:
                                 _create_index(tfr_path, force=True)
                             except Exception as e:
                                 log.warning(f"Failed to create index for {tfr_path}: {str(e)}")
+                        
+                        # Create manifest for the new TFRecord directory
+                        try:
+                            log.info(f"Creating manifest for {output_dir}")
+                            sf.io.update_manifest_at_dir(output_dir, force_update=True)
+                            log.info(f"Successfully created manifest for {target_tile_um} magnification")
+                        except Exception as e:
+                            log.warning(f"Failed to create manifest for {output_dir}: {str(e)}")
                         
                         log.info(f"Built index files for {target_tile_um} magnification")
                     else:
@@ -2113,7 +2127,34 @@ class Dataset:
                 log.info(f'Saved lower magnification extraction report: {pdf_filename}')
             except Exception as e:
                 log.warning(f'Failed to save extraction report: {e}')
-        
+
+        # Save combined tile combinations to single overview CSV
+        if all_tile_combinations:
+            import pandas as pd
+            try:
+                # Get the output directory path for saving the overview CSV
+                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
+                if dummy_tfrecord_path:
+                    output_dir = os.path.dirname(dummy_tfrecord_path)
+                    combinations_df = pd.DataFrame(all_tile_combinations)
+
+                    # Create informative filename
+                    source_mag_str = str(source_tile_um).replace('x', '') + 'x'
+                    target_mag_str = str(target_tile_um).replace('x', '') + 'x'
+                    target_px_str = f"{target_tile_px}px" if target_tile_px else f"{self.tile_px}px"
+
+                    csv_filename = f"{target_px_str}_{target_mag_str}_from_{source_mag_str}_tile_combinations.csv"
+                    csv_path = os.path.join(output_dir, csv_filename)
+
+                    combinations_df.to_csv(csv_path, index=False)
+                    log.info(f"Saved {len(all_tile_combinations)} tile combination records to overview CSV: {csv_path}")
+                else:
+                    log.warning("Could not determine output directory for saving tile combinations CSV")
+            except Exception as e:
+                log.warning(f"Failed to save tile combinations overview CSV: {e}")
+        else:
+            log.info("No tile combinations data to save to overview CSV")
+
         return {report.path: report for report in all_reports}
     
     def _get_output_tfrecord_path(
@@ -2136,13 +2177,13 @@ class Dataset:
                     else:
                         base_suffix = f"{px}px_{target_tile_um}um"
                     
-                    # Add source magnification if provided (for lower mag extraction)
+                    # Include source magnification in directory name
                     if source_tile_um is not None:
                         if isinstance(source_tile_um, str):
-                            source_suffix = source_tile_um.lower()
+                            source_mag = source_tile_um.lower()
                         else:
-                            source_suffix = f"{source_tile_um}um"
-                        mag_suffix = f"{base_suffix}_from_{source_suffix}"
+                            source_mag = f"{source_tile_um}x"
+                        mag_suffix = f"{base_suffix}_from_{source_mag}"
                     else:
                         mag_suffix = base_suffix
                     target_dir = join(tfrecord_dir, mag_suffix)
@@ -2182,6 +2223,9 @@ class Dataset:
             
         # Get slide name
         slide_name = sf.util.path_to_name(tfrecord_path)
+        
+        # Initialize list to track tile combinations for CSV logging
+        tile_combinations = []
         
         # If mag_ratio wasn't calculated, we need to determine it from actual tile data
         if mag_ratio is None:
@@ -2229,6 +2273,32 @@ class Dataset:
                         )
                         writer.write(record)
                         combined_count += 1
+                        
+                        # Log tile combination data for CSV
+                        if tile_indices:
+                            matching_source_locations = [locations[i] for i in tile_indices]
+                            # Calculate target coordinates (same as in _create_combined_tile_record)
+                            if matching_source_locations:
+                                avg_x = sum(loc[0] for loc in matching_source_locations) // len(matching_source_locations)
+                                avg_y = sum(loc[1] for loc in matching_source_locations) // len(matching_source_locations)
+                                target_coord = (avg_x, avg_y)
+                            else:
+                                target_coord = group_loc
+                            
+                            # Log each source tile that went into this target tile
+                            for idx, source_idx in enumerate(tile_indices):
+                                source_coord = locations[source_idx]
+                                tile_combinations.append({
+                                    'slide_name': slide_name,
+                                    'target_tile_id': combined_count,
+                                    'target_x': target_coord[0],
+                                    'target_y': target_coord[1],
+                                    'source_tile_idx': source_idx,
+                                    'source_x': source_coord[0],
+                                    'source_y': source_coord[1],
+                                    'group_position': idx  # Position within the mag_ratio x mag_ratio grid
+                                })
+                        
                         log.info(f"✓ Successfully combined tile group {combined_count} at location {group_loc}")
                     else:
                         log.warning(f"✗ Failed to combine tiles at {group_loc} - _combine_tiles_from_group returned None")
@@ -2311,8 +2381,8 @@ class Dataset:
             f"✓ Processed {slide_name}: combined {total_tiles} source tiles into "
             f"{combined_count} target tiles ({report_data['discarded_tiles']} discarded)"
         )
-        
-        return slide_report
+
+        return slide_report, tile_combinations
     
     def _resize_square_np(
             self,
@@ -2566,22 +2636,11 @@ class Dataset:
             else:
                 pixel_x, pixel_y = grid_x, grid_y
         
-        # Calculate target tile center coordinates (at target magnification level)
-        target_pixel_x = pixel_x // mag_ratio  
-        target_pixel_y = pixel_y // mag_ratio
-        
-        # Create record with both source and target coordinates for overlay visualization
-        # loc_x, loc_y: maintained for compatibility (target tile center)
-        # source_locations_x, source_locations_y: individual source tile centers
-        # target_location_x, target_location_y: combined tile center at target level
-        source_x_list = [loc[0] for loc in matching_source_locations] if matching_source_locations else [pixel_x]
-        source_y_list = [loc[1] for loc in matching_source_locations] if matching_source_locations else [pixel_y]
-        
         return sf.io.serialized_record(
             slide=bytes(slide_name, 'utf-8'),
             image_raw=img_bytes,
-            loc_x=target_pixel_x,
-            loc_y=target_pixel_y
+            loc_x=pixel_x,
+            loc_y=pixel_y
         )
 
     def _create_lower_mag_slide_report(
@@ -2607,9 +2666,9 @@ class Dataset:
             r = int(mag_ratio)
 
             # Draw-level box sizes (NO 224s here). Use the passed source_tile_px.
-            src_px_native = int(source_tile_px) if source_tile_px else int(getattr(self, "tile_px", 512))
-            source_box_px_draw = max(1, int(round(src_px_native / max(r, 1))))  # e.g., 512/4 = 128
-            target_box_px_draw = int(src_px_native)                             # e.g., 512
+            src_px_native = int(source_tile_px) if source_tile_px else int(getattr(self, "tile_px"))
+            source_box_px_draw = max(1, int(round(src_px_native / max(r, 1))))
+            target_box_px_draw = int(src_px_native)
 
             # Robust stride/origin on SOURCE space (after undoing loc_scale)
             def _stride_origin_source(stored_centers):
@@ -2685,8 +2744,8 @@ class Dataset:
             log.debug(f"DEBUG: Final target_thumb_coords: {slide_report.target_thumb_coords is not None} ({len(tgt_centers)} coords)")
 
             # expose draw-level box sizes for the renderer (used by calc_thumb)
-            slide_report.source_tile_px = int(source_box_px_draw)   # e.g., 128 at draw level
-            slide_report.target_tile_px = int(target_box_px_draw)   # e.g., 512 at draw level
+            slide_report.source_tile_px = int(source_box_px_draw)
+            slide_report.target_tile_px = int(target_box_px_draw)
 
             log.info(f"LowerMagSlideReport created for {slide_name}:")
             log.info(f"  Source box @draw: {source_box_px_draw}px  | Target box @draw: {target_box_px_draw}px  | r={r}")
@@ -4778,11 +4837,18 @@ class Dataset:
         # Filter the list by filters
         if self.annotations is not None:
             slides = self.slides()
+            # DEBUG: Log filtering details
+            log.debug(f"tfrecords: Available slides from annotations: {slides}")
+            log.debug(f"tfrecords: TFRecords found before filtering: {[path_to_name(tfr) for tfr in tfrecords_list]}")
+            
             filtered_tfrecords_list = [
                 tfrecord for tfrecord in tfrecords_list
                 if path_to_name(tfrecord) in slides
             ]
             filtered = filtered_tfrecords_list
+            
+            # DEBUG: Log what survived filtering
+            log.debug(f"tfrecords: TFRecords after slide filtering: {[path_to_name(tfr) for tfr in filtered]}")
         else:
             log.warning("Error filtering TFRecords, are annotations empty?")
             filtered = tfrecords_list

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2002,7 +2002,7 @@ class Dataset:
                 
         # Update manifest after processing
         self.update_manifest(force_update=True)
-        self.build_index(True)
+        self.build_index(False)
         
         # Build index files for the new TFRecords
         if all_reports:
@@ -2765,7 +2765,7 @@ class Dataset:
                 thumb_coords=None,
                 data=report_data,
                 compress=True,
-                ignore_thumb_errors=True,
+                ignore_thumb_errors=False,
             )
 
             # -------- SOURCE centers: read directly from source TFRecord --------

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1893,6 +1893,284 @@ class Dataset:
         all_reports = [r for r in all_reports if r is not None]
         return {report.path: report for report in all_reports}
 
+    def _validate_lower_mag_params(self, source_tile_um: Union[int, str], target_tile_um: Union[int, str]) -> int:
+        """Validate magnification parameters and calculate ratios.
+
+        Args:
+            source_tile_um: Source magnification (str, e.g. "20x")
+            target_tile_um: Target magnification (str, e.g. "5x")
+
+        Returns:
+            mag_ratio: Integer magnification ratio
+
+        Raises:
+            DatasetError: If magnification parameters are invalid or ratio is not an integer
+        """
+        # Ensure both parameters are magnification strings
+        sf.util.assert_is_mag(source_tile_um)
+        sf.util.assert_is_mag(target_tile_um)
+
+        # Convert to numeric magnification values
+        source_mag = sf.util.to_mag(source_tile_um)
+        target_mag = sf.util.to_mag(target_tile_um)
+
+        # Calculate magnification ratio (how many source tiles combine to make one target tile)
+        mag_ratio = source_mag / target_mag
+
+        # Validate the ratio
+        if mag_ratio <= 0:
+            raise errors.DatasetError(f"Invalid magnification ratio: {source_tile_um} to {target_tile_um}")
+
+        if not mag_ratio.is_integer() or mag_ratio < 1:
+            raise errors.DatasetError(f"Invalid magnification ratio: {source_tile_um} to {target_tile_um}. Ratio must be a positive integer, got {mag_ratio}")
+
+        return int(mag_ratio)
+
+    def _get_lower_mag_tfrecords(self, source: Optional[str] = None) -> List[str]:
+        """Get source TFRecords for processing.
+
+        Args:
+            source: Name of dataset source to select TFRecords from
+
+        Returns:
+            List of TFRecord file paths
+
+        Raises:
+            ValueError: If no TFRecords found
+        """
+        source_tfrecords = self.tfrecords(source=source)
+        if not source_tfrecords:
+            raise ValueError("No TFRecords found for processing")
+        return source_tfrecords
+
+    def _create_lower_mag_progress_bar(self, total_tfrecords: int) -> Tuple[Optional[Any], Optional[Any]]:
+        """Create progress bar for lower magnification extraction.
+
+        Args:
+            total_tfrecords: Total number of TFRecords to process
+
+        Returns:
+            Tuple of (progress_bar, task_id) or (None, None) if creation fails
+        """
+        try:
+            pb = TileExtractionProgress()
+            pb.add_task("Speed: ", progress_type="speed", total=None)
+            tfr_task = pb.add_task(
+                f"Processing TFRecords...",
+                progress_type="slide_progress",
+                total=total_tfrecords
+            )
+            pb.start()
+            return pb, tfr_task
+        except Exception:
+            return None, None
+
+    def _build_lower_mag_indices(self, target_tile_um: Union[int, str], target_tile_px: int, source_tile_um: Union[int, str]) -> None:
+        """Build index files and manifest for newly created TFRecords.
+
+        Args:
+            target_tile_um: Target magnification
+            target_tile_px: Target tile pixel size
+            source_tile_um: Source magnification
+        """
+        try:
+            dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
+            if not dummy_tfrecord_path:
+                log.warning(f"Could not determine output directory for {target_tile_um}")
+                return
+
+            output_dir = os.path.dirname(dummy_tfrecord_path)
+            if not os.path.exists(output_dir):
+                log.warning(f"Could not find output directory for {target_tile_um}")
+                return
+
+            # Find all TFRecord files in the output directory
+            tfrecord_files = glob.glob(os.path.join(output_dir, "*.tfrecords"))
+
+            log.info(f"Building index files for {len(tfrecord_files)} TFRecord files")
+            for tfr_path in tfrecord_files:
+                try:
+                    _create_index(tfr_path, force=True)
+                except Exception as e:
+                    log.warning(f"Failed to create index for {tfr_path}: {str(e)}")
+
+            # Create manifest for the new TFRecord directory
+            try:
+                log.info(f"Creating manifest for {output_dir}")
+                sf.io.update_manifest_at_dir(output_dir, force_update=True)
+                log.info(f"Successfully created manifest for {target_tile_um} magnification")
+            except Exception as e:
+                log.warning(f"Failed to create manifest for {output_dir}: {str(e)}")
+
+            log.info(f"Built index files for {target_tile_um} magnification")
+
+        except Exception as e:
+            log.warning(f"Failed to build index files for {target_tile_um}: {str(e)}")
+
+    def _save_tile_combinations_csv(self, all_tile_combinations: List[Dict], target_tile_um: Union[int, str],
+                                   target_tile_px: int, source_tile_um: Union[int, str]) -> None:
+        """Save tile combination data to overview CSV.
+
+        Args:
+            all_tile_combinations: List of tile combination records
+            target_tile_um: Target magnification
+            target_tile_px: Target tile pixel size
+            source_tile_um: Source magnification
+        """
+        if not all_tile_combinations:
+            log.info("No tile combinations data to save to overview CSV")
+            return
+
+        import pandas as pd
+        try:
+            dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
+            if not dummy_tfrecord_path:
+                log.warning("Could not determine output directory for saving tile combinations CSV")
+                return
+
+            output_dir = os.path.dirname(dummy_tfrecord_path)
+            combinations_df = pd.DataFrame(all_tile_combinations)
+
+            # Create informative filename
+            source_mag_str = str(source_tile_um).replace('x', '') + 'x'
+            target_mag_str = str(target_tile_um).replace('x', '') + 'x'
+            target_px_str = f"{target_tile_px}px"
+
+            csv_filename = f"{target_px_str}_{target_mag_str}_from_{source_mag_str}_tile_combinations.csv"
+            csv_path = os.path.join(output_dir, csv_filename)
+
+            combinations_df.to_csv(csv_path, index=False)
+            log.info(f"Saved {len(all_tile_combinations)} tile combination records to overview CSV: {csv_path}")
+
+        except Exception as e:
+            log.warning(f"Failed to save tile combinations overview CSV: {e}")
+
+    def _create_lower_mag_report_metadata(self, source_tfrecords: List[str], all_reports: List, target_tile_um: Union[int, str],
+                                        source_tile_um: Union[int, str], mag_ratio: int, **kwargs) -> Any:
+        """Create metadata for lower magnification extraction report.
+
+        Args:
+            source_tfrecords: List of source TFRecord files
+            all_reports: List of generated slide reports
+            target_tile_um: Target magnification
+            source_tile_um: Source magnification
+            mag_ratio: Magnification ratio
+            **kwargs: Additional parameters
+
+        Returns:
+            SimpleNamespace object with report metadata
+        """
+        from types import SimpleNamespace
+
+        # Read source extraction parameters from the source TFRecords directory
+        source_params = self._get_source_extraction_parameters(source_tfrecords[0] if source_tfrecords else None)
+
+        return SimpleNamespace(
+            tile_px=kwargs.get('target_tile_px', self.tile_px),
+            tile_um=target_tile_um,
+            qc=source_params.get('qc', 'None'),
+            total_slides=len(source_tfrecords),
+            slides_skipped=len(source_tfrecords) - len(all_reports),
+            roi_method=source_params.get('roi_method', 'N/A'),
+            stride=source_params.get('stride', 1),
+            gs_frac=source_params.get('gs_fraction', 'N/A'),
+            gs_thresh=source_params.get('gs_threshold', 'N/A'),
+            ws_frac=source_params.get('ws_fraction', 'N/A'),
+            ws_thresh=source_params.get('ws_threshold', 'N/A'),
+            normalizer=source_params.get('normalizer', ''),
+            img_format=source_params.get('img_format', kwargs.get('img_format', 'jpg')),
+            source_tile_um=source_tile_um,
+            mag_ratio=mag_ratio
+        )
+
+    def _create_dummy_report(self, target_tile_um: Union[int, str], source_tile_um: Union[int, str],
+                           mag_ratio: int, **kwargs) -> Any:
+        """Create a dummy report when no slides were processed.
+
+        Args:
+            target_tile_um: Target magnification
+            source_tile_um: Source magnification
+            mag_ratio: Magnification ratio
+            **kwargs: Additional parameters
+
+        Returns:
+            LowerMagSlideReport dummy object
+        """
+        return LowerMagSlideReport(
+            images=[],
+            path="No slides processed",
+            tile_px=int(kwargs.get('target_tile_px', self.tile_px)),
+            tile_um=target_tile_um,
+            source_tile_um=source_tile_um,
+            mag_ratio=int(mag_ratio) if mag_ratio else 1,
+            data={'num_tiles': 0, 'num_rois': 0, 'message': 'No complete tile groups found'},
+            ignore_thumb_errors=True
+        )
+
+    def _generate_lower_mag_pdf_report(self, all_reports: List, source_tfrecords: List[str],
+                                     target_tile_um: Union[int, str], source_tile_um: Union[int, str],
+                                     mag_ratio: int, **kwargs) -> None:
+        """Generate PDF and CSV reports for lower magnification extraction.
+
+        Args:
+            all_reports: List of slide reports
+            source_tfrecords: List of source TFRecord files
+            target_tile_um: Target magnification
+            source_tile_um: Source magnification
+            mag_ratio: Magnification ratio
+            **kwargs: Additional parameters
+        """
+        log.info(f'Generating lower magnification tile extraction PDF report...')
+        log.info(f'Found {len(all_reports)} reports to include in PDF')
+
+        # Create metadata for lower mag extraction
+        report_meta = self._create_lower_mag_report_metadata(
+            source_tfrecords, all_reports, target_tile_um, source_tile_um, mag_ratio, **kwargs
+        )
+
+        # Generate ExtractionReport PDF (handle empty reports case)
+        if all_reports:
+            pdf_report = LowerMagExtractionReport(
+                reports=all_reports,
+                meta=report_meta,
+                title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um})'
+            )
+        else:
+            log.warning('No valid reports generated - creating empty ExtractionReport')
+            dummy_report = self._create_dummy_report(target_tile_um, source_tile_um, mag_ratio, **kwargs)
+            pdf_report = LowerMagExtractionReport(
+                reports=[dummy_report],
+                meta=report_meta,
+                title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um}) - No Results'
+            )
+
+        # Save PDF and CSV with specific naming for lower mag
+        from datetime import datetime
+        _time = datetime.now().strftime('%Y%m%d-%H%M%S')
+        source_name = source_tile_um if isinstance(source_tile_um, str) else f"{source_tile_um}um"
+        target_name = target_tile_um if isinstance(target_tile_um, str) else f"{target_tile_um}um"
+
+        # Determine output directory (use target magnification directory)
+        if all_reports:
+            sample_output_path = self._get_output_tfrecord_path(
+                "dummy", target_tile_um,
+                target_tile_px=kwargs.get('target_tile_px', self.tile_px),
+                source_tile_um=source_tile_um
+            )
+            pdf_dir = os.path.dirname(sample_output_path) if sample_output_path else ''
+        else:
+            pdf_dir = ''
+
+        pdf_filename = os.path.join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}-{_time}.pdf')
+        csv_filename = os.path.join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}.csv')
+
+        try:
+            pdf_report.save(pdf_filename)
+            pdf_report.update_csv(csv_filename)
+            log.info(f'Saved lower magnification extraction report: {pdf_filename}')
+        except Exception as e:
+            log.warning(f'Failed to save extraction report: {e}')
+
     def extract_lower_mag_tiles_from_tfr(
         self,
         *,
@@ -1960,40 +2238,19 @@ class Dataset:
             - Each combined tile's coordinates (loc_x, loc_y) will correspond to the
               center/average coordinates of the source tiles that make up each combined tile.
         """
-        # Validate and calculate magnification ratio
-        source_mag = sf.util.to_mag(source_tile_um) if isinstance(source_tile_um, str) else None
-        target_mag = sf.util.to_mag(target_tile_um) if isinstance(target_tile_um, str) else None
+        # Validate parameters and calculate magnification ratio
+        mag_ratio = self._validate_lower_mag_params(source_tile_um, target_tile_um)
         target_tile_px = int(kwargs.get('target_tile_px', 224))
 
-        if source_mag and target_mag:
-            mag_ratio = source_mag / target_mag
-            if not mag_ratio.is_integer() or mag_ratio < 1:
-                raise errors.DatasetError(f"Invalid magnification ratio: {source_tile_um} to {target_tile_um}")
-            mag_ratio = int(mag_ratio)
-        else:
-            mag_ratio = None
-        # Get source TFRecords
-        source_tfrecords = self.tfrecords(source=source)
-        if not source_tfrecords:
-            raise ValueError("No TFRecords found for processing")
-        # Process each TFRecord
+        # Get source TFRecords for processing
+        source_tfrecords = self._get_lower_mag_tfrecords(source=source)
+
+        # Initialize processing variables
         all_reports = []
         all_tile_combinations = []
 
-        # --- Progress bar setup (added) ---
-        try:
-            pb = TileExtractionProgress()
-            pb.add_task("Speed: ", progress_type="speed", total=None)
-            tfr_task = pb.add_task(
-                f"Processing TFRecords...",
-                progress_type="slide_progress",
-                total=len(source_tfrecords)
-            )
-            pb.start()
-        except Exception:
-            # If progress bar can't be created for any reason, continue without it.
-            pb = None
-            tfr_task = None
+        # Set up progress bar
+        pb, tfr_task = self._create_lower_mag_progress_bar(len(source_tfrecords))
 
         # Ensure cleanup context matches other uses
         with sf.util.cleanup_progress(pb) if pb is not None else contextlib.nullcontext():
@@ -2051,149 +2308,17 @@ class Dataset:
 
         # Build index files and create manifest for the new TFRecords
         if all_reports:
-            try:
-                # Get the output directory path
-                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
-                if dummy_tfrecord_path:
-                    output_dir = os.path.dirname(dummy_tfrecord_path)
-                    if output_dir and os.path.exists(output_dir):
-                        # Find all TFRecord files in the output directory
-                        tfrecord_files = glob(os.path.join(output_dir, "*.tfrecords"))
-
-                        log.info(f"Building index files for {len(tfrecord_files)} TFRecord files")
-                        for tfr_path in tfrecord_files:
-                            try:
-                                _create_index(tfr_path, force=True)
-                            except Exception as e:
-                                log.warning(f"Failed to create index for {tfr_path}: {str(e)}")
-
-                        # Create manifest for the new TFRecord directory
-                        try:
-                            log.info(f"Creating manifest for {output_dir}")
-                            sf.io.update_manifest_at_dir(output_dir, force_update=True)
-                            log.info(f"Successfully created manifest for {target_tile_um} magnification")
-                        except Exception as e:
-                            log.warning(f"Failed to create manifest for {output_dir}: {str(e)}")
-
-                        log.info(f"Built index files for {target_tile_um} magnification")
-                    else:
-                        log.warning(f"Could not find output directory for {target_tile_um}")
-                else:
-                    log.warning(f"Could not determine output directory for {target_tile_um}")
-            except Exception as e:
-                log.warning(f"Failed to build index files for {target_tile_um}: {str(e)}")
+            self._build_lower_mag_indices(target_tile_um, target_tile_px, source_tile_um)
 
         # Filter out None reports
         all_reports = [r for r in all_reports if r is not None]
 
-        # Generate PDF report if requested (even if some slides had 0 tiles)
+        # Generate PDF report if requested
         if report:
-            log.info(f'Generating lower magnification tile extraction PDF report...')
-            log.info(f'Found {len(all_reports)} reports to include in PDF')
-
-            # Read source extraction parameters from the source TFRecords directory
-            source_params = self._get_source_extraction_parameters(source_tfrecords[0] if source_tfrecords else None)
-
-            # Create metadata for lower mag extraction
-            from types import SimpleNamespace
-            from datetime import datetime
-            report_meta = SimpleNamespace(
-                tile_px=kwargs.get('target_tile_px', self.tile_px),
-                tile_um=target_tile_um,
-                qc=source_params.get('qc', 'None'),
-                total_slides=len(source_tfrecords),
-                slides_skipped=len(source_tfrecords) - len(all_reports),
-                roi_method=source_params.get('roi_method', 'N/A'),
-                stride=source_params.get('stride', 1),
-                gs_frac=source_params.get('gs_fraction', 'N/A'),
-                gs_thresh=source_params.get('gs_threshold', 'N/A'),
-                ws_frac=source_params.get('ws_fraction', 'N/A'),
-                ws_thresh=source_params.get('ws_threshold', 'N/A'),
-                normalizer=source_params.get('normalizer', ''),
-                img_format=source_params.get('img_format', kwargs.get('img_format', 'jpg')),
-                source_tile_um=source_tile_um,  # Additional metadata specific to lower mag
-                mag_ratio=mag_ratio if mag_ratio else "calculated"
-            )
-
-            # Generate ExtractionReport PDF (handle empty reports case)
-            if all_reports:
-                pdf_report = LowerMagExtractionReport(
-                    reports=all_reports,     # List[LowerMagSlideReport]
-                    meta=report_meta,
-                    title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um})'
-                )
-            else:
-                log.warning('No valid reports generated - creating empty ExtractionReport')
-                # Create a minimal dummy report to show that processing was attempted
-
-                dummy_report = LowerMagSlideReport(
-                    images=[],
-                    path="No slides processed",
-                    tile_px=int(kwargs.get('target_tile_px', self.tile_px)),
-                    tile_um=target_tile_um,
-                    source_tile_um=source_tile_um,
-                    mag_ratio=int(mag_ratio) if mag_ratio else 1,
-                    data={'num_tiles': 0, 'num_rois': 0, 'message': 'No complete tile groups found'},
-                    ignore_thumb_errors=True
-                )
-
-                pdf_report = LowerMagExtractionReport(
-                    reports=[dummy_report],
-                    meta=report_meta,
-                    title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um}) - No Results'
-                )
-
-            # Save PDF and CSV with specific naming for lower mag
-            _time = datetime.now().strftime('%Y%m%d-%H%M%S')
-            source_name = source_tile_um if isinstance(source_tile_um, str) else f"{source_tile_um}um"
-            target_name = target_tile_um if isinstance(target_tile_um, str) else f"{target_tile_um}um"
-
-            # Determine output directory (use target magnification directory)
-            if all_reports:
-                sample_output_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=kwargs.get('target_tile_px', self.tile_px), source_tile_um=source_tile_um)
-                if sample_output_path:
-                    pdf_dir = dirname(sample_output_path)
-                else:
-                    pdf_dir = ''
-            else:
-                pdf_dir = ''
-
-            pdf_filename = join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}-{_time}.pdf')
-            csv_filename = join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}.csv')
-
-            try:
-                pdf_report.save(pdf_filename)
-                pdf_report.update_csv(csv_filename)
-                log.info(f'Saved lower magnification extraction report: {pdf_filename}')
-            except Exception as e:
-                log.warning(f'Failed to save extraction report: {e}')
+            self._generate_lower_mag_pdf_report(all_reports, source_tfrecords, target_tile_um, source_tile_um, mag_ratio, **kwargs)
 
         # Save combined tile combinations to single overview CSV
-        if all_tile_combinations:
-            import pandas as pd
-            try:
-                # Get the output directory path for saving the overview CSV
-                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
-                if dummy_tfrecord_path:
-                    output_dir = os.path.dirname(dummy_tfrecord_path)
-                    combinations_df = pd.DataFrame(all_tile_combinations)
-
-                    # Create informative filename
-                    source_mag_str = str(source_tile_um).replace('x', '') + 'x'
-                    target_mag_str = str(target_tile_um).replace('x', '') + 'x'
-                    target_px_str = f"{target_tile_px}px" if target_tile_px else f"{self.tile_px}px"
-
-                    csv_filename = f"{target_px_str}_{target_mag_str}_from_{source_mag_str}_tile_combinations.csv"
-                    csv_path = os.path.join(output_dir, csv_filename)
-
-                    combinations_df.to_csv(csv_path, index=False)
-                    log.info(f"Saved {len(all_tile_combinations)} tile combination records to overview CSV: {csv_path}")
-                else:
-                    log.warning("Could not determine output directory for saving tile combinations CSV")
-            except Exception as e:
-                log.warning(f"Failed to save tile combinations overview CSV: {e}")
-        else:
-            log.info("No tile combinations data to save to overview CSV")
+        self._save_tile_combinations_csv(all_tile_combinations, target_tile_um, target_tile_px, source_tile_um)
 
         return {report.path: report for report in all_reports}
     

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1895,7 +1895,6 @@ class Dataset:
         source: Optional[str] = None,
         skip_extracted: bool = True,
         report: bool = True,
-        img_format: str = 'jpg',
         **kwargs: Any
     ) -> Dict[str, SlideReport]:
         r"""Extract lower magnification tiles from existing high-magnification TFRecords.
@@ -2011,7 +2010,6 @@ class Dataset:
                 dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
                 if dummy_tfrecord_path:
                     output_dir = os.path.dirname(dummy_tfrecord_path)
-                    log.debug(f"OUTPUT DIR: {output_dir}")
                     if output_dir and os.path.exists(output_dir):
                         # Find all TFRecord files in the output directory
                         tfrecord_files = glob(os.path.join(output_dir, "*.tfrecords"))
@@ -2039,23 +2037,26 @@ class Dataset:
             log.info(f'Generating lower magnification tile extraction PDF report...')
             log.info(f'Found {len(all_reports)} reports to include in PDF')
             
+            # Read source extraction parameters from the source TFRecords directory
+            source_params = self._get_source_extraction_parameters(source_tfrecords[0] if source_tfrecords else None)
+            
             # Create metadata for lower mag extraction
             from types import SimpleNamespace
             from datetime import datetime
             report_meta = SimpleNamespace(
                 tile_px=kwargs.get('target_tile_px', self.tile_px),
                 tile_um=target_tile_um,
-                qc="Lower mag tile combination",  # Custom QC description
+                qc=source_params.get('qc', 'None'),
                 total_slides=len(source_tfrecords),
                 slides_skipped=len(source_tfrecords) - len(all_reports),
-                roi_method="N/A",  # Not applicable for TFRecord combination
-                stride=1,  # Not applicable 
-                gs_frac="N/A",  # These were applied during original extraction
-                gs_thresh="N/A",
-                ws_frac="N/A", 
-                ws_thresh="N/A",
-                normalizer="N/A",
-                img_format=kwargs.get('img_format', 'jpg'),
+                roi_method=source_params.get('roi_method', 'N/A'),
+                stride=source_params.get('stride', 1),
+                gs_frac=source_params.get('gs_fraction', 'N/A'),
+                gs_thresh=source_params.get('gs_threshold', 'N/A'),
+                ws_frac=source_params.get('ws_fraction', 'N/A'), 
+                ws_thresh=source_params.get('ws_threshold', 'N/A'),
+                normalizer=source_params.get('normalizer', ''),
+                img_format=source_params.get('img_format', kwargs.get('img_format', 'jpg')),
                 source_tile_um=source_tile_um,  # Additional metadata specific to lower mag
                 mag_ratio=mag_ratio if mag_ratio else "calculated"
             )
@@ -2167,25 +2168,11 @@ class Dataset:
             
         # Read coordinates from source TFRecord (the original high-mag tiles)
         source_locations = sf.io.get_locations_from_tfrecord(tfrecord_path)
-        log.debug(f"Loaded {len(source_locations)} source tile locations from {tfrecord_path}")
         
         # Try to read target TFRecord coordinates (the newly created low-mag tiles)
         target_tile_px = kwargs.get('target_tile_px')
-        target_tfrecord_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
-        target_locations = None
-        if target_tfrecord_path and exists(target_tfrecord_path):
-            try:
-                target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
-                log.debug(f"Loaded {len(target_locations)} target tile locations from {target_tfrecord_path}")
-            except Exception as e:
-                log.debug(f"Could not read target TFRecord {target_tfrecord_path}: {e}")
-                target_locations = None
-        
         # Use source locations for processing (this is what we're extracting FROM)
         locations = source_locations
-        
-        # No enhanced coordinate data needed - we'll read both TFRecords separately during visualization
-        source_locations_data = None
             
         total_tiles = len(locations)
         
@@ -2221,7 +2208,6 @@ class Dataset:
             
         # Ensure output directory exists
         os.makedirs(dirname(output_path), exist_ok=True)
-        log.debug(f"Writing combined tiles to: {output_path}")
         
         # Process tile groups and write combined tiles
         combined_count = 0
@@ -2282,8 +2268,6 @@ class Dataset:
         
         # Find the original slide path for thumbnail generation
         slide_path = self.find_slide(slide=slide_name)
-        log.debug(f"Looking for slide: {slide_name}")
-        log.debug(f"Found slide path: {slide_path}")
         if slide_path and not os.path.exists(slide_path):
             log.warning(f"Slide path does not exist: {slide_path}")
             slide_path = None
@@ -2292,19 +2276,13 @@ class Dataset:
         # Show original tile locations (where tiles were actually extracted from)
         thumb_coords = None
         if locations:
-            log.debug(f"Preparing thumbnail coordinates for {slide_name}: {len(locations)} original tiles")
             
             # Use only the original tile coordinates (these are known to be valid)
             all_coords = [(int(x), int(y)) for x, y in locations]
-            log.debug(f"Using original tile coordinates only for thumbnail")
             
             if all_coords:
                 # Convert to numpy array as expected by SlideReport
                 thumb_coords = np.array(all_coords, dtype=np.int64)
-                log.debug(f"Created thumb_coords array with {len(all_coords)} total coordinates")
-                log.debug(f"Sample coordinates: {all_coords[:5]}")
-                log.debug(f"thumb_coords shape: {thumb_coords.shape}")
-                log.debug(f"thumb_coords dtype: {thumb_coords.dtype}")
                 
                 # Verify coordinates are in the right format - should be (N, 2) array
                 if thumb_coords.ndim != 2 or thumb_coords.shape[1] != 2:
@@ -2329,22 +2307,6 @@ class Dataset:
             target_tfrecord_path=output_path,  # Pass target TFRecord path for coordinate reading
         )
                 
-        # Create alignment visualization
-        if combined_locations:
-            # Convert source locations to grid coordinates for visualization
-            source_grid_coords = self._coords_to_grid_indices(locations)
-            
-            viz_path = self._create_alignment_visualization(
-                slide_name=slide_name,
-                source_locations=source_grid_coords,  # Grid coordinates of source tiles
-                combined_locations=combined_locations,  # Grid coordinates of combined tiles  
-                mag_ratio=mag_ratio,
-                source_mag=source_tile_um,
-                target_mag=target_tile_um
-            )
-            if viz_path:
-                log.info(f"Created alignment visualization: {viz_path}")
-
         log.info(
             f"✓ Processed {slide_name}: combined {total_tiles} source tiles into "
             f"{combined_count} target tiles ({report_data['discarded_tiles']} discarded)"
@@ -2370,107 +2332,46 @@ class Dataset:
         pil = pil.resize((target_px, target_px), resample=Image.LANCZOS)
         return np.array(pil, dtype=np.uint8)
 
-    def _create_alignment_visualization(
-        self, 
-        slide_name: str,
-        source_locations: List[Tuple[int, int]],  # Grid coordinates of source tiles
-        combined_locations: List[Tuple[int, int]],  # Grid coordinates of combined tiles
-        mag_ratio: int,
-        source_mag: str,
-        target_mag: str
-    ) -> Optional[str]:
-        """Create visualization showing source tile grid with combined tiles overlaid."""
+    def _get_source_extraction_parameters(self, source_tfrecord_path: Optional[str]) -> Dict[str, Any]:
+        """Read extraction parameters from the source magnification's extraction report CSV."""
         try:
-            log.debug(f"Creating alignment viz for {slide_name}:")
-            log.debug(f"  Source locations: {len(source_locations)} tiles")
-            log.debug(f"  Combined locations: {len(combined_locations)} tiles")
-            log.debug(f"  Sample source: {source_locations[:3] if source_locations else 'none'}")
-            log.debug(f"  Sample combined: {combined_locations[:3] if combined_locations else 'none'}")
-            
-            if not source_locations:
-                log.warning(f"No source locations for {slide_name}, skipping visualization")
-                return None
+            if not source_tfrecord_path:
+                return {}
                 
-            # Create figure
-            import matplotlib.pyplot as plt
-            import matplotlib.patches as patches
-            fig, ax = plt.subplots(1, 1, figsize=(15, 12))
+            # Get the source directory from the TFRecord path
+            source_dir = os.path.dirname(source_tfrecord_path)
+            csv_path = os.path.join(source_dir, "extraction_report.csv")
             
-            # Get coordinate bounds
-            min_x = min(x for x, y in source_locations)
-            max_x = max(x for x, y in source_locations)
-            min_y = min(y for x, y in source_locations) 
-            max_y = max(y for x, y in source_locations)
+            if not os.path.exists(csv_path):
+                return {}
+                
+            # Read the CSV and get parameters from the first row (they should all be the same)
+            import pandas as pd
+            df = pd.read_csv(csv_path)
             
+            if df.empty:
+                return {}
+                
+            # Get parameters from the first slide (they should be consistent across slides)
+            first_row = df.iloc[0]
+            params = {
+                'qc': first_row.get('qc', 'None'),
+                'roi_method': 'auto',  # Most common default
+                'stride': first_row.get('stride', 1),
+                'gs_fraction': first_row.get('gs_fraction', 'N/A'),
+                'gs_threshold': first_row.get('gs_threshold', 'N/A'),
+                'ws_fraction': first_row.get('ws_fraction', 'N/A'),
+                'ws_threshold': first_row.get('ws_threshold', 'N/A'),
+                'normalizer': first_row.get('normalizer', ''),
+                'img_format': first_row.get('img_format', 'jpg'),
+                'backend': first_row.get('backend', 'libvips')
+            }
             
-            # Plot source tiles as small squares
-            log.debug(f"Drawing {len(source_locations)} source tile rectangles")
-            for i, (x, y) in enumerate(source_locations):
-                rect = patches.Rectangle(
-                    (x, y), 1, 1,  # Unit size for each source tile
-                    linewidth=0.5, edgecolor='blue', facecolor='lightblue', alpha=0.4
-                )
-                ax.add_patch(rect)
-                if i < 3:  # Debug first few
-                    log.debug(f"  Source tile {i}: rectangle at ({x}, {y}) size (1, 1)")
-            
-            # Plot combined tiles as larger squares
-            log.debug(f"Drawing {len(combined_locations)} combined tile rectangles")
-            for i, (x, y) in enumerate(combined_locations):
-                rect = patches.Rectangle(
-                    (x, y), mag_ratio, mag_ratio,  # mag_ratio x mag_ratio size
-                    linewidth=2, edgecolor='red', facecolor='none', alpha=0.8
-                )
-                ax.add_patch(rect)
-                if i < 3:  # Debug first few  
-                    log.debug(f"  Combined tile {i}: rectangle at ({x}, {y}) size ({mag_ratio}, {mag_ratio})")
-            
-            # Set up the plot
-            ax.set_xlim(min_x - 1, max_x + mag_ratio + 1)
-            ax.set_ylim(min_y - 1, max_y + mag_ratio + 1)
-            ax.set_aspect('equal')
-            ax.invert_yaxis()  # Match image coordinate system
-            
-            # Set grid ticks to match mag_ratio for easy alignment verification
-            x_ticks = np.arange(min_x, max_x + mag_ratio + 1, mag_ratio)
-            y_ticks = np.arange(min_y, max_y + mag_ratio + 1, mag_ratio)
-            ax.set_xticks(x_ticks)
-            ax.set_yticks(y_ticks)
-            ax.grid(True, alpha=0.5, linewidth=1)  # Make grid more visible
-            
-            # Add minor ticks for individual source tiles
-            x_minor_ticks = np.arange(min_x, max_x + mag_ratio + 1, 1)
-            y_minor_ticks = np.arange(min_y, max_y + mag_ratio + 1, 1)
-            ax.set_xticks(x_minor_ticks, minor=True)
-            ax.set_yticks(y_minor_ticks, minor=True)
-            ax.grid(True, which='minor', alpha=0.2, linewidth=0.5)
-            
-            ax.set_title(f'Tile Alignment Check: {slide_name}\n'
-                        f'Blue: {source_mag} source tiles ({len(source_locations)}), '
-                        f'Red: {target_mag} combined tiles ({len(combined_locations)})\n'
-                        f'Major grid: {mag_ratio}x{mag_ratio} groups, Minor grid: individual tiles')
-            ax.set_xlabel('Grid X')
-            ax.set_ylabel('Grid Y')
-            
-            # Add legend
-            blue_patch = patches.Patch(color='lightblue', alpha=0.4, label=f'{source_mag} source tiles')
-            red_patch = patches.Patch(color='red', alpha=0.8, label=f'{target_mag} combined tiles') 
-            ax.legend(handles=[blue_patch, red_patch])
-            
-            # Save visualization
-            clean_slide_name = os.path.splitext(os.path.basename(slide_name))[0]
-            viz_filename = f"data/slides/thumbs/alignment_{clean_slide_name}_{source_mag}_to_{target_mag}.png"
-            os.makedirs(os.path.dirname(viz_filename), exist_ok=True)
-            
-            plt.savefig(viz_filename, dpi=150, bbox_inches='tight')
-            plt.close()
-            
-            return viz_filename
+            return params
             
         except Exception as e:
-            log.warning(f"Failed to create alignment visualization for {slide_name}: {e}")
-            return None
-        
+            return {}
+
     def _group_tiles_for_combination(self, locations: List[Tuple[int, int]], mag_ratio: int) -> Dict[Tuple[int, int], List[int]]:
         """Group tile locations into spatial regions for combination using grid coordinates."""
         groups = defaultdict(list)
@@ -2481,9 +2382,6 @@ class Dataset:
         # Sort locations to process in a consistent order
         sorted_locations = sorted(enumerate(grid_locations), key=lambda x: (x[1][1], x[1][0]))
         
-        log.debug(f"Converted {len(locations)} coordinate locations to grid indices")
-        log.debug(f"Will group tiles into {mag_ratio}x{mag_ratio} grids")
-        
         # Group tiles into mag_ratio x mag_ratio grids based on grid indices
         for idx, (grid_x, grid_y) in sorted_locations:
             # Calculate the top-left grid index of the group this tile belongs to
@@ -2491,11 +2389,6 @@ class Dataset:
             group_grid_y = (grid_y // mag_ratio) * mag_ratio
             group_key = (group_grid_x, group_grid_y)
             groups[group_key].append(idx)
-            
-        # Log some details about the grouping
-        log.debug(f"Created {len(groups)} tile groups from {len(locations)} tiles")
-        for group_key, indices in list(groups.items())[:5]:  # Show first 5 groups
-            log.debug(f"  Group {group_key}: {len(indices)} tiles")
             
         return dict(groups)
     
@@ -2514,9 +2407,6 @@ class Dataset:
         
         stride_x = min(x_coords[i+1] - x_coords[i] for i in range(len(x_coords)-1)) if len(x_coords) > 1 else 1
         stride_y = min(y_coords[i+1] - y_coords[i] for i in range(len(y_coords)-1)) if len(y_coords) > 1 else 1
-        
-        log.debug(f"Estimated tile stride: x={stride_x}, y={stride_y}")
-        log.debug(f"Grid origin at coordinates: ({min_x}, {min_y})")
         
         # Convert each coordinate to grid index
         grid_locations = []
@@ -2553,10 +2443,8 @@ class Dataset:
                         img_raw = img_raw.numpy()
                     example_tiles.append(img_raw)
                 except Exception as e:
-                    log.debug(f"Error extracting example tile {i}: {e}")
                     continue
             
-            log.debug(f"Collected {len(example_tiles)} example tiles from {tfrecord_path}")
             return example_tiles
             
         except Exception as e:
@@ -2566,7 +2454,6 @@ class Dataset:
     def _combine_tiles_from_group(self, tfrecord_path: str, tile_indices: List[int], mag_ratio: int) -> Optional[np.ndarray]:
         """Combine tiles from a spatial group into a single lower-magnification tile."""
         
-        log.debug(f"Loading {len(tile_indices)} tiles from {tfrecord_path}")
         tiles = []
         locations = []
         
@@ -2576,7 +2463,6 @@ class Dataset:
                 image_data = sf.io.decode_image(record['image_raw'])
                 tiles.append(image_data)
                 locations.append((record['loc_x'], record['loc_y']))
-                log.debug(f"  Loaded tile {i+1}/{len(tile_indices)}: index {idx}, location ({record['loc_x']}, {record['loc_y']}), shape {image_data.shape}")
             except Exception as e:
                 log.warning(f"Error loading tile {idx}: {str(e)}")
                 return None
@@ -2651,16 +2537,12 @@ class Dataset:
         
         # Calculate pixel coordinates for the combined tile
         grid_x, grid_y = grid_location
-        source_grid_locations = self._coords_to_grid_indices(source_locations)
         
         # Use tile indices directly to get the exact source tile coordinates
         if tile_indices:
             matching_source_locations = [source_locations[i] for i in tile_indices]
-            log.debug(f"Using tile indices {tile_indices[:5]}... to get {len(matching_source_locations)} source coordinates")
-            log.debug(f"Source coordinates sample: {matching_source_locations[:3]}")
         else:
             matching_source_locations = []
-            log.debug(f"No tile indices provided - source coordinates will be empty")
         
         if matching_source_locations:
             # Use average of matching source tiles as representative coordinate
@@ -2692,12 +2574,8 @@ class Dataset:
         # loc_x, loc_y: maintained for compatibility (target tile center)
         # source_locations_x, source_locations_y: individual source tile centers
         # target_location_x, target_location_y: combined tile center at target level
-        log.debug(f"Creating TFRecord with {len(matching_source_locations)} matching source locations")
-        if matching_source_locations:
-            log.debug(f"First 3 source locations: {matching_source_locations[:3]}")
         source_x_list = [loc[0] for loc in matching_source_locations] if matching_source_locations else [pixel_x]
         source_y_list = [loc[1] for loc in matching_source_locations] if matching_source_locations else [pixel_y]
-        log.debug(f"source_x_list length: {len(source_x_list)}, source_y_list length: {len(source_y_list)}")
         
         return sf.io.serialized_record(
             slide=bytes(slide_name, 'utf-8'),
@@ -2769,24 +2647,17 @@ class Dataset:
             )
 
             # -------- SOURCE centers: read directly from source TFRecord --------
-            log.debug(f"DEBUG: Creating source_thumb_coords for {slide_name}")
-            log.debug(f"DEBUG: original_locations count: {len(original_locations) if original_locations else 0}")
-            log.debug(f"DEBUG: r={r} (no loc_scale used)")
             
             if original_locations:
                 src_coords = [
                     (int(round(x / r)), int(round(y / r)))
                     for (x, y) in original_locations
                 ]
-                log.debug(f"DEBUG: Source coords - created {len(src_coords)} source coordinates")
-                log.debug(f"DEBUG: Source coords sample: {src_coords[:3]}")
                 slide_report.source_thumb_coords = np.array(src_coords, dtype=np.int64)
             else:
-                log.debug(f"DEBUG: No original_locations available")
                 slide_report.source_thumb_coords = None
 
             # -------- TARGET centers: read directly from target TFRecord --------
-            log.debug(f"DEBUG: Creating target_thumb_coords for {slide_name}")
             
             # Get target coordinates directly from target TFRecord
             tgt_centers = []
@@ -2797,13 +2668,7 @@ class Dataset:
                     import slideflow as sf
                     target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
                     tgt_centers = [(int(x), int(y)) for x, y in target_locations]
-                    log.debug(f"DEBUG: Target coords from TFRecord - created {len(tgt_centers)} coordinates")
-                    if tgt_centers:
-                        log.debug(f"DEBUG: Target coords sample: {tgt_centers[:3]}")
-                else:
-                    log.debug(f"DEBUG: Target TFRecord not found at {target_tfrecord_path}")
             except Exception as e:
-                log.debug(f"DEBUG: Error reading target coordinates: {e}")
                 # Fallback to derived coordinates if TFRecord reading fails
                 if combined_locations and original_locations:
                     stride_x_src, stride_y_src, origin_x_src, origin_y_src = _stride_origin_source(original_locations)
@@ -2838,8 +2703,6 @@ class Dataset:
                 data=report_data,
                 ignore_thumb_errors=True,
             )
-
-
     
     def _estimate_stride_and_origin(
         self,

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2533,6 +2533,16 @@ class Dataset:
                     
         writer.close()
 
+        # Check if any tiles were successfully combined
+        if combined_count == 0:
+            # Remove empty TFRecord file
+            if os.path.exists(output_path):
+                os.remove(output_path)
+                log.warning(f"No tiles were combined for {slide_name}. Removing file {output_path}")
+
+            # Return None for slide_report since no tiles were processed
+            return None, 0
+
         # Create index file immediately after writing so target coordinates can be read for reports
         if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
             try:
@@ -2542,12 +2552,12 @@ class Dataset:
                 log.warning(f"Failed to create index for {output_path}: {e}")
 
         # Create SlideReport with combined tile locations for visualization
-        combined_locations = [group_loc for group_loc in tile_groups.keys() 
+        combined_locations = [group_loc for group_loc in tile_groups.keys()
                             if len(tile_groups[group_loc]) == mag_ratio * mag_ratio]
-        
+
         # Collect example tiles from the output
         example_tiles = self._collect_example_tiles_from_tfrecord(output_path, max_examples=5)
-        
+
         # Create report data
         report_data = {
             'slide': slide_name,
@@ -2562,32 +2572,32 @@ class Dataset:
             'mag_ratio': mag_ratio,
             'locations': list(combined_locations)  # Ensure it stays as a list
         }
-        
+
         # Find the original slide path for thumbnail generation
         slide_path = self.find_slide(slide=slide_name)
         if slide_path and not os.path.exists(slide_path):
             log.warning(f"Slide path does not exist: {slide_path}")
             slide_path = None
-        
+
         # Create thumbnail coordinates for the existing WSI thumbnail system
         # Show original tile locations (where tiles were actually extracted from)
         thumb_coords = None
         if locations:
-            
+
             # Use only the original tile coordinates (these are known to be valid)
             all_coords = [(int(x), int(y)) for x, y in locations]
-            
+
             if all_coords:
                 # Convert to numpy array as expected by SlideReport
                 thumb_coords = np.array(all_coords, dtype=np.int64)
-                
+
                 # Verify coordinates are in the right format - should be (N, 2) array
                 if thumb_coords.ndim != 2 or thumb_coords.shape[1] != 2:
                     log.error(f"Invalid thumb_coords shape: {thumb_coords.shape}, expected (N, 2)")
                     thumb_coords = None
             else:
                 log.warning("No coordinates found for thumbnail generation")
-        
+
         # Create SlideReport using separate method
         slide_report = self._create_lower_mag_slide_report(
             slide_name=slide_name,
@@ -2828,7 +2838,8 @@ class Dataset:
         else:
             # For JPEG: use quality=100 and proper subsampling to avoid corruption
             # when encoding downsampled combined tiles
-            pil_image.save(img_bytes, format='JPEG', quality=100, subsampling=0, optimize=True)
+            # Note: optimize=True can cause issues with BytesIO, so it's omitted
+            pil_image.save(img_bytes, format='JPEG', quality=100, subsampling=0)
 
         # Ensure all data is written to buffer
         img_bytes.flush()
@@ -2841,14 +2852,16 @@ class Dataset:
         if tile_indices:
             matching_source_locations = [source_locations[i] for i in tile_indices]
         else:
+            log.debug("tile_indices is None or empty")
             matching_source_locations = []
-        
+
         if matching_source_locations:
             # Use average of matching source tiles as representative coordinate
             avg_x = sum(loc[0] for loc in matching_source_locations) // len(matching_source_locations)
             avg_y = sum(loc[1] for loc in matching_source_locations) // len(matching_source_locations)
             pixel_x, pixel_y = avg_x, avg_y
         else:
+            log.debug(f"Fallback: no matching source locations (tile_indices={tile_indices})")
             # Fallback: estimate coordinates from grid position and source data
             # Note: grid_x, grid_y are grid indices (0, 1, 2, ...), not pixel coordinates
             if source_locations:

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -92,6 +92,7 @@ import time
 import types
 import tempfile
 import warnings
+import glob
 from contextlib import contextmanager
 from collections import defaultdict
 from datetime import datetime
@@ -105,11 +106,13 @@ from pprint import pformat
 from functools import partial
 from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple,
                     Union, Callable)
+import io
 import numpy as np
 import pandas as pd
 import shapely.geometry as sg
 from rich.progress import track, Progress
 from tqdm import tqdm
+from PIL import Image
 
 import slideflow as sf
 from slideflow import errors
@@ -1925,7 +1928,8 @@ class Dataset:
 
         Returns:
             Dictionary mapping slide paths to each slide's SlideReport
-            (:class:`slideflow.slide.report.SlideReport`)
+            (:class:`slideflow.slide.report.SlideReport`). When report=True,
+            also generates an ExtractionReport PDF showing tile locations.
 
         Raises:
             DatasetError: If source_tile_um or target_tile_um are invalid, or if
@@ -1954,7 +1958,519 @@ class Dataset:
             - Each combined tile's coordinates (loc_x, loc_y) will correspond to the
               upper-left tile's coordinates from the original source TFRecords grid.
         """
-        pass
+        # Validate inputs
+        if isinstance(source_tile_um, str):
+            sf.util.assert_is_mag(source_tile_um)
+            source_mag = sf.util.to_mag(source_tile_um)
+        else:
+            source_mag = None
+            
+        if isinstance(target_tile_um, str):
+            sf.util.assert_is_mag(target_tile_um)
+            target_mag = sf.util.to_mag(target_tile_um)
+        else:
+            target_mag = None
+            
+        # Calculate magnification ratio for validation
+        if source_mag is not None and target_mag is not None:
+            mag_ratio = source_mag / target_mag
+            if not mag_ratio.is_integer() or mag_ratio < 1:
+                raise errors.DatasetError(
+                    f"Cannot combine {source_tile_um} tiles to create {target_tile_um} tiles. "
+                    f"Magnification ratio must be a positive integer (got {mag_ratio})"
+                )
+            mag_ratio = int(mag_ratio)
+        else:
+            # TODO
+            # For micron-based sizes, we'll need to calculate this later per slide
+            mag_ratio = None
+            
+        # Get source TFRecords
+        source_tfrecords = self.tfrecords(source=source)
+        if not source_tfrecords:
+            raise ValueError("No TFRecords found for processing")
+            
+        # Process each TFRecord
+        all_reports = []
+        
+        for tfrecord_path in source_tfrecords:
+            if skip_extracted:
+                # Check if output already exists
+                output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um)
+                if output_path and exists(output_path):
+                    log.info(f"Skipping {tfrecord_path} - already processed")
+                    continue
+                    
+            try:
+                report = self._process_single_tfrecord_for_lower_mag(
+                    tfrecord_path=tfrecord_path,
+                    source_tile_um=source_tile_um,
+                    target_tile_um=target_tile_um,
+                    mag_ratio=mag_ratio,
+                    **kwargs
+                )
+                all_reports.append(report)
+            except Exception as e:
+                log.error(f"Error processing {tfrecord_path}: {str(e)}")
+                continue
+                
+        # Update manifest after processing
+        self.update_manifest(force_update=True)
+        self.build_index(True)
+        
+        # Build index files for the new TFRecords
+        if all_reports:
+            try:
+                # Get the output directory path
+                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um)
+                if dummy_tfrecord_path:
+                    output_dir = os.path.dirname(dummy_tfrecord_path)
+                    log.debug(f"OUTPUT DIR: {output_dir}")
+                    if output_dir and os.path.exists(output_dir):
+                        # Find all TFRecord files in the output directory
+                        tfrecord_files = glob(os.path.join(output_dir, "*.tfrecords"))
+                        
+                        log.info(f"Building index files for {len(tfrecord_files)} TFRecord files")
+                        for tfr_path in tfrecord_files:
+                            try:
+                                _create_index(tfr_path, force=True)
+                            except Exception as e:
+                                log.warning(f"Failed to create index for {tfr_path}: {str(e)}")
+                        
+                        log.info(f"Built index files for {target_tile_um} magnification")
+                    else:
+                        log.warning(f"Could not find output directory for {target_tile_um}")
+                else:
+                    log.warning(f"Could not determine output directory for {target_tile_um}")
+            except Exception as e:
+                log.warning(f"Failed to build index files for {target_tile_um}: {str(e)}")
+        
+        # Filter out None reports
+        all_reports = [r for r in all_reports if r is not None]
+        
+        # Generate ExtractionReport PDF if requested
+        if all_reports and report:
+            try:
+                self._generate_tile_combination_report(
+                    all_reports, 
+                    source_tile_um, 
+                    target_tile_um, 
+                    mag_ratio
+                )
+            except Exception as e:
+                log.warning(f'Failed to generate extraction report: {str(e)}')
+        
+        return {report.path: report for report in all_reports}
+    
+    def _generate_tile_combination_report(
+        self, 
+        slide_reports: List["SlideReport"], 
+        source_tile_um: Union[int, str], 
+        target_tile_um: Union[int, str], 
+        mag_ratio: int
+    ) -> "ExtractionReport":
+        """Generate an ExtractionReport PDF showing combined tile locations."""
+        from datetime import datetime
+        from slideflow.slide.report import ExtractionReport
+        from types import SimpleNamespace
+        from os.path import dirname, join
+        
+        log.info('Generating tile combination extraction report...')
+        
+        timestring = datetime.now().strftime('%Y%m%d-%H%M%S')
+        
+        # Generate PDF report filename 
+        filename = f'tile_combination_report-{source_tile_um}_to_{target_tile_um}-{timestring}.pdf'
+        
+        # Get the output directory by using the same logic as TFRecord paths
+        dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um)
+        if dummy_tfrecord_path:
+            report_dir = dirname(dummy_tfrecord_path)
+            report_path = join(report_dir, filename)
+        else:
+            # Fallback to current directory
+            report_path = filename
+        
+        # Create metadata for the extraction report
+        meta = SimpleNamespace()
+        meta.tile_px = self.tile_px
+        meta.tile_um = target_tile_um
+        meta.source_mag = source_tile_um
+        meta.target_mag = target_tile_um
+        meta.mag_ratio = mag_ratio
+        # Log summary of results
+        successful_reports = [r for r in slide_reports if r.data and r.data.get('num_tiles', 0) > 0]
+        log.info(f"Successfully processed {len(successful_reports)} out of {len(slide_reports)} slides")
+        
+        if successful_reports:
+            total_combined = sum(r.data['num_tiles'] for r in successful_reports)
+            total_source = sum(r.data['total_source_tiles'] for r in successful_reports)
+            log.info(f"Combined {total_source} source tiles into {total_combined} target tiles")
+        
+        return slide_reports
+        
+    def _get_output_tfrecord_path(self, input_path: str, target_tile_um: Union[int, str]) -> Optional[str]:
+        """Generate output path for lower magnification TFRecord."""
+        try:
+            # Extract slide name from input path
+            slide_name = sf.util.path_to_name(input_path)
+            
+            # Get the appropriate tfrecord directory for target magnification
+            for source in self.sources:
+                if 'tfrecords' in self.sources[source]:
+                    tfrecord_dir = self.sources[source]['tfrecords']
+                    
+                    # Use the standard slideflow naming convention: {tile_px}px_{tile_um}
+                    if isinstance(target_tile_um, str):
+                        mag_suffix = f"{self.tile_px}px_{target_tile_um.lower()}"
+                    else:
+                        mag_suffix = f"{self.tile_px}px_{target_tile_um}um"
+                    
+                    # Create subdirectory for target magnification
+                    target_dir = join(tfrecord_dir, mag_suffix)
+                    return join(target_dir, f"{slide_name}.tfrecords")
+            return None
+        except Exception:
+            return None
+            
+    def _process_single_tfrecord_for_lower_mag(
+        self,
+        tfrecord_path: str,
+        source_tile_um: Union[int, str],
+        target_tile_um: Union[int, str],
+        mag_ratio: Optional[int],
+        **kwargs
+    ) -> Optional[SlideReport]:
+        """Process a single TFRecord to extract lower magnification tiles."""
+        
+        # Get locations and validate TFRecord has location data
+        if not sf.io.tfrecord_has_locations(tfrecord_path, check_x=True, check_y=True):
+            log.error(f"TFRecord {tfrecord_path} missing location data - skipping")
+            return None
+            
+        locations = sf.io.get_locations_from_tfrecord(tfrecord_path)
+        total_tiles = len(locations)
+        
+        if total_tiles == 0:
+            log.error(f"No tiles found in {tfrecord_path}")
+            return None
+            
+        # Get slide name
+        slide_name = sf.util.path_to_name(tfrecord_path)
+        
+        # If mag_ratio wasn't calculated, we need to determine it from actual tile data
+        if mag_ratio is None:
+            # TODO
+            # This would require accessing slide metadata to calculate the ratio
+            # For now, assume a 4:1 ratio (20x to 5x)
+            log.error(f"mag_ratio is None")
+            
+        # Group tiles by spatial regions that can form target tiles
+        tile_groups = self._group_tiles_for_combination(locations, mag_ratio)
+        
+        log.info(f"Processing {slide_name}: found {len(tile_groups)} potential tile groups from {total_tiles} source tiles")
+        complete_groups = sum(1 for indices in tile_groups.values() if len(indices) == mag_ratio * mag_ratio)
+        log.info(f"  {complete_groups} complete groups (each requiring {mag_ratio}x{mag_ratio}={mag_ratio*mag_ratio} tiles)")
+        
+        # Generate output path
+        output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um)
+        if not output_path:
+            log.error(f"Could not generate output path for {tfrecord_path}")
+            return None
+            
+        # Ensure output directory exists
+        os.makedirs(dirname(output_path), exist_ok=True)
+        log.debug(f"Writing combined tiles to: {output_path}")
+        
+        # Process tile groups and write combined tiles
+        combined_count = 0
+        writer = sf.io.TFRecordWriter(output_path)
+        
+        for group_loc, tile_indices in tile_groups.items():
+            if len(tile_indices) == mag_ratio * mag_ratio:  # Complete grid
+                try:
+                    log.info(f"Attempting to combine tile group at {group_loc} with {len(tile_indices)} tiles: {tile_indices}")
+                    combined_tile = self._combine_tiles_from_group(
+                        tfrecord_path, tile_indices, mag_ratio
+                    )
+                    if combined_tile is not None:
+                        # Write combined tile to output TFRecord
+                        img_format = kwargs.get('img_format', 'jpg')
+                        record = self._create_combined_tile_record(
+                            combined_tile, slide_name, group_loc, img_format
+                        )
+                        writer.write(record)
+                        combined_count += 1
+                        log.info(f"✓ Successfully combined tile group {combined_count} at location {group_loc}")
+                    else:
+                        log.warning(f"✗ Failed to combine tiles at {group_loc} - _combine_tiles_from_group returned None")
+                except Exception as e:
+                    log.warning(f"✗ Error combining tile group at {group_loc}: {str(e)}")
+                    import traceback
+                    log.debug(f"Full traceback: {traceback.format_exc()}")
+                    continue
+            else:
+                log.debug(f"Skipping incomplete group at {group_loc} with {len(tile_indices)} tiles (need {mag_ratio*mag_ratio})")
+                    
+        writer.close()
+        
+        # Note: Index files will be generated later by self.build_index(True) call
+        
+        # Create SlideReport with combined tile locations for visualization
+        combined_locations = [group_loc for group_loc in tile_groups.keys() 
+                            if len(tile_groups[group_loc]) == mag_ratio * mag_ratio]
+        
+        # Collect example tiles from the output
+        example_tiles = self._collect_example_tiles_from_tfrecord(output_path, max_examples=5)
+        
+        # Create report data
+        report_data = {
+            'slide': slide_name,
+            'num_tiles': combined_count,
+            'total_source_tiles': total_tiles,
+            'discarded_tiles': total_tiles - (combined_count * mag_ratio * mag_ratio),
+            'source_tiles_used': combined_count * mag_ratio * mag_ratio,
+            'incomplete_groups': len(tile_groups) - combined_count,
+            'source_mag': source_tile_um,
+            'target_mag': target_tile_um,
+            'mag_ratio': mag_ratio,
+            'locations': list(combined_locations)  # Ensure it stays as a list
+        }
+        
+        # Find the original slide path for thumbnail generation
+        slide_path = self.find_slide(slide=slide_name)
+        
+        # Scale coordinates from target magnification to source magnification for thumbnail
+        if len(combined_locations) > 0:
+            try:
+                # combined_locations are in target mag space, but thumbnail will be at source mag
+                # Scale by mag_ratio: source_mag / target_mag = mag_ratio
+                scaled_locations_int = [(int(x * mag_ratio), int(y * mag_ratio)) for x, y in combined_locations]
+                
+                # Ensure we have valid coordinates before creating array
+                if len(scaled_locations_int) > 0:
+                    thumb_coords = np.array(scaled_locations_int, dtype=np.int64)
+                    log.debug(f"Created thumb_coords numpy array: shape {thumb_coords.shape}, dtype {thumb_coords.dtype}")
+                    log.debug(f"Sample scaled coordinates (int): {scaled_locations_int[:3] if len(scaled_locations_int) >= 3 else scaled_locations_int}")
+                    
+                    # Final safety check - if array is malformed, set to None
+                    if thumb_coords.size == 0 or thumb_coords.ndim != 2 or thumb_coords.shape[1] != 2:
+                        log.warning(f"Malformed thumb_coords array: shape {thumb_coords.shape}, setting to empty array")
+                        thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
+                else:
+                    log.debug("No coordinates to scale, thumb_coords set to empty array")
+                    thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
+            except Exception as e:
+                log.warning(f"Error creating scaled thumb_coords: {e}, using empty array")
+                thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
+        else:
+            thumb_coords = np.empty((0, 2), dtype=np.int64)  # Empty array instead of None
+            log.debug("No combined locations, thumb_coords set to empty array")
+        
+        # Create the SlideReport - it will automatically create thumbnail with overlays
+        # Use source magnification for thumbnail since target may not exist in original slide
+        try:
+            log.debug(f"Creating SlideReport with:")
+            log.debug(f"  slide_path: {slide_path}")
+            log.debug(f"  source_tile_um: {source_tile_um}")
+            log.debug(f"  thumb_coords shape: {thumb_coords.shape if thumb_coords is not None else 'None'}")
+            log.debug(f"  example_tiles count: {len(example_tiles)}")
+            
+            # Create thumbnail at source magnification (which exists in original slide)
+            # The coordinates have been scaled to source magnification space
+            slide_report = SlideReport(
+                images=example_tiles,
+                path=slide_path if slide_path else slide_name,
+                tile_px=self.tile_px,
+                tile_um=source_tile_um,  # Use source magnification for thumbnail generation
+                data=report_data,
+                thumb_coords=thumb_coords,  # Properly formatted scaled coordinates
+                ignore_thumb_errors=False  # Don't ignore errors so we can see what's happening
+            )
+            log.debug("SlideReport created successfully with source magnification thumbnail")
+        except Exception as e:
+            log.error(f"Error creating SlideReport with thumbnail: {e}")
+            import traceback
+            log.debug(f"Full traceback: {traceback.format_exc()}")
+            # Fallback: create report without thumbnail
+            slide_report = SlideReport(
+                images=example_tiles,
+                path=slide_name,  # Use name only to skip thumbnail
+                tile_px=self.tile_px,
+                tile_um=source_tile_um,  # Keep consistent with main path
+                data=report_data,
+                ignore_thumb_errors=True
+            )
+        
+        log.info(
+            f"✓ Processed {slide_name}: combined {total_tiles} source tiles into "
+            f"{combined_count} target tiles ({report_data['discarded_tiles']} discarded)"
+        )
+        
+        return slide_report
+        
+    def _group_tiles_for_combination(self, locations: List[Tuple[int, int]], mag_ratio: int) -> Dict[Tuple[int, int], List[int]]:
+        """Group tile locations into spatial regions for combination using grid coordinates."""
+        groups = defaultdict(list)
+        
+        # Convert coordinates to grid indices for cleaner grouping
+        grid_locations = self._coords_to_grid_indices(locations)
+        
+        # Sort locations to process in a consistent order
+        sorted_locations = sorted(enumerate(grid_locations), key=lambda x: (x[1][1], x[1][0]))
+        
+        log.debug(f"Converted {len(locations)} coordinate locations to grid indices")
+        log.debug(f"Will group tiles into {mag_ratio}x{mag_ratio} grids")
+        
+        # Group tiles into mag_ratio x mag_ratio grids based on grid indices
+        for idx, (grid_x, grid_y) in sorted_locations:
+            # Calculate the top-left grid index of the group this tile belongs to
+            group_grid_x = (grid_x // mag_ratio) * mag_ratio
+            group_grid_y = (grid_y // mag_ratio) * mag_ratio
+            group_key = (group_grid_x, group_grid_y)
+            groups[group_key].append(idx)
+            
+        # Log some details about the grouping
+        log.debug(f"Created {len(groups)} tile groups from {len(locations)} tiles")
+        for group_key, indices in list(groups.items())[:5]:  # Show first 5 groups
+            log.debug(f"  Group {group_key}: {len(indices)} tiles")
+            
+        return dict(groups)
+    
+    def _coords_to_grid_indices(self, locations: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+        """Convert coordinate locations to grid indices."""
+        if len(locations) <= 1:
+            return [(0, 0)] * len(locations)
+        
+        # Find the minimum coordinates to use as origin
+        min_x = min(loc[0] for loc in locations)
+        min_y = min(loc[1] for loc in locations)
+        
+        # Estimate tile stride by finding minimum distance between tiles
+        x_coords = sorted(set(loc[0] for loc in locations))
+        y_coords = sorted(set(loc[1] for loc in locations))
+        
+        stride_x = min(x_coords[i+1] - x_coords[i] for i in range(len(x_coords)-1)) if len(x_coords) > 1 else 1
+        stride_y = min(y_coords[i+1] - y_coords[i] for i in range(len(y_coords)-1)) if len(y_coords) > 1 else 1
+        
+        log.debug(f"Estimated tile stride: x={stride_x}, y={stride_y}")
+        log.debug(f"Grid origin at coordinates: ({min_x}, {min_y})")
+        
+        # Convert each coordinate to grid index
+        grid_locations = []
+        for x, y in locations:
+            grid_x = (x - min_x) // stride_x
+            grid_y = (y - min_y) // stride_y
+            grid_locations.append((grid_x, grid_y))
+            
+        return grid_locations
+    
+    def _collect_example_tiles_from_tfrecord(self, tfrecord_path: str, max_examples: int = 5) -> List[bytes]:
+        """Collect example tile images from the TFRecord for the report."""
+        from slideflow.io import TFRecordDataset, get_tfrecord_parser
+       
+        try:
+            if not os.path.exists(tfrecord_path):
+                log.warning(f"TFRecord not found for examples: {tfrecord_path}")
+                return []
+            
+            example_tiles = []
+            dataset = TFRecordDataset(tfrecord_path)
+            parser = get_tfrecord_parser(tfrecord_path, ('image_raw',), decode_images=False)
+            
+            for i, record in enumerate(dataset):
+                if i>= max_examples:
+                    break
+                try:
+                    # Extract image from TFRecord
+                    parsed = parser(record)
+                    img_raw = parsed[0]
+
+                    #Convert to bytes
+                    if hasattr(img_raw, 'numpy'):
+                        img_raw = img_raw.numpy()
+                    example_tiles.append(img_raw)
+                except Exception as e:
+                    log.debug(f"Error extracting example tile {i}: {e}")
+                    continue
+            
+            log.debug(f"Collected {len(example_tiles)} example tiles from {tfrecord_path}")
+            return example_tiles
+            
+        except Exception as e:
+            log.warning(f"Error collecting example tiles: {e}")
+            return []
+        
+    def _combine_tiles_from_group(self, tfrecord_path: str, tile_indices: List[int], mag_ratio: int) -> Optional[np.ndarray]:
+        """Combine tiles from a spatial group into a single lower-magnification tile."""
+        
+        log.debug(f"Loading {len(tile_indices)} tiles from {tfrecord_path}")
+        tiles = []
+        locations = []
+        
+        for i, idx in enumerate(tile_indices):
+            try:
+                record = sf.io.get_tfrecord_by_index(tfrecord_path, idx)
+                image_data = sf.io.decode_image(record['image_raw'])
+                tiles.append(image_data)
+                locations.append((record['loc_x'], record['loc_y']))
+                log.debug(f"  Loaded tile {i+1}/{len(tile_indices)}: index {idx}, location ({record['loc_x']}, {record['loc_y']}), shape {image_data.shape}")
+            except Exception as e:
+                log.warning(f"Error loading tile {idx}: {str(e)}")
+                return None
+                
+        if len(tiles) != mag_ratio * mag_ratio:
+            log.warning(f"Expected {mag_ratio * mag_ratio} tiles but got {len(tiles)}")
+            return None
+            
+        # Arrange tiles in spatial order and combine
+        tile_size = tiles[0].shape[0]  # Assume square tiles
+        combined_size = tile_size * mag_ratio
+        combined_tile = np.zeros((combined_size, combined_size, 3), dtype=np.uint8)
+        
+        # Get locations for proper tile arrangement
+        locations = []
+        for idx in tile_indices:
+            record = sf.io.get_tfrecord_by_index(tfrecord_path, idx)
+            locations.append((record['loc_x'], record['loc_y']))
+            
+        # Sort tiles by location
+        tile_loc_pairs = list(zip(tiles, locations))
+        tile_loc_pairs.sort(key=lambda x: (x[1][1], x[1][0]))  # Sort by y, then x
+        
+        # Place tiles in the combined image
+        for i, (tile_img, _) in enumerate(tile_loc_pairs):
+            row = i // mag_ratio
+            col = i % mag_ratio
+            y_start = row * tile_size
+            y_end = y_start + tile_size
+            x_start = col * tile_size
+            x_end = x_start + tile_size
+            combined_tile[y_start:y_end, x_start:x_end] = tile_img
+            
+        return combined_tile
+        
+    def _create_combined_tile_record(self, tile_image: np.ndarray, slide_name: str, location: Tuple[int, int], img_format: str) -> bytes:
+        """Create a TFRecord for a combined tile."""
+        
+        # Convert numpy array to image bytes
+        pil_image = Image.fromarray(tile_image)
+        img_bytes = io.BytesIO()
+        
+        if img_format.lower() == 'png':
+            pil_image.save(img_bytes, format='PNG')
+        else:
+            pil_image.save(img_bytes, format='JPEG', quality=95)
+            
+        img_bytes = img_bytes.getvalue()
+        
+        # Create record
+        return sf.io.serialized_record(
+            slide=bytes(slide_name, 'utf-8'),
+            image_raw=img_bytes,
+            loc_x=location[0],
+            loc_y=location[1]
+        )
 
     def extract_tiles_from_tfrecords(self, dest: str) -> None:
         """Extract tiles from a set of TFRecords.

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1961,7 +1961,8 @@ class Dataset:
         # Validate and calculate magnification ratio
         source_mag = sf.util.to_mag(source_tile_um) if isinstance(source_tile_um, str) else None
         target_mag = sf.util.to_mag(target_tile_um) if isinstance(target_tile_um, str) else None
-        
+        target_tile_px = int(kwargs.get('target_tile_px', 224))
+
         if source_mag and target_mag:
             mag_ratio = source_mag / target_mag
             if not mag_ratio.is_integer() or mag_ratio < 1:
@@ -1981,7 +1982,7 @@ class Dataset:
         for tfrecord_path in source_tfrecords:
             if skip_extracted:
                 # Check if output already exists
-                output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um)
+                output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px)
                 if output_path and exists(output_path):
                     log.info(f"Skipping {tfrecord_path} - already processed")
                     continue
@@ -2007,7 +2008,7 @@ class Dataset:
         if all_reports:
             try:
                 # Get the output directory path
-                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um)
+                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px)
                 if dummy_tfrecord_path:
                     output_dir = os.path.dirname(dummy_tfrecord_path)
                     log.debug(f"OUTPUT DIR: {output_dir}")
@@ -2035,24 +2036,22 @@ class Dataset:
         
         return {report.path: report for report in all_reports}
     
-    def _get_output_tfrecord_path(self, input_path: str, target_tile_um: Union[int, str]) -> Optional[str]:
-        """Generate output path for lower magnification TFRecord."""
+    def _get_output_tfrecord_path(
+        self,
+        input_path: str,
+        target_tile_um: Union[int, str],
+        target_tile_px: Optional[int] = None
+    ) -> Optional[str]:
         try:
-            # Extract slide name from input path
             slide_name = sf.util.path_to_name(input_path)
-            
-            # Get the appropriate tfrecord directory for target magnification
             for source in self.sources:
                 if 'tfrecords' in self.sources[source]:
                     tfrecord_dir = self.sources[source]['tfrecords']
-                    
-                    # Use the standard slideflow naming convention: {tile_px}px_{tile_um}
+                    px = int(target_tile_px) if target_tile_px is not None else int(self.tile_px)
                     if isinstance(target_tile_um, str):
-                        mag_suffix = f"{self.tile_px}px_{target_tile_um.lower()}"
+                        mag_suffix = f"{px}px_{target_tile_um.lower()}"
                     else:
-                        mag_suffix = f"{self.tile_px}px_{target_tile_um}um"
-                    
-                    # Create subdirectory for target magnification
+                        mag_suffix = f"{px}px_{target_tile_um}um"
                     target_dir = join(tfrecord_dir, mag_suffix)
                     return join(target_dir, f"{slide_name}.tfrecords")
             return None
@@ -2092,13 +2091,14 @@ class Dataset:
             
         # Group tiles by spatial regions that can form target tiles
         tile_groups = self._group_tiles_for_combination(locations, mag_ratio)
-        
+        target_tile_px = int(kwargs.get('target_tile_px', 224))
+
         log.info(f"Processing {slide_name}: found {len(tile_groups)} potential tile groups from {total_tiles} source tiles")
         complete_groups = sum(1 for indices in tile_groups.values() if len(indices) == mag_ratio * mag_ratio)
         log.info(f"  {complete_groups} complete groups (each requiring {mag_ratio}x{mag_ratio}={mag_ratio*mag_ratio} tiles)")
         
         # Generate output path
-        output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um)
+        output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px)
         if not output_path:
             log.error(f"Could not generate output path for {tfrecord_path}")
             return None
@@ -2122,7 +2122,8 @@ class Dataset:
                         # Write combined tile to output TFRecord
                         img_format = kwargs.get('img_format', 'jpg')
                         record = self._create_combined_tile_record(
-                            combined_tile, slide_name, group_loc, img_format
+                            combined_tile, slide_name, group_loc, locations, mag_ratio, img_format,
+                            target_tile_px=target_tile_px
                         )
                         writer.write(record)
                         combined_count += 1
@@ -2217,6 +2218,24 @@ class Dataset:
         
         return slide_report
     
+    def _resize_square_np(
+            self,
+            tile_image: np.ndarray, 
+            target_px: int) -> np.ndarray:
+        """Resize a HxWxC uint8 image to target_px x target_px (RGB)."""
+        if tile_image.ndim == 2:
+            mode = "L"
+        elif tile_image.shape[2] == 4:
+            # drop alpha; or keep if your pipelines support RGBA
+            tile_image = tile_image[:, :, :3]
+            mode = "RGB"
+        else:
+            mode = "RGB"
+        pil = Image.fromarray(tile_image, mode=mode)
+        # LANCZOS is high-quality for big downsampling (e.g., 2048 -> 224)
+        pil = pil.resize((target_px, target_px), resample=Image.LANCZOS)
+        return np.array(pil, dtype=np.uint8)
+
     def _create_alignment_visualization(
         self, 
         slide_name: str,
@@ -2459,26 +2478,84 @@ class Dataset:
             
         return combined_tile
         
-    def _create_combined_tile_record(self, tile_image: np.ndarray, slide_name: str, location: Tuple[int, int], img_format: str) -> bytes:
-        """Create a TFRecord for a combined tile."""
-        
-        # Convert numpy array to image bytes
+    def _create_combined_tile_record(
+        self,
+        tile_image: np.ndarray,
+        slide_name: str,
+        grid_location: Tuple[int, int],
+        source_locations: List[Tuple[int, int]],
+        mag_ratio: int,
+        img_format: str,
+        target_tile_px: int,          # <-- NEW
+    ) -> bytes:
+        # ensure 224x224 (or whatever you requested)
+        tile_image = self._resize_square_np(tile_image, target_tile_px)
+
+        # (optional) assert it is 224x224
+        h, w = tile_image.shape[:2]
+        assert (h, w) == (target_tile_px, target_tile_px), f"Unexpected size {w}x{h}"
+
+        # then encode as before
         pil_image = Image.fromarray(tile_image)
         img_bytes = io.BytesIO()
-        
         if img_format.lower() == 'png':
             pil_image.save(img_bytes, format='PNG')
         else:
             pil_image.save(img_bytes, format='JPEG', quality=95)
-            
         img_bytes = img_bytes.getvalue()
         
-        # Create record
+        # Convert grid location back to pixel coordinates 
+        # Use the center pixel coordinate that this combined tile represents
+        grid_x, grid_y = grid_location
+        
+        # Calculate the pixel coordinate bounds this combined tile represents
+        source_grid_locations = self._coords_to_grid_indices(source_locations)
+        
+        # Get the actual source locations that belong to this combined tile group
+        matching_source_locations = []
+        for i, (src_grid_x, src_grid_y) in enumerate(source_grid_locations):
+            # Check if this source tile belongs to the current combined tile grid
+            target_grid_x = src_grid_x // mag_ratio
+            target_grid_y = src_grid_y // mag_ratio
+            
+            if target_grid_x == grid_x and target_grid_y == grid_y:
+                matching_source_locations.append(source_locations[i])
+        
+        if matching_source_locations:
+            # Use the center/average of the matching source tiles as the representative coordinate
+            avg_x = sum(loc[0] for loc in matching_source_locations) // len(matching_source_locations)
+            avg_y = sum(loc[1] for loc in matching_source_locations) // len(matching_source_locations)
+            pixel_x, pixel_y = avg_x, avg_y
+            log.debug(f"Found {len(matching_source_locations)} matching tiles for grid {grid_location}, avg coord: ({pixel_x}, {pixel_y})")
+        else:
+            # This shouldn't happen, but use a reasonable fallback
+            log.warning(f"Could not find representative source tile for grid location {grid_location}")
+            log.debug(f"Source grid locations sample: {source_grid_locations[:5]}")
+            
+            # Simple fallback: convert grid to estimated pixel coordinates
+            # The target tile should be at the center of the region covered by source tiles
+            if source_locations:
+                # Calculate stride from source coordinates
+                x_coords = sorted(set(loc[0] for loc in source_locations))
+                y_coords = sorted(set(loc[1] for loc in source_locations))
+                stride_x = min(x_coords[i+1] - x_coords[i] for i in range(len(x_coords)-1)) if len(x_coords) > 1 else 512
+                stride_y = min(y_coords[i+1] - y_coords[i] for i in range(len(y_coords)-1)) if len(y_coords) > 1 else 512
+                min_x, min_y = min(x_coords), min(y_coords)
+                
+                # Convert grid location to pixel coordinates at source scale
+                # Don't multiply by mag_ratio since we want coordinates in the same space as source
+                pixel_x = min_x + grid_x * stride_x
+                pixel_y = min_y + grid_y * stride_y
+                log.debug(f"Estimated pixel coord from grid {grid_location}: ({pixel_x}, {pixel_y}) using stride ({stride_x}, {stride_y})")
+            else:
+                pixel_x, pixel_y = grid_x, grid_y
+        
+        # Create record with pixel coordinates (same system as source tiles)
         return sf.io.serialized_record(
             slide=bytes(slide_name, 'utf-8'),
             image_raw=img_bytes,
-            loc_x=location[0],
-            loc_y=location[1]
+            loc_x=pixel_x,
+            loc_y=pixel_y
         )
 
     def extract_tiles_from_tfrecords(self, dest: str) -> None:

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2294,6 +2294,14 @@ class Dataset:
             ## throw an error that target_tile_px cannot be none
             raise errors.DatasetError("target_tile_px cannot be None")
 
+        # Validate that tile_um is an integer (microns), not a string magnification
+        if not isinstance(self.tile_um, int):
+            raise errors.DatasetError(
+                f"extract_lower_mag_tiles_from_tfr only supports integer tile_um (microns), "
+                f"not string magnifications. Got tile_um={self.tile_um!r} (type: {type(self.tile_um).__name__}). "
+                f"Please set tile_um to an integer value in microns (e.g., 112 for 20x at 224px)."
+            )
+
         # Convert tile_um to integer microns at the beginning
         # Uses mpp from kwargs if provided, otherwise calculates from magnification power
         mpp = kwargs.get('mpp', None)

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2356,6 +2356,7 @@ class Dataset:
                             source_tile_um=source_tile_um,
                             target_tile_um=target_tile_um,
                             mag_ratio=mag_ratio,
+                            target_tile_px=target_tile_px,
                             **kwargs
                         )
                         src_reports.append(report)
@@ -2514,9 +2515,9 @@ class Dataset:
             
         # Read coordinates from source TFRecord (the original high-mag tiles)
         source_locations = sf.io.get_locations_from_tfrecord(tfrecord_path)
-        
-        # Try to read target TFRecord coordinates (the newly created low-mag tiles)
-        target_tile_px = kwargs.get('target_tile_px')
+
+        # Get target_tile_px from kwargs (required parameter, should always be provided)
+        target_tile_px = int(kwargs.get('target_tile_px'))
         # Use source locations for processing (this is what we're extracting FROM)
         locations = source_locations
             
@@ -2541,7 +2542,6 @@ class Dataset:
 
         # Group tiles by spatial regions that can form target tiles
         tile_groups = self._group_tiles_for_combination(locations, mag_ratio)
-        target_tile_px = int(kwargs.get('target_tile_px', 224))
         complete_groups = sum(1 for indices in tile_groups.values() if len(indices) == mag_ratio * mag_ratio)
 
         # Generate output path (will raise DatasetError if unable to determine path)

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1956,7 +1956,7 @@ class Dataset:
             - The function preserves slide names and updates coordinates appropriately
               for the new magnification level.
             - Each combined tile's coordinates (loc_x, loc_y) will correspond to the
-              upper-left tile's coordinates from the original source TFRecords grid.
+              center/average coordinates of the source tiles that make up each combined tile.
         """
         # Validate and calculate magnification ratio
         source_mag = sf.util.to_mag(source_tile_um) if isinstance(source_tile_um, str) else None
@@ -2486,16 +2486,26 @@ class Dataset:
         source_locations: List[Tuple[int, int]],
         mag_ratio: int,
         img_format: str,
-        target_tile_px: int,          # <-- NEW
+        target_tile_px: int,
     ) -> bytes:
-        # ensure 224x224 (or whatever you requested)
+        """Create a TFRecord for a combined tile.
+        
+        Args:
+            tile_image: Combined tile image as numpy array
+            slide_name: Name of the slide
+            grid_location: Grid coordinates (x, y) of the combined tile
+            source_locations: List of pixel coordinates from source tiles
+            mag_ratio: Magnification ratio (e.g., 4 for 40x->10x)
+            img_format: Image format ('png' or 'jpeg')
+            target_tile_px: Target tile size in pixels
+            
+        Returns:
+            Serialized TFRecord bytes
+        """
+        # ensure correct tile px size
         tile_image = self._resize_square_np(tile_image, target_tile_px)
 
-        # (optional) assert it is 224x224
-        h, w = tile_image.shape[:2]
-        assert (h, w) == (target_tile_px, target_tile_px), f"Unexpected size {w}x{h}"
-
-        # then encode as before
+        # Encode image to PIL
         pil_image = Image.fromarray(tile_image)
         img_bytes = io.BytesIO()
         if img_format.lower() == 'png':
@@ -2504,49 +2514,36 @@ class Dataset:
             pil_image.save(img_bytes, format='JPEG', quality=95)
         img_bytes = img_bytes.getvalue()
         
-        # Convert grid location back to pixel coordinates 
-        # Use the center pixel coordinate that this combined tile represents
+        # Calculate pixel coordinates for the combined tile
         grid_x, grid_y = grid_location
-        
-        # Calculate the pixel coordinate bounds this combined tile represents
         source_grid_locations = self._coords_to_grid_indices(source_locations)
         
-        # Get the actual source locations that belong to this combined tile group
+        # Find source tiles that belong to this combined tile group
         matching_source_locations = []
         for i, (src_grid_x, src_grid_y) in enumerate(source_grid_locations):
-            # Check if this source tile belongs to the current combined tile grid
-            target_grid_x = src_grid_x // mag_ratio
-            target_grid_y = src_grid_y // mag_ratio
-            
-            if target_grid_x == grid_x and target_grid_y == grid_y:
+            if (grid_x <= src_grid_x < grid_x + mag_ratio and 
+                grid_y <= src_grid_y < grid_y + mag_ratio):
                 matching_source_locations.append(source_locations[i])
         
         if matching_source_locations:
-            # Use the center/average of the matching source tiles as the representative coordinate
+            # Use average of matching source tiles as representative coordinate
             avg_x = sum(loc[0] for loc in matching_source_locations) // len(matching_source_locations)
             avg_y = sum(loc[1] for loc in matching_source_locations) // len(matching_source_locations)
             pixel_x, pixel_y = avg_x, avg_y
-            log.debug(f"Found {len(matching_source_locations)} matching tiles for grid {grid_location}, avg coord: ({pixel_x}, {pixel_y})")
         else:
-            # This shouldn't happen, but use a reasonable fallback
-            log.warning(f"Could not find representative source tile for grid location {grid_location}")
-            log.debug(f"Source grid locations sample: {source_grid_locations[:5]}")
-            
-            # Simple fallback: convert grid to estimated pixel coordinates
-            # The target tile should be at the center of the region covered by source tiles
+            # Fallback: estimate coordinates from grid position and source data
             if source_locations:
-                # Calculate stride from source coordinates
                 x_coords = sorted(set(loc[0] for loc in source_locations))
                 y_coords = sorted(set(loc[1] for loc in source_locations))
                 stride_x = min(x_coords[i+1] - x_coords[i] for i in range(len(x_coords)-1)) if len(x_coords) > 1 else 512
                 stride_y = min(y_coords[i+1] - y_coords[i] for i in range(len(y_coords)-1)) if len(y_coords) > 1 else 512
                 min_x, min_y = min(x_coords), min(y_coords)
                 
-                # Convert grid location to pixel coordinates at source scale
-                # Don't multiply by mag_ratio since we want coordinates in the same space as source
-                pixel_x = min_x + grid_x * stride_x
-                pixel_y = min_y + grid_y * stride_y
-                log.debug(f"Estimated pixel coord from grid {grid_location}: ({pixel_x}, {pixel_y}) using stride ({stride_x}, {stride_y})")
+                # Place at center of the mag_ratio x mag_ratio region
+                center_offset_x = (mag_ratio - 1) * stride_x // 2
+                center_offset_y = (mag_ratio - 1) * stride_y // 2
+                pixel_x = min_x + grid_x * stride_x + center_offset_x
+                pixel_y = min_y + grid_y * stride_y + center_offset_y
             else:
                 pixel_x, pixel_y = grid_x, grid_y
         

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1893,45 +1893,78 @@ class Dataset:
         all_reports = [r for r in all_reports if r is not None]
         return {report.path: report for report in all_reports}
 
-    def _validate_lower_mag_params(self, mag_ratio: int) -> int:
+    def _parse_tile_um_to_microns(self, tile_um_value: Union[int, str], tile_px: int, mpp: Optional[float] = None) -> int:
+        """Convert tile_um (str like '40x' or int like 129) to integer microns.
+
+        Args:
+            tile_um_value: Either a string like "40x" or an integer in microns
+            tile_px: Tile size in pixels
+            mpp: Optional microns per pixel. If provided, uses this for conversion.
+                 If not provided, calculates from magnification power using standard formula.
+
+        Returns:
+            Integer microns for the full tile
+
+        Raises:
+            DatasetError: If tile_um_value format is invalid
+        """
+        if isinstance(tile_um_value, str):
+            tile_str = tile_um_value.strip().lower()
+            if tile_str.endswith('x'):
+                # Parse magnification power (e.g., "40x")
+                try:
+                    mag_power = float(tile_str[:-1])
+                except ValueError:
+                    raise errors.DatasetError(f"Invalid magnification string: {tile_um_value}")
+
+                # Calculate um per pixel
+                if mpp is not None:
+                    # Use provided mpp
+                    um_per_pixel = mpp
+                else:
+                    # Standard formula: um/px = 10 / mag_power
+                    # 40x → 0.25 um/px, 20x → 0.5 um/px, 10x → 1.0 um/px
+                    um_per_pixel = 10.0 / mag_power
+
+                # Calculate total um for tile
+                return int(round(um_per_pixel * tile_px))
+            elif tile_str.endswith('um'):
+                try:
+                    return int(tile_str[:-2])
+                except ValueError:
+                    raise errors.DatasetError(f"Invalid um string: {tile_um_value}")
+            else:
+                try:
+                    return int(tile_str)
+                except ValueError:
+                    raise errors.DatasetError(f"Cannot parse tile_um: {tile_um_value}")
+        else:
+            # Already an integer in microns
+            return int(tile_um_value)
+
+    def _validate_lower_mag_params(self, mag_ratio: int, source_tile_um: int) -> int:
         """Validate magnification ratio and calculate target magnification.
 
         Args:
-            mag_ratio: Magnification ratio (how many source tiles per target tile)
+            mag_ratio: Linear magnification ratio (e.g., 4 for 40x→10x or 112um→448um)
+            source_tile_um: Source tile size in microns (integer)
 
         Returns:
             target_tile_um: Calculated target magnification as an integer (in um)
 
         Raises:
-            DatasetError: If magnification parameters are invalid or ratio doesn't form a perfect square
+            DatasetError: If magnification parameters are invalid
         """
-        # Validate that dataset has tile_um set
-        if self.tile_um is None:
-            raise errors.DatasetError("Dataset tile_um must be set before calling extract_lower_mag_tiles_from_tfr")
-
-        # Get source tile_um from dataset
-        source_tile_um = self.tile_um
-
         # Validate mag_ratio
         if not isinstance(mag_ratio, int) or mag_ratio < 1:
             raise errors.DatasetError(f"mag_ratio must be a positive integer, got {mag_ratio}")
 
-        # Validate that the ratio forms a perfect square (required for tile concatenation)
-        # For example: ratio 4 means 4x4 grid ✓
-        #              ratio 3 is not a perfect square ✗
-        sqrt_ratio = mag_ratio ** 0.5
-        if not sqrt_ratio.is_integer():
-            raise errors.DatasetError(
-                f"Invalid mag_ratio: {mag_ratio}. "
-                f"Ratio must be a perfect square for tile concatenation (e.g., 1, 4, 9, 16). "
-                f"Valid examples: 20um with ratio=4 → 80um (4×4 grid), 10um with ratio=16 → 160um (16×16 grid)"
-            )
-
-        # Calculate target magnification
+        # Calculate target magnification (multiply um values by linear ratio)
+        # Example: 112um with ratio 4 → 448um
         target_um = source_tile_um * mag_ratio
 
         # Validate that target_um is reasonable (positive integer)
-        if not isinstance(target_um, int) or target_um <= 0:
+        if target_um <= 0:
             raise errors.DatasetError(
                 f"Invalid result: {source_tile_um}um with ratio {mag_ratio} produces "
                 f"target magnification {target_um}um"
@@ -2188,6 +2221,7 @@ class Dataset:
         self,
         *,
         mag_ratio: int,
+        target_tile_px: int,
         source: Optional[str] = None,
         skip_extracted: bool = True,
         report: bool = True,
@@ -2249,11 +2283,20 @@ class Dataset:
             - Each combined tile's coordinates (loc_x, loc_y) will correspond to the
               center/average coordinates of the source tiles that make up each combined tile.
         """
-        # Validate parameters and calculate target magnification
-        target_tile_um = self._validate_lower_mag_params(mag_ratio)
-        source_tile_um = self.tile_um
-        target_tile_px = int(kwargs.get('target_tile_px', 224))
+        # Validate that dataset has tile_um set
+        if self.tile_um is None:
+            raise errors.DatasetError("Dataset tile_um must be set before calling extract_lower_mag_tiles_from_tfr")
+        if not target_tile_px:
+            ## throw an error that target_tile_px cannot be none
+            raise errors.DatasetError("target_tile_px cannot be None")
 
+        # Convert tile_um to integer microns at the beginning
+        # Uses mpp from kwargs if provided, otherwise calculates from magnification power
+        mpp = kwargs.get('mpp', None)
+        source_tile_um = self._parse_tile_um_to_microns(self.tile_um, self.tile_px, mpp=mpp)
+
+        # Validate parameters and calculate target magnification
+        target_tile_um = self._validate_lower_mag_params(mag_ratio, source_tile_um)
         # Get source TFRecords for processing
         source_tfrecords = self._get_lower_mag_tfrecords(source=source)
 
@@ -2782,16 +2825,22 @@ class Dataset:
             pixel_x, pixel_y = avg_x, avg_y
         else:
             # Fallback: estimate coordinates from grid position and source data
+            # Note: grid_x, grid_y are grid indices (0, 1, 2, ...), not pixel coordinates
             if source_locations:
                 x_coords = sorted(set(loc[0] for loc in source_locations))
                 y_coords = sorted(set(loc[1] for loc in source_locations))
                 stride_x = min(x_coords[i+1] - x_coords[i] for i in range(len(x_coords)-1)) if len(x_coords) > 1 else 512
                 stride_y = min(y_coords[i+1] - y_coords[i] for i in range(len(y_coords)-1)) if len(y_coords) > 1 else 512
                 min_x, min_y = min(x_coords), min(y_coords)
-                
-                # Place at center of the mag_ratio x mag_ratio region
+
+                # Calculate the center of the mag_ratio x mag_ratio region
+                # grid_x, grid_y represent the top-left grid index of the combined block
+                # Each grid cell is stride_x × stride_y pixels
+                # The block spans from grid_x to (grid_x + mag_ratio - 1)
+                # Center is at grid_x + (mag_ratio - 1) / 2
                 center_offset_x = (mag_ratio - 1) * stride_x // 2
                 center_offset_y = (mag_ratio - 1) * stride_y // 2
+                # Convert grid position to pixel position
                 pixel_x = min_x + grid_x * stride_x + center_offset_x
                 pixel_y = min_y + grid_y * stride_y + center_offset_y
             else:
@@ -2867,18 +2916,15 @@ class Dataset:
             )
 
             # -------- SOURCE centers: read directly from source TFRecord --------
-            
+            # Source coordinates are already in pixel space, no scaling needed
             if original_locations:
-                src_coords = [
-                    (int(round(x / r)), int(round(y / r)))
-                    for (x, y) in original_locations
-                ]
+                src_coords = [(int(round(x)), int(round(y))) for (x, y) in original_locations]
                 slide_report.source_thumb_coords = np.array(src_coords, dtype=np.int64)
             else:
                 slide_report.source_thumb_coords = None
 
             # -------- TARGET centers: read directly from target TFRecord --------
-            
+
             # Get target coordinates directly from target TFRecord
             tgt_centers = []
             try:
@@ -2888,18 +2934,31 @@ class Dataset:
                     import slideflow as sf
                     target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
                     tgt_centers = [(int(x), int(y)) for x, y in target_locations]
+                    log.debug(f"DEBUG: Successfully read {len(tgt_centers)} target coordinates from {target_tfrecord_path}")
+                else:
+                    log.debug(f"DEBUG: Target TFRecord path does not exist or is None: {target_tfrecord_path}")
             except Exception as e:
                 # Fallback to derived coordinates if TFRecord reading fails
-                if combined_locations and original_locations:
-                    stride_x_src, stride_y_src, origin_x_src, origin_y_src = _stride_origin_source(original_locations)
-                    log.debug(f"DEBUG: Fallback - calculated stride_src: ({stride_x_src}, {stride_y_src}), origin_src: ({origin_x_src}, {origin_y_src})")
-                    half_block_x = ((r - 1) * stride_x_src) / 2.0
-                    half_block_y = ((r - 1) * stride_y_src) / 2.0
-                    for gx, gy in combined_locations:
-                        cx_src = origin_x_src + gx * stride_x_src + half_block_x
-                        cy_src = origin_y_src + gy * stride_y_src + half_block_y
-                        tgt_centers.append((int(round(cx_src / r)), int(round(cy_src / r))))
-                    log.debug(f"DEBUG: Fallback derived coords - created {len(tgt_centers)} coordinates")
+                log.warning(f"Failed to read target coordinates from {target_tfrecord_path}: {e}")
+
+            # If we couldn't read target coordinates (file doesn't exist, read failed, or empty result),
+            # fall back to deriving them from source coordinates
+            if not tgt_centers and combined_locations and original_locations:
+                log.debug(f"DEBUG: Using fallback coordinate derivation (no valid target coords found)")
+                stride_x_src, stride_y_src, origin_x_src, origin_y_src = _stride_origin_source(original_locations)
+                log.debug(f"DEBUG: Fallback - calculated stride_src: ({stride_x_src}, {stride_y_src}), origin_src: ({origin_x_src}, {origin_y_src})")
+                # The center of an r×r block of source tiles
+                # If r=4: source tiles at grid positions 0,1,2,3 → center at 1.5 (halfway between 1 and 2)
+                half_block_x = ((r - 1) * stride_x_src) / 2.0
+                half_block_y = ((r - 1) * stride_y_src) / 2.0
+                for gx, gy in combined_locations:
+                    # gx, gy are the top-left grid indices of the source tiles being combined
+                    # Calculate the pixel coordinate of the center of this r×r block
+                    cx_src = origin_x_src + gx * stride_x_src + half_block_x
+                    cy_src = origin_y_src + gy * stride_y_src + half_block_y
+                    # Target coordinates remain in the same pixel space (no division)
+                    tgt_centers.append((int(round(cx_src)), int(round(cy_src))))
+                log.debug(f"DEBUG: Fallback derived coords - created {len(tgt_centers)} coordinates")
 
             slide_report.target_thumb_coords = np.array(tgt_centers, dtype=np.int64) if tgt_centers else None
             log.debug(f"DEBUG: Final target_thumb_coords: {slide_report.target_thumb_coords is not None} ({len(tgt_centers)} coords)")

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2011,16 +2011,17 @@ class Dataset:
         except Exception:
             return None, None
 
-    def _build_lower_mag_indices(self, target_tile_um: Union[int, str], target_tile_px: int, source_tile_um: Union[int, str]) -> None:
+    def _build_lower_mag_indices(self, target_tile_um: Union[int, str], target_tile_px: int, source_tile_um: Union[int, str], source_name: Optional[str] = None) -> None:
         """Build index files and manifest for newly created TFRecords.
 
         Args:
             target_tile_um: Target magnification
             target_tile_px: Target tile pixel size
             source_tile_um: Source magnification
+            source_name: Optional source name to use for multi-source datasets
         """
         try:
-            dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
+            dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um, source_name=source_name)
             if not dummy_tfrecord_path:
                 log.warning(f"Could not determine output directory for {target_tile_um}")
                 return
@@ -2054,7 +2055,7 @@ class Dataset:
             log.warning(f"Failed to build index files for {target_tile_um}: {str(e)}")
 
     def _save_tile_combinations_csv(self, all_tile_combinations: List[Dict], target_tile_um: Union[int, str],
-                                   target_tile_px: int, source_tile_um: Union[int, str]) -> None:
+                                   target_tile_px: int, source_tile_um: Union[int, str], source_name: Optional[str] = None) -> None:
         """Save tile combination data to overview CSV.
 
         Args:
@@ -2062,6 +2063,7 @@ class Dataset:
             target_tile_um: Target magnification
             target_tile_px: Target tile pixel size
             source_tile_um: Source magnification
+            source_name: Optional source name to use for multi-source datasets
         """
         if not all_tile_combinations:
             log.info("No tile combinations data to save to overview CSV")
@@ -2069,7 +2071,7 @@ class Dataset:
 
         import pandas as pd
         try:
-            dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
+            dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um, source_name=source_name)
             if not dummy_tfrecord_path:
                 log.warning("Could not determine output directory for saving tile combinations CSV")
                 return
@@ -2155,7 +2157,7 @@ class Dataset:
 
     def _generate_lower_mag_pdf_report(self, all_reports: List, source_tfrecords: List[str],
                                      target_tile_um: Union[int, str], source_tile_um: Union[int, str],
-                                     mag_ratio: int, **kwargs) -> None:
+                                     mag_ratio: int, source_name: Optional[str] = None, **kwargs) -> None:
         """Generate PDF and CSV reports for lower magnification extraction.
 
         Args:
@@ -2164,6 +2166,7 @@ class Dataset:
             target_tile_um: Target magnification
             source_tile_um: Source magnification
             mag_ratio: Magnification ratio
+            source_name: Optional source name to use for multi-source datasets
             **kwargs: Additional parameters
         """
         log.info(f'Generating lower magnification tile extraction PDF report...')
@@ -2193,22 +2196,23 @@ class Dataset:
         # Save PDF and CSV with specific naming for lower mag
         from datetime import datetime
         _time = datetime.now().strftime('%Y%m%d-%H%M%S')
-        source_name = source_tile_um if isinstance(source_tile_um, str) else f"{source_tile_um}um"
-        target_name = target_tile_um if isinstance(target_tile_um, str) else f"{target_tile_um}um"
+        source_mag_str = source_tile_um if isinstance(source_tile_um, str) else f"{source_tile_um}um"
+        target_mag_str = target_tile_um if isinstance(target_tile_um, str) else f"{target_tile_um}um"
 
         # Determine output directory (use target magnification directory)
         if all_reports:
             sample_output_path = self._get_output_tfrecord_path(
                 "dummy", target_tile_um,
                 target_tile_px=kwargs.get('target_tile_px', self.tile_px),
-                source_tile_um=source_tile_um
+                source_tile_um=source_tile_um,
+                source_name=source_name
             )
             pdf_dir = os.path.dirname(sample_output_path) if sample_output_path else ''
         else:
             pdf_dir = ''
 
-        pdf_filename = os.path.join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}-{_time}.pdf')
-        csv_filename = os.path.join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}.csv')
+        pdf_filename = os.path.join(pdf_dir, f'lower_mag_extraction_report_{source_mag_str}_to_{target_mag_str}-{_time}.pdf')
+        csv_filename = os.path.join(pdf_dir, f'lower_mag_extraction_report_{source_mag_str}_to_{target_mag_str}.csv')
 
         try:
             pdf_report.save(pdf_filename)
@@ -2297,128 +2301,188 @@ class Dataset:
 
         # Validate parameters and calculate target magnification
         target_tile_um = self._validate_lower_mag_params(mag_ratio, source_tile_um)
-        # Get source TFRecords for processing
-        source_tfrecords = self._get_lower_mag_tfrecords(source=source)
 
-        # Initialize processing variables
-        all_reports = []
-        all_tile_combinations = []
+        # Determine which sources to process
+        if source is not None:
+            sources_to_process = [source]
+        else:
+            sources_to_process = list(self.sources.keys())
 
-        # Set up progress bar
-        pb, tfr_task = self._create_lower_mag_progress_bar(len(source_tfrecords))
+        # Process each source separately
+        all_reports_dict = {}
+        for src in sources_to_process:
+            log.info(f"Processing source: {src}")
 
-        # Ensure cleanup context matches other uses
-        with sf.util.cleanup_progress(pb) if pb is not None else contextlib.nullcontext():
-            for tfrecord_path in source_tfrecords:
-                try:
-                    if skip_extracted:
-                        # Check if output already exists
-                        output_path = self._get_output_tfrecord_path(
-                            tfrecord_path,
-                            target_tile_um,
-                            target_tile_px=target_tile_px,
-                            source_tile_um=source_tile_um
+            # Get source TFRecords for this specific source
+            src_tfrecords = self._get_lower_mag_tfrecords(source=src)
+            if not src_tfrecords:
+                log.warning(f"No TFRecords found for source {src}, skipping")
+                continue
+
+            # Initialize processing variables for this source
+            src_reports = []
+            src_tile_combinations = []
+
+            # Set up progress bar
+            pb, tfr_task = self._create_lower_mag_progress_bar(len(src_tfrecords))
+
+            # Ensure cleanup context matches other uses
+            with sf.util.cleanup_progress(pb) if pb is not None else contextlib.nullcontext():
+                for tfrecord_path in src_tfrecords:
+                    try:
+                        if skip_extracted:
+                            # Check if output already exists
+                            output_path = self._get_output_tfrecord_path(
+                                tfrecord_path,
+                                target_tile_um,
+                                target_tile_px=target_tile_px,
+                                source_tile_um=source_tile_um
+                            )
+                            if output_path and exists(output_path):
+                                log.info(f"Skipping {tfrecord_path} - already processed")
+                                if pb is not None:
+                                    pb.advance(tfr_task)
+                                continue
+
+                        report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
+                            tfrecord_path=tfrecord_path,
+                            source_tile_um=source_tile_um,
+                            target_tile_um=target_tile_um,
+                            mag_ratio=mag_ratio,
+                            **kwargs
                         )
-                        if output_path and exists(output_path):
-                            log.info(f"Skipping {tfrecord_path} - already processed")
-                            if pb is not None:
-                                pb.advance(tfr_task)
-                            continue
+                        src_reports.append(report)
+                        if tile_combinations:
+                            src_tile_combinations.extend(tile_combinations)
 
-                    report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
-                        tfrecord_path=tfrecord_path,
-                        source_tile_um=source_tile_um,
-                        target_tile_um=target_tile_um,
-                        mag_ratio=mag_ratio,
-                        **kwargs
-                    )
-                    all_reports.append(report)
-                    if tile_combinations:
-                        all_tile_combinations.extend(tile_combinations)
+                        if pb is not None:
+                            pb.advance(tfr_task)
 
-                    if pb is not None:
-                        pb.advance(tfr_task)
+                    except KeyboardInterrupt:
+                        log.info("Interrupted by user during lower-mag processing")
+                        break
+                    except errors.DatasetError as e:
+                        # DatasetErrors indicate configuration/data issues that should stop processing
+                        log.error(f"Fatal error processing {tfrecord_path}: {str(e)}")
+                        if pb is not None:
+                            pb.advance(tfr_task)
+                        # Re-raise to stop processing - these errors indicate fundamental problems
+                        raise
+                    except Exception as e:
+                        # Catch other unexpected errors but log them prominently
+                        log.error(f"Unexpected error processing {tfrecord_path}: {str(e)}")
+                        import traceback
+                        log.debug(f"Full traceback: {traceback.format_exc()}")
+                        if pb is not None:
+                            pb.advance(tfr_task)
+                        # Continue to next TFRecord for non-fatal errors
+                        continue
+            # --- End progress bar loop for this source ---
 
-                except KeyboardInterrupt:
-                    log.info("Interrupted by user during lower-mag processing")
-                    break
-                except errors.DatasetError as e:
-                    # DatasetErrors indicate configuration/data issues that should stop processing
-                    log.error(f"Fatal error processing {tfrecord_path}: {str(e)}")
-                    if pb is not None:
-                        pb.advance(tfr_task)
-                    # Re-raise to stop processing - these errors indicate fundamental problems
-                    raise
-                except Exception as e:
-                    # Catch other unexpected errors but log them prominently
-                    log.error(f"Unexpected error processing {tfrecord_path}: {str(e)}")
-                    import traceback
-                    log.debug(f"Full traceback: {traceback.format_exc()}")
-                    if pb is not None:
-                        pb.advance(tfr_task)
-                    # Continue to next TFRecord for non-fatal errors
-                    continue
-        # --- End progress bar loop ---
+            # Filter out None reports
+            src_reports = [r for r in src_reports if r is not None]
 
-        # Update manifest after processing
+            # Build index files and create manifest for the new TFRecords for this source
+            if src_reports:
+                self._build_lower_mag_indices(target_tile_um, target_tile_px, source_tile_um, source_name=src)
+
+            # Generate PDF report if requested for this source
+            if report and src_reports:
+                self._generate_lower_mag_pdf_report(src_reports, src_tfrecords, target_tile_um, source_tile_um, mag_ratio, source_name=src, **kwargs)
+
+            # Save tile combinations CSV for this source
+            if src_tile_combinations:
+                self._save_tile_combinations_csv(src_tile_combinations, target_tile_um, target_tile_px, source_tile_um, source_name=src)
+
+            # Store reports for this source
+            all_reports_dict[src] = {r.path: r for r in src_reports}
+
+        # Update manifest after processing all sources
         self.update_manifest(force_update=True)
         self.build_index(False)
 
-        # Build index files and create manifest for the new TFRecords
-        if all_reports:
-            self._build_lower_mag_indices(target_tile_um, target_tile_px, source_tile_um)
+        # Flatten all reports for return value
+        all_reports = {}
+        for src_reports in all_reports_dict.values():
+            all_reports.update(src_reports)
 
-        # Filter out None reports
-        all_reports = [r for r in all_reports if r is not None]
-
-        # Generate PDF report if requested
-        if report:
-            self._generate_lower_mag_pdf_report(all_reports, source_tfrecords, target_tile_um, source_tile_um, mag_ratio, **kwargs)
-
-        # Save combined tile combinations to single overview CSV
-        self._save_tile_combinations_csv(all_tile_combinations, target_tile_um, target_tile_px, source_tile_um)
-
-        return {report.path: report for report in all_reports}
+        return all_reports
     
     def _get_output_tfrecord_path(
         self,
         input_path: str,
         target_tile_um: Union[int, str],
         target_tile_px: Optional[int] = None,
-        source_tile_um: Optional[Union[int, str]] = None
+        source_tile_um: Optional[Union[int, str]] = None,
+        source_name: Optional[str] = None
     ) -> str:
         """Get output TFRecord path for lower magnification tiles.
+
+        Args:
+            input_path: Path to input TFRecord or slide name
+            target_tile_um: Target magnification
+            target_tile_px: Target tile pixel size
+            source_tile_um: Source magnification
+            source_name: Optional source name to use (if not provided, will be determined from input_path)
 
         Raises:
             DatasetError: If unable to determine output path due to missing sources or configuration.
         """
         slide_name = sf.util.path_to_name(input_path)
-        for source in self.sources:
-            if 'tfrecords' in self.sources[source]:
-                tfrecord_dir = self.sources[source]['tfrecords']
-                px = int(target_tile_px) if target_tile_px is not None else int(self.tile_px)
 
-                # Create directory name with source magnification info
-                if isinstance(target_tile_um, str):
-                    base_suffix = f"{px}px_{target_tile_um.lower()}"
-                else:
-                    base_suffix = f"{px}px_{target_tile_um}um"
+        # Determine which source this input TFRecord belongs to
+        if source_name is not None:
+            # Use the provided source name
+            tfr_source = source_name
+        else:
+            try:
+                tfr_source = self.get_slide_source(slide_name)
+            except errors.DatasetError:
+                # If slide not found in sources, fall back to checking path
+                tfr_source = None
+                for source in self.sources:
+                    if 'tfrecords' in self.sources[source]:
+                        tfrecord_dir = self.sources[source]['tfrecords']
+                        if input_path.startswith(tfrecord_dir):
+                            tfr_source = source
+                            break
 
-                # Include source magnification in directory name
-                if source_tile_um is not None:
-                    if isinstance(source_tile_um, str):
-                        source_mag = source_tile_um.lower()
+                if tfr_source is None:
+                    # Last resort: if only one source, use it
+                    if len(self.sources) == 1:
+                        tfr_source = list(self.sources.keys())[0]
                     else:
-                        source_mag = f"{source_tile_um}um"
-                    mag_suffix = f"{base_suffix}_from_{source_mag}"
-                else:
-                    mag_suffix = base_suffix
-                target_dir = join(tfrecord_dir, mag_suffix)
-                return join(target_dir, f"{slide_name}.tfrecords")
+                        raise errors.DatasetError(
+                            f"Unable to determine source for {input_path}. "
+                            f"Please provide source_name parameter for multi-source datasets."
+                        )
 
-        raise errors.DatasetError(
-            f"Unable to determine output path for {input_path}: no TFRecord sources configured"
-        )
+        # Now build the output path using only the correct source
+        if tfr_source not in self.sources or 'tfrecords' not in self.sources[tfr_source]:
+            raise errors.DatasetError(
+                f"TFRecords directory not configured for source {tfr_source}"
+            )
+
+        tfrecord_dir = self.sources[tfr_source]['tfrecords']
+        px = int(target_tile_px) if target_tile_px is not None else int(self.tile_px)
+
+        # Create directory name with source magnification info
+        if isinstance(target_tile_um, str):
+            base_suffix = f"{px}px_{target_tile_um.lower()}"
+        else:
+            base_suffix = f"{px}px_{target_tile_um}um"
+
+        # Include source magnification in directory name
+        if source_tile_um is not None:
+            if isinstance(source_tile_um, str):
+                source_mag = source_tile_um.lower()
+            else:
+                source_mag = f"{source_tile_um}um"
+            mag_suffix = f"{base_suffix}_from_{source_mag}"
+        else:
+            mag_suffix = base_suffix
+        target_dir = join(tfrecord_dir, mag_suffix)
+        return join(target_dir, f"{slide_name}.tfrecords")
             
     def _process_single_tfrecord_for_lower_mag(
         self,

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2031,7 +2031,7 @@ class Dataset:
                 return
 
             # Find all TFRecord files in the output directory
-            tfrecord_files = glob.glob(os.path.join(output_dir, "*.tfrecords"))
+            tfrecord_files = glob(os.path.join(output_dir, "*.tfrecords"))
 
             log.info(f"Building index files for {len(tfrecord_files)} TFRecord files")
             for tfr_path in tfrecord_files:
@@ -2520,9 +2520,15 @@ class Dataset:
             #     log.debug(f"Skipping incomplete group at {group_loc} with {len(tile_indices)} tiles (need {mag_ratio*mag_ratio})")
                     
         writer.close()
-        
-        # Note: Index files will be generated later by self.build_index(True) call
-        
+
+        # Create index file immediately after writing so target coordinates can be read for reports
+        if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+            try:
+                _create_index(output_path, force=True)
+                log.debug(f"Created index for {output_path}")
+            except Exception as e:
+                log.warning(f"Failed to create index for {output_path}: {e}")
+
         # Create SlideReport with combined tile locations for visualization
         combined_locations = [group_loc for group_loc in tile_groups.keys() 
                             if len(tile_groups[group_loc]) == mag_ratio * mag_ratio]
@@ -2875,10 +2881,12 @@ class Dataset:
             # -------- constants / helpers --------
             r = int(mag_ratio)
 
-            # Draw-level box sizes (NO 224s here). Use the passed source_tile_px.
+            # Box sizes in level-0 WSI pixel space (same coordinate space as stored coordinates)
+            # Source tiles are extracted at the source tile size (e.g., 224×224 pixels)
+            # Target tiles are r×r grids of source tiles (e.g., 4×4 = 896×896 pixels)
             src_px_native = int(source_tile_px) if source_tile_px else int(getattr(self, "tile_px"))
-            source_box_px_draw = max(1, int(round(src_px_native / max(r, 1))))
-            target_box_px_draw = int(src_px_native)
+            source_box_px_draw = int(src_px_native)  # Source tile size in WSI pixels (e.g., 224)
+            target_box_px_draw = int(src_px_native * r)  # Target box is r×r source tiles (e.g., 224*4=896)
 
             # Robust stride/origin on SOURCE space (after undoing loc_scale)
             def _stride_origin_source(stored_centers):

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -116,7 +116,7 @@ from PIL import Image
 
 import slideflow as sf
 from slideflow import errors
-from slideflow.slide import WSI, ExtractionReport, SlideReport
+from slideflow.slide import WSI, ExtractionReport, LowerMagExtractionReport, SlideReport, LowerMagSlideReport
 from slideflow.util import (log, Labels, _shortname, path_to_name,
                             tfrecord2idx, TileExtractionProgress, MultiprocessProgress)
 
@@ -1895,6 +1895,7 @@ class Dataset:
         source: Optional[str] = None,
         skip_extracted: bool = True,
         report: bool = True,
+        img_format: str = 'jpg',
         **kwargs: Any
     ) -> Dict[str, SlideReport]:
         r"""Extract lower magnification tiles from existing high-magnification TFRecords.
@@ -1929,7 +1930,6 @@ class Dataset:
         Returns:
             Dictionary mapping slide paths to each slide's SlideReport
             (:class:`slideflow.slide.report.SlideReport`). When report=True,
-            also generates an ExtractionReport PDF showing tile locations.
 
         Raises:
             DatasetError: If source_tile_um or target_tile_um are invalid, or if
@@ -1982,7 +1982,7 @@ class Dataset:
         for tfrecord_path in source_tfrecords:
             if skip_extracted:
                 # Check if output already exists
-                output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px)
+                output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
                 if output_path and exists(output_path):
                     log.info(f"Skipping {tfrecord_path} - already processed")
                     continue
@@ -2008,7 +2008,7 @@ class Dataset:
         if all_reports:
             try:
                 # Get the output directory path
-                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px)
+                dummy_tfrecord_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
                 if dummy_tfrecord_path:
                     output_dir = os.path.dirname(dummy_tfrecord_path)
                     log.debug(f"OUTPUT DIR: {output_dir}")
@@ -2034,13 +2034,93 @@ class Dataset:
         # Filter out None reports
         all_reports = [r for r in all_reports if r is not None]
         
+        # Generate PDF report if requested (even if some slides had 0 tiles)
+        if report:
+            log.info(f'Generating lower magnification tile extraction PDF report...')
+            log.info(f'Found {len(all_reports)} reports to include in PDF')
+            
+            # Create metadata for lower mag extraction
+            from types import SimpleNamespace
+            from datetime import datetime
+            report_meta = SimpleNamespace(
+                tile_px=kwargs.get('target_tile_px', self.tile_px),
+                tile_um=target_tile_um,
+                qc="Lower mag tile combination",  # Custom QC description
+                total_slides=len(source_tfrecords),
+                slides_skipped=len(source_tfrecords) - len(all_reports),
+                roi_method="N/A",  # Not applicable for TFRecord combination
+                stride=1,  # Not applicable 
+                gs_frac="N/A",  # These were applied during original extraction
+                gs_thresh="N/A",
+                ws_frac="N/A", 
+                ws_thresh="N/A",
+                normalizer="N/A",
+                img_format=kwargs.get('img_format', 'jpg'),
+                source_tile_um=source_tile_um,  # Additional metadata specific to lower mag
+                mag_ratio=mag_ratio if mag_ratio else "calculated"
+            )
+            
+            # Generate ExtractionReport PDF (handle empty reports case)
+            if all_reports:
+                pdf_report = LowerMagExtractionReport(
+                    reports=all_reports,     # List[LowerMagSlideReport]
+                    meta=report_meta,
+                    title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um})'
+                )
+            else:
+                log.warning('No valid reports generated - creating empty ExtractionReport')
+                # Create a minimal dummy report to show that processing was attempted
+
+                dummy_report = LowerMagSlideReport(
+                    images=[],
+                    path="No slides processed",
+                    tile_px=int(kwargs.get('target_tile_px', self.tile_px)),
+                    tile_um=target_tile_um,
+                    source_tile_um=source_tile_um,
+                    mag_ratio=int(mag_ratio) if mag_ratio else 1,
+                    data={'num_tiles': 0, 'num_rois': 0, 'message': 'No complete tile groups found'},
+                    ignore_thumb_errors=True
+                )
+
+                pdf_report = LowerMagExtractionReport(
+                    reports=[dummy_report],
+                    meta=report_meta,
+                    title=f'Lower Magnification Tile Extraction Report ({source_tile_um} to {target_tile_um}) - No Results'
+                )
+            
+            # Save PDF and CSV with specific naming for lower mag
+            _time = datetime.now().strftime('%Y%m%d-%H%M%S')
+            source_name = source_tile_um if isinstance(source_tile_um, str) else f"{source_tile_um}um"
+            target_name = target_tile_um if isinstance(target_tile_um, str) else f"{target_tile_um}um"
+            
+            # Determine output directory (use target magnification directory)
+            if all_reports:
+                sample_output_path = self._get_output_tfrecord_path("dummy", target_tile_um, target_tile_px=kwargs.get('target_tile_px', self.tile_px), source_tile_um=source_tile_um)
+                if sample_output_path:
+                    pdf_dir = dirname(sample_output_path)
+                else:
+                    pdf_dir = ''
+            else:
+                pdf_dir = ''
+            
+            pdf_filename = join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}-{_time}.pdf')
+            csv_filename = join(pdf_dir, f'lower_mag_extraction_report_{source_name}_to_{target_name}.csv')
+            
+            try:
+                pdf_report.save(pdf_filename)
+                pdf_report.update_csv(csv_filename)
+                log.info(f'Saved lower magnification extraction report: {pdf_filename}')
+            except Exception as e:
+                log.warning(f'Failed to save extraction report: {e}')
+        
         return {report.path: report for report in all_reports}
     
     def _get_output_tfrecord_path(
         self,
         input_path: str,
         target_tile_um: Union[int, str],
-        target_tile_px: Optional[int] = None
+        target_tile_px: Optional[int] = None,
+        source_tile_um: Optional[Union[int, str]] = None
     ) -> Optional[str]:
         try:
             slide_name = sf.util.path_to_name(input_path)
@@ -2048,10 +2128,22 @@ class Dataset:
                 if 'tfrecords' in self.sources[source]:
                     tfrecord_dir = self.sources[source]['tfrecords']
                     px = int(target_tile_px) if target_tile_px is not None else int(self.tile_px)
+                    
+                    # Create directory name with source magnification info
                     if isinstance(target_tile_um, str):
-                        mag_suffix = f"{px}px_{target_tile_um.lower()}"
+                        base_suffix = f"{px}px_{target_tile_um.lower()}"
                     else:
-                        mag_suffix = f"{px}px_{target_tile_um}um"
+                        base_suffix = f"{px}px_{target_tile_um}um"
+                    
+                    # Add source magnification if provided (for lower mag extraction)
+                    if source_tile_um is not None:
+                        if isinstance(source_tile_um, str):
+                            source_suffix = source_tile_um.lower()
+                        else:
+                            source_suffix = f"{source_tile_um}um"
+                        mag_suffix = f"{base_suffix}_from_{source_suffix}"
+                    else:
+                        mag_suffix = base_suffix
                     target_dir = join(tfrecord_dir, mag_suffix)
                     return join(target_dir, f"{slide_name}.tfrecords")
             return None
@@ -2073,7 +2165,28 @@ class Dataset:
             log.error(f"TFRecord {tfrecord_path} missing location data - skipping")
             return None
             
-        locations = sf.io.get_locations_from_tfrecord(tfrecord_path)
+        # Read coordinates from source TFRecord (the original high-mag tiles)
+        source_locations = sf.io.get_locations_from_tfrecord(tfrecord_path)
+        log.debug(f"Loaded {len(source_locations)} source tile locations from {tfrecord_path}")
+        
+        # Try to read target TFRecord coordinates (the newly created low-mag tiles)
+        target_tile_px = kwargs.get('target_tile_px')
+        target_tfrecord_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
+        target_locations = None
+        if target_tfrecord_path and exists(target_tfrecord_path):
+            try:
+                target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
+                log.debug(f"Loaded {len(target_locations)} target tile locations from {target_tfrecord_path}")
+            except Exception as e:
+                log.debug(f"Could not read target TFRecord {target_tfrecord_path}: {e}")
+                target_locations = None
+        
+        # Use source locations for processing (this is what we're extracting FROM)
+        locations = source_locations
+        
+        # No enhanced coordinate data needed - we'll read both TFRecords separately during visualization
+        source_locations_data = None
+            
         total_tiles = len(locations)
         
         if total_tiles == 0:
@@ -2094,11 +2207,14 @@ class Dataset:
         target_tile_px = int(kwargs.get('target_tile_px', 224))
 
         log.info(f"Processing {slide_name}: found {len(tile_groups)} potential tile groups from {total_tiles} source tiles")
+        log.info(f"  Source tiles: {self.tile_px}px @ {source_tile_um}")
+        log.info(f"  Target tiles: {target_tile_px}px @ {target_tile_um}")
+        log.info(f"  Mag ratio: {mag_ratio}x (need {mag_ratio}x{mag_ratio}={mag_ratio*mag_ratio} source tiles per target)")
         complete_groups = sum(1 for indices in tile_groups.values() if len(indices) == mag_ratio * mag_ratio)
         log.info(f"  {complete_groups} complete groups (each requiring {mag_ratio}x{mag_ratio}={mag_ratio*mag_ratio} tiles)")
         
         # Generate output path
-        output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px)
+        output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
         if not output_path:
             log.error(f"Could not generate output path for {tfrecord_path}")
             return None
@@ -2123,7 +2239,7 @@ class Dataset:
                         img_format = kwargs.get('img_format', 'jpg')
                         record = self._create_combined_tile_record(
                             combined_tile, slide_name, group_loc, locations, mag_ratio, img_format,
-                            target_tile_px=target_tile_px
+                            target_tile_px=target_tile_px, tile_indices=tile_indices
                         )
                         writer.write(record)
                         combined_count += 1
@@ -2153,6 +2269,7 @@ class Dataset:
         report_data = {
             'slide': slide_name,
             'num_tiles': combined_count,
+            'num_rois': 0,  # ROIs not applicable for TFRecord combination
             'total_source_tiles': total_tiles,
             'discarded_tiles': total_tiles - (combined_count * mag_ratio * mag_ratio),
             'source_tiles_used': combined_count * mag_ratio * mag_ratio,
@@ -2165,36 +2282,53 @@ class Dataset:
         
         # Find the original slide path for thumbnail generation
         slide_path = self.find_slide(slide=slide_name)
+        log.debug(f"Looking for slide: {slide_name}")
+        log.debug(f"Found slide path: {slide_path}")
+        if slide_path and not os.path.exists(slide_path):
+            log.warning(f"Slide path does not exist: {slide_path}")
+            slide_path = None
         
-        # Scale coordinates for thumbnail  
-        if combined_locations:
-            scaled_coords = [(int(x * mag_ratio), int(y * mag_ratio)) for x, y in combined_locations]
-            thumb_coords = np.array(scaled_coords, dtype=np.int64)
-        else:
-            thumb_coords = np.empty((0, 2), dtype=np.int64)
+        # Create thumbnail coordinates for the existing WSI thumbnail system
+        # Show original tile locations (where tiles were actually extracted from)
+        thumb_coords = None
+        if locations:
+            log.debug(f"Preparing thumbnail coordinates for {slide_name}: {len(locations)} original tiles")
+            
+            # Use only the original tile coordinates (these are known to be valid)
+            all_coords = [(int(x), int(y)) for x, y in locations]
+            log.debug(f"Using original tile coordinates only for thumbnail")
+            
+            if all_coords:
+                # Convert to numpy array as expected by SlideReport
+                thumb_coords = np.array(all_coords, dtype=np.int64)
+                log.debug(f"Created thumb_coords array with {len(all_coords)} total coordinates")
+                log.debug(f"Sample coordinates: {all_coords[:5]}")
+                log.debug(f"thumb_coords shape: {thumb_coords.shape}")
+                log.debug(f"thumb_coords dtype: {thumb_coords.dtype}")
+                
+                # Verify coordinates are in the right format - should be (N, 2) array
+                if thumb_coords.ndim != 2 or thumb_coords.shape[1] != 2:
+                    log.error(f"Invalid thumb_coords shape: {thumb_coords.shape}, expected (N, 2)")
+                    thumb_coords = None
+            else:
+                log.warning("No coordinates found for thumbnail generation")
         
-        # Create SlideReport with thumbnail
-        try:
-            slide_report = SlideReport(
-                images=example_tiles,
-                path=slide_path or slide_name,
-                tile_px=self.tile_px,
-                tile_um=source_tile_um,
-                data=report_data,
-                thumb_coords=thumb_coords,
-                ignore_thumb_errors=True
-            )
-        except Exception as e:
-            log.warning(f"Error creating SlideReport: {e}")
-            slide_report = SlideReport(
-                images=example_tiles,
-                path=slide_name,
-                tile_px=self.tile_px,
-                tile_um=source_tile_um,
-                data=report_data,
-                ignore_thumb_errors=True
-            )
-        
+        # Create SlideReport using separate method
+        slide_report = self._create_lower_mag_slide_report(
+            slide_name=slide_name,
+            slide_path=slide_path,
+            original_locations=locations,
+            combined_locations=combined_locations,
+            example_tiles=example_tiles,
+            report_data=report_data,
+            source_tile_um=source_tile_um,
+            target_tile_um=target_tile_um,
+            target_tile_px=target_tile_px,     # ONLY for saved crops (224); not used in overlays
+            source_tile_px=self.tile_px,       # pass your source tile px (e.g., 512)
+            mag_ratio=mag_ratio,
+            target_tfrecord_path=output_path,  # Pass target TFRecord path for coordinate reading
+        )
+                
         # Create alignment visualization
         if combined_locations:
             # Convert source locations to grid coordinates for visualization
@@ -2487,6 +2621,7 @@ class Dataset:
         mag_ratio: int,
         img_format: str,
         target_tile_px: int,
+        tile_indices: List[int] = None,
     ) -> bytes:
         """Create a TFRecord for a combined tile.
         
@@ -2518,12 +2653,14 @@ class Dataset:
         grid_x, grid_y = grid_location
         source_grid_locations = self._coords_to_grid_indices(source_locations)
         
-        # Find source tiles that belong to this combined tile group
-        matching_source_locations = []
-        for i, (src_grid_x, src_grid_y) in enumerate(source_grid_locations):
-            if (grid_x <= src_grid_x < grid_x + mag_ratio and 
-                grid_y <= src_grid_y < grid_y + mag_ratio):
-                matching_source_locations.append(source_locations[i])
+        # Use tile indices directly to get the exact source tile coordinates
+        if tile_indices:
+            matching_source_locations = [source_locations[i] for i in tile_indices]
+            log.debug(f"Using tile indices {tile_indices[:5]}... to get {len(matching_source_locations)} source coordinates")
+            log.debug(f"Source coordinates sample: {matching_source_locations[:3]}")
+        else:
+            matching_source_locations = []
+            log.debug(f"No tile indices provided - source coordinates will be empty")
         
         if matching_source_locations:
             # Use average of matching source tiles as representative coordinate
@@ -2547,13 +2684,214 @@ class Dataset:
             else:
                 pixel_x, pixel_y = grid_x, grid_y
         
-        # Create record with pixel coordinates (same system as source tiles)
+        # Calculate target tile center coordinates (at target magnification level)
+        target_pixel_x = pixel_x // mag_ratio  
+        target_pixel_y = pixel_y // mag_ratio
+        
+        # Create record with both source and target coordinates for overlay visualization
+        # loc_x, loc_y: maintained for compatibility (target tile center)
+        # source_locations_x, source_locations_y: individual source tile centers
+        # target_location_x, target_location_y: combined tile center at target level
+        log.debug(f"Creating TFRecord with {len(matching_source_locations)} matching source locations")
+        if matching_source_locations:
+            log.debug(f"First 3 source locations: {matching_source_locations[:3]}")
+        source_x_list = [loc[0] for loc in matching_source_locations] if matching_source_locations else [pixel_x]
+        source_y_list = [loc[1] for loc in matching_source_locations] if matching_source_locations else [pixel_y]
+        log.debug(f"source_x_list length: {len(source_x_list)}, source_y_list length: {len(source_y_list)}")
+        
         return sf.io.serialized_record(
             slide=bytes(slide_name, 'utf-8'),
             image_raw=img_bytes,
-            loc_x=pixel_x,
-            loc_y=pixel_y
+            loc_x=target_pixel_x,
+            loc_y=target_pixel_y
         )
+
+    def _create_lower_mag_slide_report(
+            self,
+            slide_name: str,
+            slide_path: Optional[str],
+            original_locations: List[tuple],     # TFRecord-stored centers (divided by loc_scale)
+            combined_locations: List[tuple],     # target grid coords (top-left grid indices, in SOURCE grid)
+            example_tiles: List[bytes],
+            report_data: Dict[str, Any],
+            source_tile_um: Union[int, str],
+            target_tile_um: Union[int, str],
+            target_tile_px: int,                 # used only for saved crops; NOT for overlays
+            source_tile_px: int,                 # native source tile edge (e.g., 512)
+            mag_ratio: int,                      # r = source_mag / target_mag
+            target_tfrecord_path: Optional[str] = None,  # Path to target TFRecord for coordinate reading
+        ) -> LowerMagSlideReport:
+        """Create LowerMagSlideReport with dual overlays (centers/boxes in DRAW space)."""
+        try:
+            import numpy as np
+
+            # -------- constants / helpers --------
+            r = int(mag_ratio)
+
+            # Draw-level box sizes (NO 224s here). Use the passed source_tile_px.
+            src_px_native = int(source_tile_px) if source_tile_px else int(getattr(self, "tile_px", 512))
+            source_box_px_draw = max(1, int(round(src_px_native / max(r, 1))))  # e.g., 512/4 = 128
+            target_box_px_draw = int(src_px_native)                             # e.g., 512
+
+            # Robust stride/origin on SOURCE space (after undoing loc_scale)
+            def _stride_origin_source(stored_centers):
+                if not stored_centers:
+                    return src_px_native, src_px_native, 0, 0
+                xs = sorted(set(int(round(x)) for x, _ in stored_centers))
+                ys = sorted(set(int(round(y)) for _, y in stored_centers))
+                def _step(u):
+                    if len(u) < 2:
+                        return src_px_native
+                    diffs = [u[i+1] - u[i] for i in range(len(u)-1) if u[i+1] > u[i]]
+                    if not diffs:
+                        return src_px_native
+                    # median is robust to gaps/outliers
+                    return int(round(float(np.median(diffs))))
+                sx = _step(xs)
+                sy = _step(ys)
+                ox = xs[0] if xs else 0
+                oy = ys[0] if ys else 0
+                return sx, sy, ox, oy
+
+            # -------- create report shell --------
+            slide_report = LowerMagSlideReport(
+                images=example_tiles,
+                path=slide_path or slide_name,
+                tile_px=target_box_px_draw,       # report tile size == target box size AT DRAW LEVEL
+                tile_um=target_tile_um,
+                source_tile_um=source_tile_um,
+                mag_ratio=r,
+                thumb=None,
+                thumb_coords=None,
+                data=report_data,
+                compress=True,
+                ignore_thumb_errors=True,
+            )
+
+            # -------- SOURCE centers: read directly from source TFRecord --------
+            log.debug(f"DEBUG: Creating source_thumb_coords for {slide_name}")
+            log.debug(f"DEBUG: original_locations count: {len(original_locations) if original_locations else 0}")
+            log.debug(f"DEBUG: r={r} (no loc_scale used)")
+            
+            if original_locations:
+                src_coords = [
+                    (int(round(x / r)), int(round(y / r)))
+                    for (x, y) in original_locations
+                ]
+                log.debug(f"DEBUG: Source coords - created {len(src_coords)} source coordinates")
+                log.debug(f"DEBUG: Source coords sample: {src_coords[:3]}")
+                slide_report.source_thumb_coords = np.array(src_coords, dtype=np.int64)
+            else:
+                log.debug(f"DEBUG: No original_locations available")
+                slide_report.source_thumb_coords = None
+
+            # -------- TARGET centers: read directly from target TFRecord --------
+            log.debug(f"DEBUG: Creating target_thumb_coords for {slide_name}")
+            
+            # Get target coordinates directly from target TFRecord
+            tgt_centers = []
+            try:
+                # Use the passed target TFRecord path
+                if target_tfrecord_path and os.path.exists(target_tfrecord_path):
+                    # Use get_locations_from_tfrecord to read target coordinates
+                    import slideflow as sf
+                    target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
+                    tgt_centers = [(int(x), int(y)) for x, y in target_locations]
+                    log.debug(f"DEBUG: Target coords from TFRecord - created {len(tgt_centers)} coordinates")
+                    if tgt_centers:
+                        log.debug(f"DEBUG: Target coords sample: {tgt_centers[:3]}")
+                else:
+                    log.debug(f"DEBUG: Target TFRecord not found at {target_tfrecord_path}")
+            except Exception as e:
+                log.debug(f"DEBUG: Error reading target coordinates: {e}")
+                # Fallback to derived coordinates if TFRecord reading fails
+                if combined_locations and original_locations:
+                    stride_x_src, stride_y_src, origin_x_src, origin_y_src = _stride_origin_source(original_locations)
+                    log.debug(f"DEBUG: Fallback - calculated stride_src: ({stride_x_src}, {stride_y_src}), origin_src: ({origin_x_src}, {origin_y_src})")
+                    half_block_x = ((r - 1) * stride_x_src) / 2.0
+                    half_block_y = ((r - 1) * stride_y_src) / 2.0
+                    for gx, gy in combined_locations:
+                        cx_src = origin_x_src + gx * stride_x_src + half_block_x
+                        cy_src = origin_y_src + gy * stride_y_src + half_block_y
+                        tgt_centers.append((int(round(cx_src / r)), int(round(cy_src / r))))
+                    log.debug(f"DEBUG: Fallback derived coords - created {len(tgt_centers)} coordinates")
+
+            slide_report.target_thumb_coords = np.array(tgt_centers, dtype=np.int64) if tgt_centers else None
+            log.debug(f"DEBUG: Final target_thumb_coords: {slide_report.target_thumb_coords is not None} ({len(tgt_centers)} coords)")
+
+            # expose draw-level box sizes for the renderer (used by calc_thumb)
+            slide_report.source_tile_px = int(source_box_px_draw)   # e.g., 128 at draw level
+            slide_report.target_tile_px = int(target_box_px_draw)   # e.g., 512 at draw level
+
+            log.info(f"LowerMagSlideReport created for {slide_name}:")
+            log.info(f"  Source box @draw: {source_box_px_draw}px  | Target box @draw: {target_box_px_draw}px  | r={r}")
+            return slide_report
+
+        except Exception as e:
+            log.warning(f"Error creating LowerMagSlideReport: {e}")
+            # Fallback to a basic SlideReport so the pipeline keeps going
+            return SlideReport(
+                images=[],
+                path=slide_path or slide_name,
+                tile_px=int(target_tile_px),
+                tile_um=target_tile_um,
+                data=report_data,
+                ignore_thumb_errors=True,
+            )
+
+
+    
+    def _estimate_stride_and_origin(
+        self,
+        centers,
+        *,
+        r: int = 1,                # mag_ratio; set r>1 to get DRAW-level values, else r=1 for SOURCE
+        space: str = "draw"        # "draw" (target) or "source"
+    ) -> tuple[int, int, int, int]:
+        """
+        Estimate (stride_x, stride_y, origin_x, origin_y) in the requested `space`.
+
+        - centers: list[(x_stored, y_stored)] from TFRecords (i.e., values were divided by loc_scale).
+        - r: source->draw downsample (mag_ratio). If space="draw", values are divided by r.
+        - space: "draw" returns values at target/draw level; "source" returns at source level.
+
+        Returns ints: (stride_x, stride_y, origin_x, origin_y).
+        """
+        import numpy as np
+
+        if not centers:
+            return 1, 1, 0, 0
+
+        # Use TFRecord coordinates directly (no loc_scale)
+        # 1) Use stored coordinates as SOURCE px
+        xs_src = np.array([c[0] for c in centers], dtype=float)
+        ys_src = np.array([c[1] for c in centers], dtype=float)
+
+        # 2) Robust stride (median of positive diffs of unique coords)
+        def _stride(v):
+            u = np.unique(np.round(v).astype(np.int64))
+            if u.size < 2:
+                return 1
+            diffs = np.diff(u)
+            diffs = diffs[diffs > 0]
+            if diffs.size == 0:
+                return 1
+            return int(max(1, np.round(np.median(diffs))))
+
+        stride_x_src = _stride(xs_src)
+        stride_y_src = _stride(ys_src)
+        origin_x_src = int(np.min(np.round(xs_src)))
+        origin_y_src = int(np.min(np.round(ys_src)))
+
+        if space.lower() == "source" or r <= 1:
+            return stride_x_src, stride_y_src, origin_x_src, origin_y_src
+
+        # 3) SOURCE -> DRAW (target) px by dividing by r
+        stride_x_draw = max(1, int(round(stride_x_src / r)))
+        stride_y_draw = max(1, int(round(stride_y_src / r)))
+        origin_x_draw = int(round(origin_x_src / r))
+        origin_y_draw = int(round(origin_y_src / r))
+        return stride_x_draw, stride_y_draw, origin_x_draw, origin_y_draw
 
     def extract_tiles_from_tfrecords(self, dest: str) -> None:
         """Extract tiles from a set of TFRecords.

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2265,14 +2265,13 @@ class Dataset:
             (:class:`slideflow.slide.report.SlideReport`). When report=True,
 
         Raises:
-            DatasetError: If Dataset tile_um is not set, or if mag_ratio is invalid.
-                For example, mag_ratio=4 (20x→5x, 4×4 grid) is valid, but mag_ratio=3
-                (not a perfect square) is not.
+            DatasetError: If Dataset tile_um is not set or is not an integer, or if 
+            mag_ratio is invalid.
             ValueError: If required TFRecord directories are not configured.
 
         Example:
             >>> # Combine 20x tiles with mag_ratio=4 to create 5x tiles (4×4 grid)
-            >>> dataset = sf.Dataset(..., tile_um="20x")
+            >>> dataset = sf.Dataset(..., tile_um="112um")
             >>> reports = dataset.extract_lower_mag_tiles_from_tfr(mag_ratio=4)
             >>> print(f"Processed {len(reports)} slides")
 
@@ -2299,7 +2298,7 @@ class Dataset:
             raise errors.DatasetError(
                 f"extract_lower_mag_tiles_from_tfr only supports integer tile_um (microns), "
                 f"not string magnifications. Got tile_um={self.tile_um!r} (type: {type(self.tile_um).__name__}). "
-                f"Please set tile_um to an integer value in microns (e.g., 112 for 20x at 224px)."
+                f"Please set tile_um to an integer value in microns."
             )
 
         # Convert tile_um to integer microns at the beginning
@@ -2600,8 +2599,6 @@ class Dataset:
                     import traceback
                     log.debug(f"Full traceback: {traceback.format_exc()}")
                     continue
-            # else:
-            #     log.debug(f"Skipping incomplete group at {group_loc} with {len(tile_indices)} tiles (need {mag_ratio*mag_ratio})")
                     
         writer.close()
 
@@ -2619,7 +2616,6 @@ class Dataset:
         if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
             try:
                 _create_index(output_path, force=True)
-                log.debug(f"Created index for {output_path}")
             except Exception as e:
                 log.warning(f"Failed to create index for {output_path}: {e}")
 
@@ -2901,8 +2897,6 @@ class Dataset:
         tile_image = self._resize_square_np(tile_image, target_tile_px)
 
         # Encode image to bytes
-        # Use PNG for combined tiles to avoid JPEG artifacts and corruption issues
-        # that can occur when aggressively downsampling large combined images
         pil_image = Image.fromarray(tile_image)
         img_bytes = io.BytesIO()
         if img_format.lower() == 'png':
@@ -2921,40 +2915,32 @@ class Dataset:
         grid_x, grid_y = grid_location
         
         # Use tile indices directly to get the exact source tile coordinates
-        if tile_indices:
-            matching_source_locations = [source_locations[i] for i in tile_indices]
-        else:
-            log.debug("tile_indices is None or empty")
-            matching_source_locations = []
+        if not tile_indices:
+            raise ValueError(
+                f"No tile_indices provided for combined tile at grid location {grid_location}. "
+                f"Cannot create combined tile record without source tile information."
+            )
 
-        if matching_source_locations:
-            # Use average of matching source tiles as representative coordinate
-            avg_x = sum(loc[0] for loc in matching_source_locations) // len(matching_source_locations)
-            avg_y = sum(loc[1] for loc in matching_source_locations) // len(matching_source_locations)
-            pixel_x, pixel_y = avg_x, avg_y
-        else:
-            log.debug(f"Fallback: no matching source locations (tile_indices={tile_indices})")
-            # Fallback: estimate coordinates from grid position and source data
-            # Note: grid_x, grid_y are grid indices (0, 1, 2, ...), not pixel coordinates
-            if source_locations:
-                x_coords = sorted(set(loc[0] for loc in source_locations))
-                y_coords = sorted(set(loc[1] for loc in source_locations))
-                stride_x = min(x_coords[i+1] - x_coords[i] for i in range(len(x_coords)-1)) if len(x_coords) > 1 else 512
-                stride_y = min(y_coords[i+1] - y_coords[i] for i in range(len(y_coords)-1)) if len(y_coords) > 1 else 512
-                min_x, min_y = min(x_coords), min(y_coords)
+        if not source_locations:
+            raise ValueError(
+                f"No source_locations provided for combined tile at grid location {grid_location}. "
+                f"Cannot create combined tile record without source location information."
+            )
 
-                # Calculate the center of the mag_ratio x mag_ratio region
-                # grid_x, grid_y represent the top-left grid index of the combined block
-                # Each grid cell is stride_x × stride_y pixels
-                # The block spans from grid_x to (grid_x + mag_ratio - 1)
-                # Center is at grid_x + (mag_ratio - 1) / 2
-                center_offset_x = (mag_ratio - 1) * stride_x // 2
-                center_offset_y = (mag_ratio - 1) * stride_y // 2
-                # Convert grid position to pixel position
-                pixel_x = min_x + grid_x * stride_x + center_offset_x
-                pixel_y = min_y + grid_y * stride_y + center_offset_y
-            else:
-                pixel_x, pixel_y = grid_x, grid_y
+        # Validate that all tile indices are valid
+        for idx in tile_indices:
+            if idx < 0 or idx >= len(source_locations):
+                raise ValueError(
+                    f"Invalid tile index {idx} for combined tile at grid location {grid_location}. "
+                    f"Source locations has {len(source_locations)} entries (indices 0-{len(source_locations)-1})."
+                )
+
+        matching_source_locations = [source_locations[i] for i in tile_indices]
+
+        # Use average of matching source tiles as representative coordinate
+        avg_x = sum(loc[0] for loc in matching_source_locations) // len(matching_source_locations)
+        avg_y = sum(loc[1] for loc in matching_source_locations) // len(matching_source_locations)
+        pixel_x, pixel_y = avg_x, avg_y
         
         return sf.io.serialized_record(
             slide=bytes(slide_name, 'utf-8'),
@@ -3048,7 +3034,6 @@ class Dataset:
                     target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
                     if target_locations:
                         tgt_centers = [(int(x), int(y)) for x, y in target_locations]
-                        log.debug(f"Successfully read {len(tgt_centers)} target coordinates from {target_tfrecord_path}")
                     else:
                         raise errors.DatasetError(
                             f"Target TFRecord {target_tfrecord_path} exists but contains no location data. "
@@ -3066,7 +3051,6 @@ class Dataset:
                 )
 
             slide_report.target_thumb_coords = np.array(tgt_centers, dtype=np.int64)
-            log.debug(f"Final target_thumb_coords: {len(tgt_centers)} coordinates")
 
             # expose draw-level box sizes for the renderer (used by calc_thumb)
             slide_report.source_tile_px = int(source_box_px_draw)

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -2310,7 +2310,6 @@ class Dataset:
         # Ensure cleanup context matches other uses
         with sf.util.cleanup_progress(pb) if pb is not None else contextlib.nullcontext():
             for tfrecord_path in source_tfrecords:
-                # Advance the progress even if we skip so the bar stays accurate.
                 try:
                     if skip_extracted:
                         # Check if output already exists
@@ -2326,34 +2325,38 @@ class Dataset:
                                 pb.advance(tfr_task)
                             continue
 
-                    try:
-                        report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
-                            tfrecord_path=tfrecord_path,
-                            source_tile_um=source_tile_um,
-                            target_tile_um=target_tile_um,
-                            mag_ratio=mag_ratio,
-                            **kwargs
-                        )
-                        all_reports.append(report)
-                        if tile_combinations:
-                            all_tile_combinations.extend(tile_combinations)
-                    except Exception as e:
-                        log.error(f"Error processing {tfrecord_path}: {str(e)}")
-                        # still advance progress bar
-                    finally:
-                        if pb is not None:
-                            pb.advance(tfr_task)
+                    report, tile_combinations = self._process_single_tfrecord_for_lower_mag(
+                        tfrecord_path=tfrecord_path,
+                        source_tile_um=source_tile_um,
+                        target_tile_um=target_tile_um,
+                        mag_ratio=mag_ratio,
+                        **kwargs
+                    )
+                    all_reports.append(report)
+                    if tile_combinations:
+                        all_tile_combinations.extend(tile_combinations)
+
+                    if pb is not None:
+                        pb.advance(tfr_task)
+
                 except KeyboardInterrupt:
                     log.info("Interrupted by user during lower-mag processing")
                     break
-                except Exception as e:
-                    # Catch any unexpected error per-record so the loop continues
-                    log.error(f"Unexpected error while handling {tfrecord_path}: {str(e)}")
+                except errors.DatasetError as e:
+                    # DatasetErrors indicate configuration/data issues that should stop processing
+                    log.error(f"Fatal error processing {tfrecord_path}: {str(e)}")
                     if pb is not None:
-                        try:
-                            pb.advance(tfr_task)
-                        except Exception:
-                            pass
+                        pb.advance(tfr_task)
+                    # Re-raise to stop processing - these errors indicate fundamental problems
+                    raise
+                except Exception as e:
+                    # Catch other unexpected errors but log them prominently
+                    log.error(f"Unexpected error processing {tfrecord_path}: {str(e)}")
+                    import traceback
+                    log.debug(f"Full traceback: {traceback.format_exc()}")
+                    if pb is not None:
+                        pb.advance(tfr_task)
+                    # Continue to next TFRecord for non-fatal errors
                     continue
         # --- End progress bar loop ---
 
@@ -2383,34 +2386,39 @@ class Dataset:
         target_tile_um: Union[int, str],
         target_tile_px: Optional[int] = None,
         source_tile_um: Optional[Union[int, str]] = None
-    ) -> Optional[str]:
-        try:
-            slide_name = sf.util.path_to_name(input_path)
-            for source in self.sources:
-                if 'tfrecords' in self.sources[source]:
-                    tfrecord_dir = self.sources[source]['tfrecords']
-                    px = int(target_tile_px) if target_tile_px is not None else int(self.tile_px)
-                    
-                    # Create directory name with source magnification info
-                    if isinstance(target_tile_um, str):
-                        base_suffix = f"{px}px_{target_tile_um.lower()}"
-                    else:
-                        base_suffix = f"{px}px_{target_tile_um}um"
+    ) -> str:
+        """Get output TFRecord path for lower magnification tiles.
 
-                    # Include source magnification in directory name
-                    if source_tile_um is not None:
-                        if isinstance(source_tile_um, str):
-                            source_mag = source_tile_um.lower()
-                        else:
-                            source_mag = f"{source_tile_um}um"
-                        mag_suffix = f"{base_suffix}_from_{source_mag}"
+        Raises:
+            DatasetError: If unable to determine output path due to missing sources or configuration.
+        """
+        slide_name = sf.util.path_to_name(input_path)
+        for source in self.sources:
+            if 'tfrecords' in self.sources[source]:
+                tfrecord_dir = self.sources[source]['tfrecords']
+                px = int(target_tile_px) if target_tile_px is not None else int(self.tile_px)
+
+                # Create directory name with source magnification info
+                if isinstance(target_tile_um, str):
+                    base_suffix = f"{px}px_{target_tile_um.lower()}"
+                else:
+                    base_suffix = f"{px}px_{target_tile_um}um"
+
+                # Include source magnification in directory name
+                if source_tile_um is not None:
+                    if isinstance(source_tile_um, str):
+                        source_mag = source_tile_um.lower()
                     else:
-                        mag_suffix = base_suffix
-                    target_dir = join(tfrecord_dir, mag_suffix)
-                    return join(target_dir, f"{slide_name}.tfrecords")
-            return None
-        except Exception:
-            return None
+                        source_mag = f"{source_tile_um}um"
+                    mag_suffix = f"{base_suffix}_from_{source_mag}"
+                else:
+                    mag_suffix = base_suffix
+                target_dir = join(tfrecord_dir, mag_suffix)
+                return join(target_dir, f"{slide_name}.tfrecords")
+
+        raise errors.DatasetError(
+            f"Unable to determine output path for {input_path}: no TFRecord sources configured"
+        )
             
     def _process_single_tfrecord_for_lower_mag(
         self,
@@ -2420,12 +2428,18 @@ class Dataset:
         mag_ratio: Optional[int],
         **kwargs
     ) -> Optional[SlideReport]:
-        """Process a single TFRecord to extract lower magnification tiles."""
-        
+        """Process a single TFRecord to extract lower magnification tiles.
+
+        Raises:
+            DatasetError: If TFRecord is missing required location data.
+        """
+
         # Get locations and validate TFRecord has location data
         if not sf.io.tfrecord_has_locations(tfrecord_path, check_x=True, check_y=True):
-            log.error(f"TFRecord {tfrecord_path} missing location data - skipping")
-            return None
+            raise errors.DatasetError(
+                f"TFRecord {tfrecord_path} missing required location data (loc_x, loc_y). "
+                f"Location data is required for combining tiles into lower magnification tiles."
+            )
             
         # Read coordinates from source TFRecord (the original high-mag tiles)
         source_locations = sf.io.get_locations_from_tfrecord(tfrecord_path)
@@ -2449,20 +2463,18 @@ class Dataset:
         
         # If mag_ratio wasn't calculated, we need to determine it from actual tile data
         if mag_ratio is None:
-            # TODO
-            # This would require accessing slide metadata to calculate the ratio
-            log.error(f"mag_ratio is None")
-            
+            raise errors.DatasetError(
+                f"mag_ratio is None for TFRecord {tfrecord_path}. "
+                f"Magnification ratio must be specified to combine tiles."
+            )
+
         # Group tiles by spatial regions that can form target tiles
         tile_groups = self._group_tiles_for_combination(locations, mag_ratio)
         target_tile_px = int(kwargs.get('target_tile_px', 224))
         complete_groups = sum(1 for indices in tile_groups.values() if len(indices) == mag_ratio * mag_ratio)
-        
-        # Generate output path
+
+        # Generate output path (will raise DatasetError if unable to determine path)
         output_path = self._get_output_tfrecord_path(tfrecord_path, target_tile_um, target_tile_px=target_tile_px, source_tile_um=source_tile_um)
-        if not output_path:
-            log.error(f"Could not generate output path for {tfrecord_path}")
-            return None
             
         # Ensure output directory exists
         os.makedirs(dirname(output_path), exist_ok=True)
@@ -2806,13 +2818,20 @@ class Dataset:
         # ensure correct tile px size
         tile_image = self._resize_square_np(tile_image, target_tile_px)
 
-        # Encode image to PIL
+        # Encode image to bytes
+        # Use PNG for combined tiles to avoid JPEG artifacts and corruption issues
+        # that can occur when aggressively downsampling large combined images
         pil_image = Image.fromarray(tile_image)
         img_bytes = io.BytesIO()
         if img_format.lower() == 'png':
-            pil_image.save(img_bytes, format='PNG')
+            pil_image.save(img_bytes, format='PNG', optimize=True)
         else:
-            pil_image.save(img_bytes, format='JPEG', quality=95)
+            # For JPEG: use quality=100 and proper subsampling to avoid corruption
+            # when encoding downsampled combined tiles
+            pil_image.save(img_bytes, format='JPEG', quality=100, subsampling=0, optimize=True)
+
+        # Ensure all data is written to buffer
+        img_bytes.flush()
         img_bytes = img_bytes.getvalue()
         
         # Calculate pixel coordinates for the combined tile
@@ -2934,42 +2953,35 @@ class Dataset:
             # -------- TARGET centers: read directly from target TFRecord --------
 
             # Get target coordinates directly from target TFRecord
+            # DO NOT fall back to deriving coordinates - this can mislead users into thinking
+            # tiles were created correctly when they may not have been
             tgt_centers = []
-            try:
-                # Use the passed target TFRecord path
-                if target_tfrecord_path and os.path.exists(target_tfrecord_path):
+            if target_tfrecord_path and os.path.exists(target_tfrecord_path):
+                try:
                     # Use get_locations_from_tfrecord to read target coordinates
                     import slideflow as sf
                     target_locations = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
-                    tgt_centers = [(int(x), int(y)) for x, y in target_locations]
-                    log.debug(f"DEBUG: Successfully read {len(tgt_centers)} target coordinates from {target_tfrecord_path}")
-                else:
-                    log.debug(f"DEBUG: Target TFRecord path does not exist or is None: {target_tfrecord_path}")
-            except Exception as e:
-                # Fallback to derived coordinates if TFRecord reading fails
-                log.warning(f"Failed to read target coordinates from {target_tfrecord_path}: {e}")
+                    if target_locations:
+                        tgt_centers = [(int(x), int(y)) for x, y in target_locations]
+                        log.debug(f"Successfully read {len(tgt_centers)} target coordinates from {target_tfrecord_path}")
+                    else:
+                        raise errors.DatasetError(
+                            f"Target TFRecord {target_tfrecord_path} exists but contains no location data. "
+                            f"Cannot create accurate report visualization."
+                        )
+                except Exception as e:
+                    raise errors.DatasetError(
+                        f"Failed to read target coordinates from {target_tfrecord_path}: {e}. "
+                        f"Accurate target coordinates are required for report visualization."
+                    )
+            else:
+                raise errors.DatasetError(
+                    f"Target TFRecord path does not exist: {target_tfrecord_path}. "
+                    f"Cannot create report without target tile coordinates."
+                )
 
-            # If we couldn't read target coordinates (file doesn't exist, read failed, or empty result),
-            # fall back to deriving them from source coordinates
-            if not tgt_centers and combined_locations and original_locations:
-                log.debug(f"DEBUG: Using fallback coordinate derivation (no valid target coords found)")
-                stride_x_src, stride_y_src, origin_x_src, origin_y_src = _stride_origin_source(original_locations)
-                log.debug(f"DEBUG: Fallback - calculated stride_src: ({stride_x_src}, {stride_y_src}), origin_src: ({origin_x_src}, {origin_y_src})")
-                # The center of an r×r block of source tiles
-                # If r=4: source tiles at grid positions 0,1,2,3 → center at 1.5 (halfway between 1 and 2)
-                half_block_x = ((r - 1) * stride_x_src) / 2.0
-                half_block_y = ((r - 1) * stride_y_src) / 2.0
-                for gx, gy in combined_locations:
-                    # gx, gy are the top-left grid indices of the source tiles being combined
-                    # Calculate the pixel coordinate of the center of this r×r block
-                    cx_src = origin_x_src + gx * stride_x_src + half_block_x
-                    cy_src = origin_y_src + gy * stride_y_src + half_block_y
-                    # Target coordinates remain in the same pixel space (no division)
-                    tgt_centers.append((int(round(cx_src)), int(round(cy_src))))
-                log.debug(f"DEBUG: Fallback derived coords - created {len(tgt_centers)} coordinates")
-
-            slide_report.target_thumb_coords = np.array(tgt_centers, dtype=np.int64) if tgt_centers else None
-            log.debug(f"DEBUG: Final target_thumb_coords: {slide_report.target_thumb_coords is not None} ({len(tgt_centers)} coords)")
+            slide_report.target_thumb_coords = np.array(tgt_centers, dtype=np.int64)
+            log.debug(f"Final target_thumb_coords: {len(tgt_centers)} coordinates")
 
             # expose draw-level box sizes for the renderer (used by calc_thumb)
             slide_report.source_tile_px = int(source_box_px_draw)
@@ -2977,17 +2989,14 @@ class Dataset:
 
             return slide_report
 
+        except errors.DatasetError:
+            # Re-raise DatasetErrors so they bubble up properly
+            raise
         except Exception as e:
-            log.warning(f"Error creating LowerMagSlideReport: {e}")
-            # Fallback to a basic SlideReport so the pipeline keeps going
-            return SlideReport(
-                images=[],
-                path=slide_path or slide_name,
-                tile_px=int(target_tile_px),
-                tile_um=target_tile_um,
-                data=report_data,
-                ignore_thumb_errors=True,
-            )
+            # For unexpected errors, raise with context
+            raise errors.DatasetError(
+                f"Unexpected error creating LowerMagSlideReport for {slide_name}: {e}"
+            ) from e
     
     def _estimate_stride_and_origin(
         self,

--- a/slideflow/dataset.py
+++ b/slideflow/dataset.py
@@ -1893,38 +1893,65 @@ class Dataset:
         all_reports = [r for r in all_reports if r is not None]
         return {report.path: report for report in all_reports}
 
-    def _validate_lower_mag_params(self, source_tile_um: Union[int, str], target_tile_um: Union[int, str]) -> int:
-        """Validate magnification parameters and calculate ratios.
+    def _validate_lower_mag_params(self, mag_ratio: int) -> str:
+        """Validate magnification ratio and calculate target magnification.
 
         Args:
-            source_tile_um: Source magnification (str, e.g. "20x")
-            target_tile_um: Target magnification (str, e.g. "5x")
+            mag_ratio: Magnification ratio (how many source tiles per target tile)
 
         Returns:
-            mag_ratio: Integer magnification ratio
+            target_tile_um: Calculated target magnification as a string (e.g. "5x")
 
         Raises:
-            DatasetError: If magnification parameters are invalid or ratio is not an integer
+            DatasetError: If magnification parameters are invalid or ratio doesn't form a perfect square
         """
-        # Ensure both parameters are magnification strings
+        # Validate that dataset has tile_um set
+        if self.tile_um is None:
+            raise errors.DatasetError("Dataset tile_um must be set before calling extract_lower_mag_tiles_from_tfr")
+
+        # Get source tile_um from dataset
+        source_tile_um = self.tile_um
+
+        # Convert source_tile_um to magnification if it's in microns (int)
+        if isinstance(source_tile_um, int):
+            source_tile_um = sf.util.um_to_mag(source_tile_um)
+
+        # Ensure source_tile_um is a magnification string
         sf.util.assert_is_mag(source_tile_um)
-        sf.util.assert_is_mag(target_tile_um)
 
-        # Convert to numeric magnification values
+        # Validate mag_ratio
+        if not isinstance(mag_ratio, int) or mag_ratio < 1:
+            raise errors.DatasetError(f"mag_ratio must be a positive integer, got {mag_ratio}")
+
+        # Validate that the ratio forms a perfect square (required for tile concatenation)
+        # For example: ratio 4 means 4x4 grid ✓
+        #              ratio 3 is not a perfect square ✗
+        sqrt_ratio = mag_ratio ** 0.5
+        if not sqrt_ratio.is_integer():
+            raise errors.DatasetError(
+                f"Invalid mag_ratio: {mag_ratio}. "
+                f"Ratio must be a perfect square for tile concatenation (e.g., 1, 4, 9, 16). "
+                f"Valid examples: 20x with ratio=4 → 5x (4×4 grid), 40x with ratio=16 → 2.5x (16×16 grid)"
+            )
+
+        # Convert to numeric magnification value
         source_mag = sf.util.to_mag(source_tile_um)
-        target_mag = sf.util.to_mag(target_tile_um)
 
-        # Calculate magnification ratio (how many source tiles combine to make one target tile)
-        mag_ratio = source_mag / target_mag
+        # Calculate target magnification
+        target_mag = source_mag / mag_ratio
 
-        # Validate the ratio
-        if mag_ratio <= 0:
-            raise errors.DatasetError(f"Invalid magnification ratio: {source_tile_um} to {target_tile_um}")
+        # Validate that target_mag is reasonable
+        if target_mag <= 0:
+            raise errors.DatasetError(
+                f"Invalid result: {source_tile_um} with ratio {mag_ratio} produces "
+                f"target magnification {target_mag}x"
+            )
 
-        if not mag_ratio.is_integer() or mag_ratio < 1:
-            raise errors.DatasetError(f"Invalid magnification ratio: {source_tile_um} to {target_tile_um}. Ratio must be a positive integer, got {mag_ratio}")
-
-        return int(mag_ratio)
+        # Return as magnification string
+        if target_mag == int(target_mag):
+            return f"{int(target_mag)}x"
+        else:
+            return f"{target_mag}x"
 
     def _get_lower_mag_tfrecords(self, source: Optional[str] = None) -> List[str]:
         """Get source TFRecords for processing.
@@ -2174,8 +2201,7 @@ class Dataset:
     def extract_lower_mag_tiles_from_tfr(
         self,
         *,
-        source_tile_um: Union[int, str],
-        target_tile_um: Union[int, str],
+        mag_ratio: int,
         source: Optional[str] = None,
         skip_extracted: bool = True,
         report: bool = True,
@@ -2185,18 +2211,21 @@ class Dataset:
 
         This function reads existing high-magnification TFRecord files and combines
         adjacent tiles to create lower-magnification tiles when spatial coverage
-        allows. For example, combining 4x4 grid of 20x tiles to create a single 5x tile.
+        allows. For example, combining a 4×4 grid of 20x tiles (mag_ratio=4) to create
+        a single 5x tile.
 
         The function reconstructs the spatial arrangement of tiles from their stored
         coordinates, identifies regions with sufficient tile coverage to form lower
         magnification tiles, combines the image data, and writes new TFRecord files
         at the target magnification. A PDF report is generated similar to extract_tiles.
 
+        The source magnification is taken from the Dataset's tile_um property.
+
         Keyword Args:
-            source_tile_um (int or str): Source tile size in microns (int) or 
-                magnification (str, e.g. "20x") of the input TFRecords.
-            target_tile_um (int or str): Target tile size in microns (int) or
-                magnification (str, e.g. "5x") for the output TFRecords.
+            mag_ratio (int): Magnification ratio determining how many source tiles
+                combine into one target tile. The grid size will be mag_ratio × mag_ratio.
+                For example, mag_ratio=4 means a 4×4 grid of source tiles (16 tiles total)
+                combine into 1 target tile. Valid values: 1, 4, 9, 16, etc.
             source (str, optional): Name of dataset source from which to select
                 TFRecords for processing. Defaults to None. If not provided, will
                 default to all sources in project.
@@ -2212,19 +2241,15 @@ class Dataset:
             (:class:`slideflow.slide.report.SlideReport`). When report=True,
 
         Raises:
-            DatasetError: If source_tile_um or target_tile_um are invalid, or if
-                the magnification ratio doesn't allow for integer tile combination
-                (e.g., cannot combine 20x tiles to make 7x tiles).
-            ValueError: If target magnification is higher than source magnification,
-                or if required TFRecord directories are not configured.
+            DatasetError: If Dataset tile_um is not set, or if mag_ratio is invalid.
+                For example, mag_ratio=4 (20x→5x, 4×4 grid) is valid, but mag_ratio=3
+                (not a perfect square) is not.
+            ValueError: If required TFRecord directories are not configured.
 
         Example:
-            >>> # Combine 20x tiles to create 5x tiles  
-            >>> dataset = sf.Dataset(...)
-            >>> reports = dataset.extract_lower_mag_tiles_from_tfr(
-            ...     source_tile_um="20x",
-            ...     target_tile_um="5x"
-            ... )
+            >>> # Combine 20x tiles with mag_ratio=4 to create 5x tiles (4×4 grid)
+            >>> dataset = sf.Dataset(..., tile_um="20x")
+            >>> reports = dataset.extract_lower_mag_tiles_from_tfr(mag_ratio=4)
             >>> print(f"Processed {len(reports)} slides")
 
         Note:
@@ -2238,8 +2263,9 @@ class Dataset:
             - Each combined tile's coordinates (loc_x, loc_y) will correspond to the
               center/average coordinates of the source tiles that make up each combined tile.
         """
-        # Validate parameters and calculate magnification ratio
-        mag_ratio = self._validate_lower_mag_params(source_tile_um, target_tile_um)
+        # Validate parameters and calculate target magnification
+        target_tile_um = self._validate_lower_mag_params(mag_ratio)
+        source_tile_um = self.tile_um
         target_tile_px = int(kwargs.get('target_tile_px', 224))
 
         # Get source TFRecords for processing

--- a/slideflow/io/torch/iterable.py
+++ b/slideflow/io/torch/iterable.py
@@ -146,7 +146,7 @@ class InterleaveIterator(torch.utils.data.IterableDataset):
             raise ValueError(
                 f"Expected normalizer to be type StainNormalizer, got: {type(normalizer)}"
             )
-        self.tfrecords = np.array(tfrecords).astype(np.string_)
+        self.tfrecords = np.array(tfrecords).astype(np.bytes_)
         self.prob_weights = None if prob_weights is None else np.array(prob_weights)
         self.clip = clip
         self.indices = indices

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -1470,7 +1470,6 @@ class DualMagnificationFeatures(DatasetFeatures):
             # Apply max_tiles limit if specified
             if max_tiles > 0 and len(slide_features) > max_tiles:
                 # Randomly sample tiles to respect max_tiles limit
-                import numpy as np
                 indices = np.random.choice(len(slide_features), max_tiles, replace=False)
                 slide_features = slide_features[indices]
             
@@ -1575,7 +1574,6 @@ class DualMagnificationFeatures(DatasetFeatures):
             # Apply max_tiles filtering by randomly sampling matched pairs
             if max_tiles is not None and num_matched_tiles > max_tiles:
                 log.info(f"Slide {slide_name} has {num_matched_tiles} matched tiles, randomly sampling {max_tiles}")
-                import numpy as np
                 indices = np.random.choice(num_matched_tiles, max_tiles, replace=False)
                 matched_pairs = [matched_pairs[i] for i in sorted(indices)]
                 num_matched_tiles = max_tiles

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -1263,7 +1263,7 @@ class DualMagnificationFeatures(DatasetFeatures):
     
     def __init__(self, output_dir: str):
         """Initialize with output directory for saving intermediate and final features.
-        
+
         Args:
             output_dir: Directory to save features during extraction
         """
@@ -1284,11 +1284,17 @@ class DualMagnificationFeatures(DatasetFeatures):
         self.slides = []
         self.output_dir = output_dir
 
+        # Store dual magnification metadata
+        self.high_mag_tile_px = None
+        self.high_mag_tile_um = None
+        self.low_mag_tile_px = None
+        self.low_mag_tile_um = None
+
         # Define subdirectories for different feature types
         self.high_mag_dir = os.path.join(output_dir, "high_mag_features")
         self.low_mag_dir = os.path.join(output_dir, "low_mag_features")
         self.concatenated_dir = os.path.join(output_dir, "concatenated_features")
-        
+
         # Create subdirectories
         os.makedirs(self.high_mag_dir, exist_ok=True)
         os.makedirs(self.low_mag_dir, exist_ok=True)
@@ -1296,12 +1302,43 @@ class DualMagnificationFeatures(DatasetFeatures):
     
     def dump_config(self):
         """Override dump_config to provide consistent configuration for dual magnification features."""
+        # Get extractor config if available
+        if hasattr(self, 'extractor') and self.extractor is not None:
+            try:
+                # Try to get the extractor's dump_config (for built extractors)
+                if hasattr(self.extractor, 'dump_config'):
+                    extractor_config = self.extractor.dump_config()
+                elif hasattr(self.extractor, 'generator') and hasattr(self.extractor.generator, 'dump_config'):
+                    extractor_config = self.extractor.generator.dump_config()
+                else:
+                    extractor_config = getattr(self, 'model', 'dual_magnification_concatenated')
+            except:
+                extractor_config = getattr(self, 'model', 'dual_magnification_concatenated')
+        else:
+            extractor_config = getattr(self, 'model', 'dual_magnification_concatenated')
+
+        # Get normalizer config if available
+        normalizer_config = None
+        if hasattr(self, 'normalizer') and self.normalizer is not None:
+            normalizer_config = dict(
+                method=self.normalizer.method,
+                fit=self.normalizer.get_fit(as_list=True),
+            )
+
         return {
-            'model': 'dual_magnification_concatenated',
-            'dataset': None,
-            'extractor': None,
-            'tile_px': self.tile_px,
-            'tile_um': None,
+            'extractor': extractor_config,
+            'normalizer': normalizer_config,
+            'num_features': self.num_features,
+            # Include both specific and legacy fields
+            'tile_px': self.high_mag_tile_px,  # Legacy field
+            'tile_um': self.high_mag_tile_um,  # Legacy field
+            'high_mag_tile_px': self.high_mag_tile_px,
+            'high_mag_tile_um': self.high_mag_tile_um,
+            'low_mag_tile_px': self.low_mag_tile_px,
+            'low_mag_tile_um': self.low_mag_tile_um,
+            'high_mag_features_path': getattr(self, 'high_mag_features_path', None),
+            'low_mag_features_path': getattr(self, 'low_mag_features_path', None),
+            'concatenated_dir': self.concatenated_dir,
             'slides': self.slides,
             'features_version': sf.__version__
         } 
@@ -1361,15 +1398,25 @@ class DualMagnificationFeatures(DatasetFeatures):
         else:
             # At least one set of features needs to be extracted
             # Find common slides between high and low magnification datasets
-            high_slides = set(sf.util.path_to_name(tfr) for tfr in high_mag_dataset.tfrecords())
-            low_slides = set(sf.util.path_to_name(tfr) for tfr in low_mag_dataset.tfrecords())
+            high_tfrs = high_mag_dataset.tfrecords()
+            low_tfrs = low_mag_dataset.tfrecords()
+            high_slides = set(sf.util.path_to_name(tfr) for tfr in high_tfrs)
+            low_slides = set(sf.util.path_to_name(tfr) for tfr in low_tfrs)
             common_slides = high_slides.intersection(low_slides)
-            
+
             log.info(f"Found {len(high_slides)} high mag slides, {len(low_slides)} low mag slides")
+            log.debug(f"High mag TFRecords: {[sf.util.path_to_name(t) for t in high_tfrs[:5]]}...")
+            log.debug(f"Low mag TFRecords: {[sf.util.path_to_name(t) for t in low_tfrs[:5]]}...")
             log.info(f"Common slides for dual extraction: {len(common_slides)}")
-            
+
             if not common_slides:
-                raise ValueError("No common slides found between high and low magnification datasets")
+                log.error(f"High mag slides: {sorted(high_slides)[:10]}")
+                log.error(f"Low mag slides: {sorted(low_slides)[:10]}")
+                raise ValueError(
+                    f"No common slides found between high and low magnification datasets. "
+                    f"High mag has {len(high_slides)} slides, low mag has {len(low_slides)} slides. "
+                    f"Check that both datasets are finding TFRecords in the correct directories."
+                )
             
             # Filter datasets to only include common slides
             high_mag_dataset = self._filter_dataset_by_slides(high_mag_dataset, common_slides)
@@ -1384,9 +1431,15 @@ class DualMagnificationFeatures(DatasetFeatures):
                     log.info(f"Building feature extractor: {model_path}")
                     kwargs['device'] = device
                     extractor = sf.build_feature_extractor(model_path, tile_px=high_mag_dataset.tile_px, **kwargs)
+                    # Store model name for config
+                    self.model = model_path
                 else:
                     # File path to saved model
                     extractor = model_path
+                    self.model = model_path
+
+                # Store extractor for accessing normalizer later
+                self.extractor = extractor
             
             # Step 1: Handle high magnification features
             if has_high_features:
@@ -1530,22 +1583,31 @@ class DualMagnificationFeatures(DatasetFeatures):
     ):
         """Create concatenated features with spatial matching logic."""
         import pandas as pd
-        
+
+        # Store dataset metadata for config
+        self.high_mag_tile_px = high_mag_dataset.tile_px
+        self.high_mag_tile_um = high_mag_dataset.tile_um
+        self.low_mag_tile_px = low_mag_dataset.tile_px
+        self.low_mag_tile_um = low_mag_dataset.tile_um
+
+        log.info(f"Dual magnification config: High mag {self.high_mag_tile_px}px @ {self.high_mag_tile_um}, "
+                 f"Low mag {self.low_mag_tile_px}px @ {self.low_mag_tile_um}")
+
         # Get feature data
         high_activations = high_mag_features.activations
         high_locations = high_mag_features.locations
         low_activations = low_mag_features.activations
         low_locations = low_mag_features.locations
-        
+
         # Initialize containers
         self.activations = defaultdict(list)
         self.locations = defaultdict(list)
         self.predictions = defaultdict(list)
         self.uncertainty = defaultdict(list)
-        
+
         # Initialize list to collect matched tile data
         matched_tiles_data = []
-        
+
         # Process each slide with spatial matching
         slides_processed = 0
         for slide_name in track(high_activations.keys(), description="Matching and concatenating features"):
@@ -1792,22 +1854,6 @@ class DualMagnificationFeatures(DatasetFeatures):
         
         log.debug(f"Created filtered dataset with {len(filtered_dataset.tfrecords())} TFRecords")
         return filtered_dataset
-    
-    def dump_config(self):
-        """Return a dictionary of the dual magnification feature extraction configuration."""
-        # For dual magnification features, we don't have a single feature generator
-        # Return a simplified config that indicates this is a dual magnification extraction
-        config = dict(
-            extractor="dual_magnification_concatenated",
-            normalizer=None,
-            num_features=self.num_features,
-            tile_px=getattr(self, 'tile_px', None),
-            tile_um=getattr(self, 'tile_um', None),
-            high_mag_features_path=getattr(self, 'high_mag_features_path', None),
-            low_mag_features_path=getattr(self, 'low_mag_features_path', None),
-            concatenated_dir=getattr(self, 'concatenated_dir', None)
-        )
-        return config
 
 # -----------------------------------------------------------------------------
 

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -1336,8 +1336,9 @@ class DualMagnificationFeatures(DatasetFeatures):
             'high_mag_tile_um': self.high_mag_tile_um,
             'low_mag_tile_px': self.low_mag_tile_px,
             'low_mag_tile_um': self.low_mag_tile_um,
-            'high_mag_features_path': getattr(self, 'high_mag_features_path', None),
-            'low_mag_features_path': getattr(self, 'low_mag_features_path', None),
+            # Store the TFRecord directory paths (where features were extracted from)
+            'high_mag_features_path': getattr(self, 'high_mag_tfr_dir', None),
+            'low_mag_features_path': getattr(self, 'low_mag_tfr_dir', None),
             'concatenated_dir': self.concatenated_dir,
             'slides': self.slides,
             'features_version': sf.__version__

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -1311,6 +1311,7 @@ class DualMagnificationFeatures(DatasetFeatures):
         high_mag_dataset: "sf.Dataset",
         low_mag_dataset: "sf.Dataset",
         model_path: str,
+        device = 'cuda',
         *,
         batch_size: int = 32,
         num_workers: int = 4,
@@ -1381,8 +1382,7 @@ class DualMagnificationFeatures(DatasetFeatures):
                 if isinstance(model_path, str) and not os.path.exists(model_path):
                     # Built-in feature extractor
                     log.info(f"Building feature extractor: {model_path}")
-                    if 'device' not in kwargs:
-                        kwargs['device'] = 'cpu' if not sf.util.torch_utils.gpu_available() else 'cuda'
+                    kwargs['device'] = device
                     extractor = sf.build_feature_extractor(model_path, tile_px=high_mag_dataset.tile_px, **kwargs)
                 else:
                     # File path to saved model

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -1309,11 +1309,13 @@ class DualMagnificationFeatures(DatasetFeatures):
     def extract_and_concatenate(
         self,
         high_mag_dataset: "sf.Dataset",
-        low_mag_dataset: "sf.Dataset", 
+        low_mag_dataset: "sf.Dataset",
         model_path: str,
         *,
         batch_size: int = 32,
         num_workers: int = 4,
+        min_tiles: Optional[int] = None,
+        max_tiles: Optional[int] = None,
         high_mag_features_path: Optional[str] = None,
         low_mag_features_path: Optional[str] = None,
         **kwargs
@@ -1326,6 +1328,8 @@ class DualMagnificationFeatures(DatasetFeatures):
             model_path: Path to model or name of built-in feature extractor
             batch_size: Batch size for feature extraction
             num_workers: Number of worker processes
+            min_tiles: Minimum tiles per slide. Slides with fewer tiles are excluded.
+            max_tiles: Maximum tiles per slide. Excess tiles are randomly sampled.
             high_mag_features_path: Path to pre-extracted high mag features (for concatenate_only mode)
             low_mag_features_path: Path to pre-extracted low mag features (for concatenate_only mode)
             **kwargs: Additional arguments passed to feature extraction
@@ -1410,7 +1414,7 @@ class DualMagnificationFeatures(DatasetFeatures):
         
         # Step 3: Create concatenated features with spatial matching
         log.info("Creating concatenated features with spatial matching...")
-        self._create_concatenated_features(high_mag_features, low_mag_features, high_mag_dataset, low_mag_dataset)
+        self._create_concatenated_features(high_mag_features, low_mag_features, high_mag_dataset, low_mag_dataset, min_tiles, max_tiles)
         log.info(f"Concatenated features saved iteratively to {self.concatenated_dir}")
     
         return self
@@ -1517,11 +1521,13 @@ class DualMagnificationFeatures(DatasetFeatures):
         return features
     
     def _create_concatenated_features(
-        self, 
-        high_mag_features: DatasetFeatures, 
+        self,
+        high_mag_features: DatasetFeatures,
         low_mag_features: DatasetFeatures,
         high_mag_dataset: "sf.Dataset",
-        low_mag_dataset: "sf.Dataset"
+        low_mag_dataset: "sf.Dataset",
+        min_tiles: Optional[int] = None,
+        max_tiles: Optional[int] = None
     ):
         """Create concatenated features with spatial matching logic."""
         import pandas as pd
@@ -1547,19 +1553,33 @@ class DualMagnificationFeatures(DatasetFeatures):
             if slide_name not in low_activations:
                 log.warning(f"Slide {slide_name} found in high mag but not low mag - skipping")
                 continue
-                
+
             # Get tile coordinates and features
             high_coords = high_locations[slide_name]
-            high_feats = high_activations[slide_name] 
+            high_feats = high_activations[slide_name]
             low_coords = low_locations[slide_name]
             low_feats = low_activations[slide_name]
-            
+
             # Spatial matching logic - pass the datasets to calculate proper thresholds
             matched_pairs = self._find_spatial_matches(
                 high_coords, high_feats, low_coords, low_feats,
                 high_mag_dataset, low_mag_dataset
             )
-            
+
+            # Early filtering: check if we have enough matched pairs before processing
+            num_matched_tiles = len(matched_pairs)
+            if min_tiles is not None and num_matched_tiles < min_tiles:
+                log.warning(f"Slide {slide_name} has only {num_matched_tiles} matched tiles (< {min_tiles}), skipping")
+                continue
+
+            # Apply max_tiles filtering by randomly sampling matched pairs
+            if max_tiles is not None and num_matched_tiles > max_tiles:
+                log.info(f"Slide {slide_name} has {num_matched_tiles} matched tiles, randomly sampling {max_tiles}")
+                import numpy as np
+                indices = np.random.choice(num_matched_tiles, max_tiles, replace=False)
+                matched_pairs = [matched_pairs[i] for i in sorted(indices)]
+                num_matched_tiles = max_tiles
+
             # Create concatenated features for matched pairs
             for high_idx, low_idx, high_coord, distance in matched_pairs:
                 high_feat = high_feats[high_idx]
@@ -1611,7 +1631,7 @@ class DualMagnificationFeatures(DatasetFeatures):
                 
                 # Save individual torch files for this slide immediately (but not config yet)
                 self._save_single_slide_torch_files(slide_name)
-                log.info(f"✓ Saved concatenated features for slide {slide_name} ({len(matched_pairs)} tiles)")
+                log.info(f"✓ Saved concatenated features for slide {slide_name} ({num_matched_tiles} tiles)")
             else:
                 log.warning(f"No concatenated features created for slide {slide_name}")
             

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -1406,9 +1406,6 @@ class DualMagnificationFeatures(DatasetFeatures):
             common_slides = high_slides.intersection(low_slides)
 
             log.info(f"Found {len(high_slides)} high mag slides, {len(low_slides)} low mag slides")
-            log.debug(f"High mag TFRecords: {[sf.util.path_to_name(t) for t in high_tfrs[:5]]}...")
-            log.debug(f"Low mag TFRecords: {[sf.util.path_to_name(t) for t in low_tfrs[:5]]}...")
-            log.info(f"Common slides for dual extraction: {len(common_slides)}")
 
             if not common_slides:
                 log.error(f"High mag slides: {sorted(high_slides)[:10]}")

--- a/slideflow/model/features.py
+++ b/slideflow/model/features.py
@@ -8,6 +8,8 @@ import time
 import warnings
 import multiprocessing as mp
 from collections import defaultdict
+import glob
+from pathlib import Path
 from math import isnan
 from os.path import exists, join
 from typing import (
@@ -1251,6 +1253,545 @@ class DatasetFeatures:
         return self.softmax_predict(*args, **kwargs)
 
 # -----------------------------------------------------------------------------
+class DualMagnificationFeatures(DatasetFeatures):
+    """Specialized subclass for extracting and concatenating features from dual magnification tiles.
+    
+    This class handles the extraction of features from both high and low magnification tiles,
+    performs spatial matching between corresponding tiles, and creates concatenated feature vectors.
+    Features are saved incrementally during the process for memory efficiency and resumability.
+    """
+    
+    def __init__(self, output_dir: str):
+        """Initialize with output directory for saving intermediate and final features.
+        
+        Args:
+            output_dir: Directory to save features during extraction
+        """
+        # Initialize the basic attributes without calling parent __init__
+        # to avoid the "0/0 slides" logging from DatasetFeatures.__init__
+        self.activations = defaultdict(list)
+        self.predictions = defaultdict(list)
+        self.uncertainty = defaultdict(list)
+        self.locations = defaultdict(list)
+        self.num_features = 0
+        self.num_classes = 0
+        self.model = None
+        self.dataset = None
+        self.feature_generator = None
+        self.tile_px = None
+        self.manifest = dict()
+        self.tfrecords = []
+        self.slides = []
+        self.output_dir = output_dir
+
+        # Define subdirectories for different feature types
+        self.high_mag_dir = os.path.join(output_dir, "high_mag_features")
+        self.low_mag_dir = os.path.join(output_dir, "low_mag_features")
+        self.concatenated_dir = os.path.join(output_dir, "concatenated_features")
+        
+        # Create subdirectories
+        os.makedirs(self.high_mag_dir, exist_ok=True)
+        os.makedirs(self.low_mag_dir, exist_ok=True)
+        os.makedirs(self.concatenated_dir, exist_ok=True)
+    
+    def dump_config(self):
+        """Override dump_config to provide consistent configuration for dual magnification features."""
+        return {
+            'model': 'dual_magnification_concatenated',
+            'dataset': None,
+            'extractor': None,
+            'tile_px': self.tile_px,
+            'tile_um': None,
+            'slides': self.slides,
+            'features_version': sf.__version__
+        } 
+    
+    def extract_and_concatenate(
+        self,
+        high_mag_dataset: "sf.Dataset",
+        low_mag_dataset: "sf.Dataset", 
+        model_path: str,
+        *,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        high_mag_features_path: Optional[str] = None,
+        low_mag_features_path: Optional[str] = None,
+        **kwargs
+    ) -> "DualMagnificationFeatures":
+        """Extract features from both magnifications and concatenate spatially corresponding tiles.
+        
+        Args:
+            high_mag_dataset: Dataset containing high magnification TFRecords
+            low_mag_dataset: Dataset containing low magnification TFRecords
+            model_path: Path to model or name of built-in feature extractor
+            batch_size: Batch size for feature extraction
+            num_workers: Number of worker processes
+            high_mag_features_path: Path to pre-extracted high mag features (for concatenate_only mode)
+            low_mag_features_path: Path to pre-extracted low mag features (for concatenate_only mode)
+            **kwargs: Additional arguments passed to feature extraction
+            
+        Returns:
+            Self with concatenated features loaded
+        """
+        
+        # Set up paths for checking existing features  
+        self.high_mag_features_path = high_mag_features_path
+        self.low_mag_features_path = low_mag_features_path
+
+        log.info(f"High mag features save to {self.high_mag_dir}")
+        log.info(f"Low mag features save to {self.low_mag_dir}")
+        log.info(f"Concatenated features will save to {self.concatenated_dir}")
+
+        # Check which features are already available
+        has_high_features = high_mag_features_path and os.path.exists(high_mag_features_path)
+        has_low_features = low_mag_features_path and os.path.exists(low_mag_features_path)
+        
+        if has_high_features and has_low_features:
+            log.info("Full concatenate-only mode: Loading pre-extracted features...")
+            log.info(f"Loading high mag features from: {high_mag_features_path}")
+            high_mag_features = DatasetFeatures.from_bags(high_mag_features_path)
+            log.info(f"Loading low mag features from: {low_mag_features_path}")
+            low_mag_features = DatasetFeatures.from_bags(low_mag_features_path)
+            
+        else:
+            # At least one set of features needs to be extracted
+            # Find common slides between high and low magnification datasets
+            high_slides = set(sf.util.path_to_name(tfr) for tfr in high_mag_dataset.tfrecords())
+            low_slides = set(sf.util.path_to_name(tfr) for tfr in low_mag_dataset.tfrecords())
+            common_slides = high_slides.intersection(low_slides)
+            
+            log.info(f"Found {len(high_slides)} high mag slides, {len(low_slides)} low mag slides")
+            log.info(f"Common slides for dual extraction: {len(common_slides)}")
+            
+            if not common_slides:
+                raise ValueError("No common slides found between high and low magnification datasets")
+            
+            # Filter datasets to only include common slides
+            high_mag_dataset = self._filter_dataset_by_slides(high_mag_dataset, common_slides)
+            low_mag_dataset = self._filter_dataset_by_slides(low_mag_dataset, common_slides)
+            
+            log.info(f"Filtered datasets - High: {len(high_mag_dataset.tfrecords())} TFRecords, Low: {len(low_mag_dataset.tfrecords())} TFRecords")
+            
+            # Build feature extractor if needed (only if we need to extract features)
+            if not has_high_features or not has_low_features:
+                if isinstance(model_path, str) and not os.path.exists(model_path):
+                    # Built-in feature extractor
+                    log.info(f"Building feature extractor: {model_path}")
+                    if 'device' not in kwargs:
+                        kwargs['device'] = 'cpu' if not sf.util.torch_utils.gpu_available() else 'cuda'
+                    extractor = sf.build_feature_extractor(model_path, tile_px=high_mag_dataset.tile_px, **kwargs)
+                else:
+                    # File path to saved model
+                    extractor = model_path
+            
+            # Step 1: Handle high magnification features
+            if has_high_features:
+                log.info(f"Loading existing high mag features from: {high_mag_features_path}")
+                high_mag_features = DatasetFeatures.from_bags(high_mag_features_path)
+            else:
+                log.info("Extracting features from high magnification tiles...")
+                high_mag_features = self._extract_features_with_extractor(
+                    high_mag_dataset, extractor, batch_size, num_workers, **kwargs
+                )
+                high_mag_features.to_torch(self.high_mag_dir, verbose=True)
+                log.info(f"Saved high mag features to {self.high_mag_dir}")
+            
+            # Step 2: Handle low magnification features
+            if has_low_features:
+                log.info(f"Loading existing low mag features from: {low_mag_features_path}")
+                low_mag_features = DatasetFeatures.from_bags(low_mag_features_path)
+            else:
+                log.info("Extracting features from low magnification tiles...")
+                low_mag_features = self._extract_features_with_extractor(
+                    low_mag_dataset, extractor, batch_size, num_workers, **kwargs
+                )
+                low_mag_features.to_torch(self.low_mag_dir, verbose=True)
+                log.info(f"Saved low mag features to {self.low_mag_dir}")
+        
+        # Step 3: Create concatenated features with spatial matching
+        log.info("Creating concatenated features with spatial matching...")
+        self._create_concatenated_features(high_mag_features, low_mag_features, high_mag_dataset, low_mag_dataset)
+        log.info(f"Concatenated features saved iteratively to {self.concatenated_dir}")
+    
+        return self
+    
+    def to_bags(
+        self,
+        bags_dir: str,
+        *,
+        min_tiles: int = 16,
+        max_tiles: int = 0,
+        **kwargs
+    ) -> str:
+        """Convert the concatenated dual magnification features to bags for MIL training.
+        
+        This method converts all concatenated features to bags without additional filtering,
+        since the concatenated features already represent the intersection of slides that
+        exist in both high and low magnification datasets.
+        
+        Args:
+            bags_dir (str): Output directory for bags
+            
+        Keyword Args:
+            min_tiles (int): Minimum tiles per slide. Defaults to 16.
+            max_tiles (int): Maximum tiles per slide. Defaults to 0 (no limit).
+            **kwargs: Additional arguments (for compatibility)
+            
+        Returns:
+            str: Path to bags directory
+        """
+        import torch
+        
+        # Load the concatenated features
+        log.info(f"Loading concatenated dual magnification features from {self.concatenated_dir}")
+        features = DatasetFeatures.from_bags(self.concatenated_dir)
+        
+        # Use all available slides (no additional filtering needed)
+        slides_to_convert = features.slides
+        log.info(f"Converting all {len(slides_to_convert)} dual magnification slides to bags")
+        
+        # Create output directory
+        os.makedirs(bags_dir, exist_ok=True)
+        
+        # Convert each slide's features to a bag
+        log.info(f"Converting concatenated features to bags in {bags_dir}")
+        for slide in track(slides_to_convert, description="Creating bags"):
+            if slide not in features.activations:
+                log.warning(f"No features found for slide {slide}, skipping")
+                continue
+                
+            # Get features for this slide
+            slide_features = features.activations[slide]
+            
+            # Apply max_tiles limit if specified
+            if max_tiles > 0 and len(slide_features) > max_tiles:
+                # Randomly sample tiles to respect max_tiles limit
+                import numpy as np
+                indices = np.random.choice(len(slide_features), max_tiles, replace=False)
+                slide_features = slide_features[indices]
+            
+            # Apply min_tiles filter
+            if len(slide_features) < min_tiles:
+                log.warning(f"Slide {slide} has only {len(slide_features)} tiles (< {min_tiles}), skipping")
+                continue
+            
+            # Convert to torch tensor and save as bag
+            bag_tensor = torch.from_numpy(slide_features).float()
+            bag_path = os.path.join(bags_dir, f"{slide}.pt")
+            torch.save(bag_tensor, bag_path)
+        
+        # Count successful conversions
+        bag_files = [f for f in os.listdir(bags_dir) if f.endswith('.pt')]
+        log.info(f"Successfully created {len(bag_files)} dual magnification bags in {bags_dir}")
+        
+        return bags_dir
+    
+    def _extract_features_with_extractor(
+        self, 
+        dataset: "sf.Dataset", 
+        extractor, 
+        batch_size: int, 
+        num_workers: int,
+        **kwargs
+    ) -> DatasetFeatures:
+        """Extract features from a single dataset using a pre-built extractor."""
+        
+        log.info(f"Starting feature extraction with batch_size={batch_size}, num_workers={num_workers}")
+        log.info(f"Dataset has {len(dataset.tfrecords())} TFRecords")
+        
+        # Extract features
+        features = DatasetFeatures(
+            extractor,
+            dataset, 
+            batch_size=batch_size,
+            num_workers=num_workers,
+            progress=True,
+            **kwargs
+        )
+        
+        # Debug logging to check what we extracted
+        log.info(f"Feature extraction completed. Extracted features for {len(features.slides)} slides")
+        log.debug(f"Feature slides list: {features.slides}")
+        log.debug(f"Number of features per vector: {features.num_features}")
+            
+        return features
+    
+    def _create_concatenated_features(
+        self, 
+        high_mag_features: DatasetFeatures, 
+        low_mag_features: DatasetFeatures,
+        high_mag_dataset: "sf.Dataset",
+        low_mag_dataset: "sf.Dataset"
+    ):
+        """Create concatenated features with spatial matching logic."""
+        import pandas as pd
+        
+        # Get feature data
+        high_activations = high_mag_features.activations
+        high_locations = high_mag_features.locations
+        low_activations = low_mag_features.activations
+        low_locations = low_mag_features.locations
+        
+        # Initialize containers
+        self.activations = defaultdict(list)
+        self.locations = defaultdict(list)
+        self.predictions = defaultdict(list)
+        self.uncertainty = defaultdict(list)
+        
+        # Initialize list to collect matched tile data
+        matched_tiles_data = []
+        
+        # Process each slide with spatial matching
+        slides_processed = 0
+        for slide_name in track(high_activations.keys(), description="Matching and concatenating features"):
+            if slide_name not in low_activations:
+                log.warning(f"Slide {slide_name} found in high mag but not low mag - skipping")
+                continue
+                
+            # Get tile coordinates and features
+            high_coords = high_locations[slide_name]
+            high_feats = high_activations[slide_name] 
+            low_coords = low_locations[slide_name]
+            low_feats = low_activations[slide_name]
+            
+            # Spatial matching logic - pass the datasets to calculate proper thresholds
+            matched_pairs = self._find_spatial_matches(
+                high_coords, high_feats, low_coords, low_feats,
+                high_mag_dataset, low_mag_dataset
+            )
+            
+            # Create concatenated features for matched pairs
+            for high_idx, low_idx, high_coord, distance in matched_pairs:
+                high_feat = high_feats[high_idx]
+                low_feat = low_feats[low_idx]
+                low_coord = low_coords[low_idx]
+                
+                # Log matched tile data
+                matched_tiles_data.append({
+                    'slide_name': slide_name,
+                    'high_mag_x': high_coord[0],
+                    'high_mag_y': high_coord[1], 
+                    'low_mag_x': low_coord[0],
+                    'low_mag_y': low_coord[1],
+                    'distance': distance,
+                    'high_mag_idx': high_idx,
+                    'low_mag_idx': low_idx
+                })
+                
+                # Concatenate features
+                concat_feat = np.concatenate([high_feat, low_feat])
+                
+                self.activations[slide_name].append(concat_feat)
+                self.locations[slide_name].append(high_coord)
+                
+                # Handle predictions if available
+                if (slide_name in high_mag_features.predictions and 
+                    slide_name in low_mag_features.predictions):
+                    high_pred = high_mag_features.predictions[slide_name][high_idx]
+                    low_pred = low_mag_features.predictions[slide_name][low_idx]
+                    concat_pred = np.concatenate([high_pred, low_pred])
+                    self.predictions[slide_name].append(concat_pred)
+                
+                # Handle uncertainty if available  
+                if (slide_name in high_mag_features.uncertainty and
+                    slide_name in low_mag_features.uncertainty):
+                    high_unc = high_mag_features.uncertainty[slide_name][high_idx]
+                    low_unc = low_mag_features.uncertainty[slide_name][low_idx]
+                    concat_unc = np.concatenate([high_unc, low_unc])
+                    self.uncertainty[slide_name].append(concat_unc)
+            
+            # Convert lists to numpy arrays for this slide
+            if self.activations[slide_name]:
+                self.activations[slide_name] = np.stack(self.activations[slide_name])
+                self.locations[slide_name] = np.stack(self.locations[slide_name])
+                if self.predictions[slide_name]:
+                    self.predictions[slide_name] = np.stack(self.predictions[slide_name])
+                if self.uncertainty[slide_name]:
+                    self.uncertainty[slide_name] = np.stack(self.uncertainty[slide_name])
+                
+                # Save individual torch files for this slide immediately (but not config yet)
+                self._save_single_slide_torch_files(slide_name)
+                log.info(f"✓ Saved concatenated features for slide {slide_name} ({len(matched_pairs)} tiles)")
+            else:
+                log.warning(f"No concatenated features created for slide {slide_name}")
+            
+            slides_processed += 1
+        
+        # Arrays were already converted and saved per slide above
+        
+        # Set metadata
+        self.slides = list(self.activations.keys())
+        self.num_features = self.activations[self.slides[0]].shape[-1] if self.slides else 0
+        self.num_classes = (self.predictions[self.slides[0]].shape[-1] 
+                           if self.slides and self.predictions[self.slides[0]] else 0)
+        
+        # Save matched tiles data to CSV
+        if matched_tiles_data:
+            matched_df = pd.DataFrame(matched_tiles_data)
+            csv_path = os.path.join(self.output_dir, "matched_tiles_coordinates.csv")
+            matched_df.to_csv(csv_path, index=False)
+            log.info(f"Saved {len(matched_tiles_data)} matched tile pairs to {csv_path}")
+        else:
+            log.warning("No matched tiles data to save")
+        
+        # Save the final config file now that all slides are processed
+        self._save_concatenated_config()
+        
+        log.info(f"Successfully processed {slides_processed} slides")
+        log.info(f"Concatenated feature extraction complete. Total features per tile: {self.num_features}")
+    
+    def _find_spatial_matches(self, high_coords, high_feats, low_coords, low_feats, high_mag_dataset, low_mag_dataset):
+        """Find spatial matches between high and low magnification tiles."""
+        
+        matched_pairs = []
+        
+        # Get magnification info from datasets using slideflow's utility functions
+        high_mag_px = high_mag_dataset.tile_px
+        low_mag_px = low_mag_dataset.tile_px
+        high_mag_um = high_mag_dataset.tile_um
+        low_mag_um = low_mag_dataset.tile_um
+        
+        # Convert tile_um to actual magnification values using slideflow's utility functions
+        if sf.util.is_mag(str(high_mag_um)):
+            high_mag_val = sf.util.to_mag(str(high_mag_um))
+        else:
+            # Convert microns to magnification using slideflow's formula
+            high_mag_val = 10 / (int(high_mag_um) / high_mag_px)
+            
+        if sf.util.is_mag(str(low_mag_um)):
+            low_mag_val = sf.util.to_mag(str(low_mag_um))
+        else:
+            # Convert microns to magnification using slideflow's formula
+            low_mag_val = 10 / (int(low_mag_um) / low_mag_px)
+        
+        # Calculate the magnification ratio
+        mag_ratio = high_mag_val / low_mag_val
+        
+        # Calculate spatial threshold: low mag tile covers larger area
+        # The coordinate system is typically in tile pixels, so we need to account for 
+        # the fact that a low mag tile covers the area of multiple high mag tiles
+        spatial_threshold = low_mag_px * mag_ratio / 2  # Half coverage for overlap tolerance
+        
+        # For each low magnification tile, find all high magnification tiles that fall within it
+        for j, low_coord in enumerate(low_coords):
+            for i, high_coord in enumerate(high_coords):
+                # Calculate spatial distance between tile centers in coordinate space
+                x_offset = abs(high_coord[0] - low_coord[0])
+                y_offset = abs(high_coord[1] - low_coord[1])
+                distance = np.sqrt(x_offset**2 + y_offset**2)
+                
+                # Check if the high mag tile falls within the low mag tile's coverage area
+                if x_offset <= spatial_threshold and y_offset <= spatial_threshold:
+                    matched_pairs.append((i, j, high_coord, distance))
+        
+        return matched_pairs
+    
+    
+    def _save_single_slide_torch_files(self, slide_name: str):
+        """Save torch and index files for a single slide without config."""
+        import torch
+        from os.path import join
+        
+        # Ensure output directory exists
+        if not os.path.exists(self.concatenated_dir):
+            os.makedirs(self.concatenated_dir)
+        
+        # Save the torch file
+        if len(self.activations[slide_name]):
+            slide_activations = torch.from_numpy(
+                self.activations[slide_name].astype(np.float32)
+            )
+            torch.save(slide_activations, join(self.concatenated_dir, f'{slide_name}.pt'))
+            
+            # Save the index file
+            sf.io.tfrecord2idx.save_index(
+                self.locations[slide_name],
+                join(self.concatenated_dir, f'{slide_name}.index')
+            )
+    
+    def _save_concatenated_config(self):
+        """Save the configuration file for concatenated features."""
+        from os.path import join
+        
+        config = self.dump_config()
+        config_path = join(self.concatenated_dir, 'bags_config.json')
+        sf.util.write_json(config, config_path)
+        log.info(f"Saved concatenated features config to {config_path}")
+    
+    def _save_concatenated_features(self):
+        """Save concatenated features to pickle file."""
+        with open(self.concatenated_dir, 'wb') as f:
+            pickle.dump({
+                'activations': self.activations,
+                'locations': self.locations,
+                'predictions': self.predictions,
+                'uncertainty': self.uncertainty,
+                'slides': self.slides,
+                'num_features': self.num_features,
+                'num_classes': self.num_classes
+            }, f)
+    
+    def _load_concatenated_features(self):
+        """Load concatenated features from pickle file."""
+        with open(self.concatenated_dir, 'rb') as f:
+            data = pickle.load(f)
+        
+        self.activations = data['activations']
+        self.locations = data['locations']
+        self.predictions = data['predictions'] 
+        self.uncertainty = data['uncertainty']
+        self.slides = data['slides']
+        self.num_features = data['num_features']
+        self.num_classes = data['num_classes']
+    
+    def _filter_dataset_by_slides(self, dataset: "sf.Dataset", slide_names: set) -> "sf.Dataset":
+        """Filter a dataset to only include TFRecords for the specified slides.
+        
+        Args:
+            dataset: The dataset to filter
+            slide_names: Set of slide names to keep
+            
+        Returns:
+            New dataset containing only TFRecords for the specified slides
+        """
+        # Get all TFRecord files from the dataset
+        all_tfrecords = dataset.tfrecords()
+        log.debug(f"Original dataset has {len(all_tfrecords)} TFRecords")
+        
+        # Filter to only include TFRecords for slides in the slide_names set
+        filtered_tfrecords = []
+        for tfr_path in all_tfrecords:
+            slide_name = sf.util.path_to_name(tfr_path)
+            if slide_name in slide_names:
+                filtered_tfrecords.append(tfr_path)
+        
+        log.debug(f"Filtered dataset will have {len(filtered_tfrecords)} TFRecords")
+        
+        # Use the standard filter approach to preserve all dataset attributes including source_um
+        # Create a filter that includes only the slide names we want
+        slide_filter = {'slide': list(slide_names)}
+        filtered_dataset = dataset.filter(slide_filter)
+        
+        log.debug(f"Created filtered dataset with {len(filtered_dataset.tfrecords())} TFRecords")
+        return filtered_dataset
+    
+    def dump_config(self):
+        """Return a dictionary of the dual magnification feature extraction configuration."""
+        # For dual magnification features, we don't have a single feature generator
+        # Return a simplified config that indicates this is a dual magnification extraction
+        config = dict(
+            extractor="dual_magnification_concatenated",
+            normalizer=None,
+            num_features=self.num_features,
+            tile_px=getattr(self, 'tile_px', None),
+            tile_um=getattr(self, 'tile_um', None),
+            high_mag_features_path=getattr(self, 'high_mag_features_path', None),
+            low_mag_features_path=getattr(self, 'low_mag_features_path', None),
+            concatenated_dir=getattr(self, 'concatenated_dir', None)
+        )
+        return config
+
+# -----------------------------------------------------------------------------
 
 class _FeatureGenerator:
     """Provides common API for feature generator interfaces."""
@@ -1418,7 +1959,7 @@ class _FeatureGenerator:
         elif self.is_torch():
             slides = batch_slides
             model_out = [
-                m.cpu().numpy() if not isinstance(m, list) else m
+                m.cpu().float().numpy() if not isinstance(m, list) else m # REVERT ASAP THIS IS JSUT FOR TESTING WITHOUT CUDA
                 for m in model_out
             ]
             if batch_loc[0] is not None:
@@ -1753,7 +2294,6 @@ class _FeatureGenerator:
         batch_proc_thread.join()
         if hasattr(dataset, 'close'):
             dataset.close()
-
         return activations, predictions, locations, uncertainty
 
 

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -2077,12 +2077,17 @@ class Project:
 
     def extract_dual_magnification_features(
         self,
-        high_mag_tfr_dir: str,
-        low_mag_tfr_dir: str,
         model_path: str,
         output_dir: str,
         device = 'cuda',
         *,
+        high_mag_tfr_dir: Optional[str] = None,
+        low_mag_tfr_dir: Optional[str] = None,
+        sources: Optional[Union[str, List[str]]] = None,
+        high_mag_um: Optional[int] = None,
+        low_mag_um: Optional[int] = None,
+        tile_px: Optional[int] = None,
+        mag_ratio: Optional[int] = None,
         filters: Optional[Dict] = None,
         batch_size: int = 32,
         num_workers: int = 4,
@@ -2101,13 +2106,33 @@ class Project:
         The output concatenated features are saved as individual .pt files per slide with
         accompanying .index files containing coordinate information. These files are directly
         compatible with MIL training without requiring additional conversion to bags.
-        
+
+        This method supports two modes:
+
+        **Mode 1 (Legacy - Direct directories):**
+        Provide `high_mag_tfr_dir` and `low_mag_tfr_dir` to specify exact TFRecord directories.
+
+        **Mode 2 (Source-based - Recommended for multi-source projects):**
+        Provide `sources`, `high_mag_um`, `low_mag_um`, `tile_px`, and optionally `mag_ratio`.
+        The method will automatically find the correct TFRecord directories across all sources.
+        All features from all sources will be saved to the same output directory.
+
         Args:
-            high_mag_tfr_dir (str): Directory containing high magnification TFRecords
-            low_mag_tfr_dir (str): Directory containing low magnification TFRecords  
-            device (str): 'cuda' or 'cpu'
             model_path (str): Path to the feature extraction model
             output_dir (str): Directory to save the concatenated feature bags
+            device (str): 'cuda' or 'cpu'. Defaults to 'cuda'.
+
+            high_mag_tfr_dir (str, optional): [Mode 1] Directory containing high magnification TFRecords
+            low_mag_tfr_dir (str, optional): [Mode 1] Directory containing low magnification TFRecords
+
+            sources (str or list, optional): [Mode 2] Source name(s) to process. Can be a single
+                source name (str) or list of source names. If None, processes all sources.
+            high_mag_um (int, optional): [Mode 2] High magnification in microns (integers only)
+            low_mag_um (int, optional): [Mode 2] Low magnification in microns (integers only)
+            tile_px (int, optional): [Mode 2] Tile size in pixels
+            mag_ratio (int, optional): [Mode 2] Magnification ratio (e.g., 4 for 4x4 grid).
+                If not provided, will be inferred from high_mag_um and low_mag_um.
+
             filters (dict, optional): Dataset filters to apply
             batch_size (int): Batch size for feature extraction. Defaults to 32.
             num_workers (int): Number of worker processes. Defaults to 4.
@@ -2118,72 +2143,136 @@ class Project:
             low_mag_features_path (str, optional): Path to pre-extracted low mag features
                 (for concatenate_only mode)
             **kwargs: Additional arguments passed to feature extraction
-            
+
         Returns:
             DatasetFeatures: Object containing MIL-ready concatenated features saved as
             individual .pt files per slide, directly usable for training without conversion
-            
-        Example:
-            >>> # Extract concatenated features from 40x and 10x tiles
-            >>> features = DatasetFeatures.extract_concatenated_features(
-            ...     high_mag_tfr_dir='project/tfrecords/512px_40x',
-            ...     low_mag_tfr_dir='project/tfrecords/224px_10x_from_40x', 
+
+        Examples:
+            >>> # Mode 1: Direct directories (legacy)
+            >>> features = project.extract_dual_magnification_features(
             ...     model_path='path/to/model.pt',
-            ...     output_dir='project/concatenated_features'
+            ...     output_dir='project/concatenated_features',
+            ...     high_mag_tfr_dir='project/tfrecords/224px_112um',
+            ...     low_mag_tfr_dir='project/tfrecords/224px_448um_from_112um'
+            ... )
+
+            >>> # Mode 2: Source-based (multi-source support)
+            >>> features = project.extract_dual_magnification_features(
+            ...     model_path='path/to/model.pt',
+            ...     output_dir='project/concatenated_features',
+            ...     sources=['source1', 'source2'],
+            ...     high_mag_um=112,
+            ...     low_mag_um=448,
+            ...     tile_px=224,
+            ...     mag_ratio=4
             ... )
         """
-        
-        log.info(f"Starting concatenated feature extraction")
-        log.info(f"  High mag TFRecords: {high_mag_tfr_dir}")
-        log.info(f"  Low mag TFRecords: {low_mag_tfr_dir}")
+
+        log.info(f"Starting dual magnification feature extraction")
         log.info(f"  Model: {model_path}")
         log.info(f"  Output: {output_dir}")
-        
-        # Validate input directories
-        if not os.path.exists(high_mag_tfr_dir):
-            raise FileNotFoundError(f"High magnification TFRecord directory not found: {high_mag_tfr_dir}")
-        if not os.path.exists(low_mag_tfr_dir):
-            raise FileNotFoundError(f"Low magnification TFRecord directory not found: {low_mag_tfr_dir}")
-        tfrecords_base = os.path.dirname(high_mag_tfr_dir)  # Get parent dir
+
         # Create output directory
         os.makedirs(output_dir, exist_ok=True)
 
-        # Get extraction information from report csvs
-        out = Project._get_extraction_csv(self, high_mag_tfr_dir, low_mag_tfr_dir)
-        
-        # Find all TFRecord files in both directories
-        high_mag_tfrs = glob.glob(os.path.join(high_mag_tfr_dir, "*.tfrecords"))
-        low_mag_tfrs = glob.glob(os.path.join(low_mag_tfr_dir, "*.tfrecords"))
-        
-        if not high_mag_tfrs:
-            raise ValueError(f"No TFRecord files found in high mag directory: {high_mag_tfr_dir}")
-        if not low_mag_tfrs:
-            raise ValueError(f"No TFRecord files found in low mag directory: {low_mag_tfr_dir}")
-            
-        log.info(f"Found {len(high_mag_tfrs)} high mag TFRecords and {len(low_mag_tfrs)} low mag TFRecords")
-        log.debug(f"Found high mag: {out['high']['tile_px']} px at {out['high']['tile_um']} and low mag : {out['low']['tile_px']}px at {out['low']['tile_um']}")
-        # Create datasets using the standard approach with source_um for low mag
-        # High mag dataset (standard approach)
-        high_mag_dataset = Dataset(
-            tfrecords=tfrecords_base,
-            tile_px=out['high']['tile_px'],
-            tile_um=out['high']['tile_um'],
-            annotations=self.annotations,
-            filters=filters
-        )
+        # Determine which mode we're in
+        mode_1 = high_mag_tfr_dir is not None and low_mag_tfr_dir is not None
+        mode_2 = high_mag_um is not None and low_mag_um is not None and tile_px is not None
 
-        # Low mag dataset with source_um to find "224px_10x_from_40x" directories
-        low_mag_dataset = Dataset(
-            tfrecords=tfrecords_base,
-            tile_px=out['low']['tile_px'],
-            tile_um=out['low']['tile_um'],
-            source_um=out['high']['tile_um'],  # This creates "224px_10x_from_40x" label
-            annotations=self.annotations,
-            filters=filters
-        )
+        if mode_1 and mode_2:
+            raise ValueError(
+                "Cannot specify both directory-based parameters (high_mag_tfr_dir, low_mag_tfr_dir) "
+                "and source-based parameters (high_mag_um, low_mag_um, tile_px) simultaneously. "
+                "Please use only one mode."
+            )
+        elif not mode_1 and not mode_2:
+            raise ValueError(
+                "Must specify either:\n"
+                "  Mode 1: high_mag_tfr_dir and low_mag_tfr_dir, OR\n"
+                "  Mode 2: high_mag_um, low_mag_um, and tile_px"
+            )
 
-        log.info(f"High mag dataset config: tile_px={out['high']['tile_px']}, tile_um={out['high']['tile_um']}")
-        log.info(f"Low mag dataset config: tile_px={out['low']['tile_px']}, tile_um={out['low']['tile_um']}, source_um={out['high']['tile_um']}")
+        # Mode 1: Legacy direct directory specification
+        if mode_1:
+            log.info(f"Using Mode 1 (direct directories)")
+            log.info(f"  High mag TFRecords: {high_mag_tfr_dir}")
+            log.info(f"  Low mag TFRecords: {low_mag_tfr_dir}")
+
+            # Validate input directories
+            if not os.path.exists(high_mag_tfr_dir):
+                raise FileNotFoundError(f"High magnification TFRecord directory not found: {high_mag_tfr_dir}")
+            if not os.path.exists(low_mag_tfr_dir):
+                raise FileNotFoundError(f"Low magnification TFRecord directory not found: {low_mag_tfr_dir}")
+            tfrecords_base = os.path.dirname(high_mag_tfr_dir)  # Get parent dir
+
+            # Get extraction information from report csvs
+            out = Project._get_extraction_csv(self, high_mag_tfr_dir, low_mag_tfr_dir)
+
+            # Find all TFRecord files in both directories
+            high_mag_tfrs = glob.glob(os.path.join(high_mag_tfr_dir, "*.tfrecords"))
+            low_mag_tfrs = glob.glob(os.path.join(low_mag_tfr_dir, "*.tfrecords"))
+
+            if not high_mag_tfrs:
+                raise ValueError(f"No TFRecord files found in high mag directory: {high_mag_tfr_dir}")
+            if not low_mag_tfrs:
+                raise ValueError(f"No TFRecord files found in low mag directory: {low_mag_tfr_dir}")
+
+            log.info(f"Found {len(high_mag_tfrs)} high mag TFRecords and {len(low_mag_tfrs)} low mag TFRecords")
+            log.debug(f"Found high mag: {out['high']['tile_px']} px at {out['high']['tile_um']} and low mag : {out['low']['tile_px']}px at {out['low']['tile_um']}")
+
+            # Create datasets using the standard approach with source_um for low mag
+            high_mag_dataset = Dataset(
+                tfrecords=tfrecords_base,
+                tile_px=out['high']['tile_px'],
+                tile_um=out['high']['tile_um'],
+                annotations=self.annotations,
+                filters=filters
+            )
+
+            low_mag_dataset = Dataset(
+                tfrecords=tfrecords_base,
+                tile_px=out['low']['tile_px'],
+                tile_um=out['low']['tile_um'],
+                source_um=out['high']['tile_um'],
+                annotations=self.annotations,
+                filters=filters
+            )
+
+        # Mode 2: Source-based specification
+        else:
+            log.info(f"Using Mode 2 (source-based)")
+
+            # Validate that magnifications are integers only
+            if not isinstance(high_mag_um, int):
+                raise ValueError(f"high_mag_um must be an integer (microns), got {type(high_mag_um).__name__}")
+            if not isinstance(low_mag_um, int):
+                raise ValueError(f"low_mag_um must be an integer (microns), got {type(low_mag_um).__name__}")
+            if not isinstance(tile_px, int):
+                raise ValueError(f"tile_px must be an integer, got {type(tile_px).__name__}")
+
+            log.info(f"  High mag: {high_mag_um}um at {tile_px}px")
+            log.info(f"  Low mag: {low_mag_um}um at {tile_px}px")
+            log.info(f"  Sources: {sources if sources else 'all'}")
+
+            # Create high mag dataset using project's dataset method
+            # This will automatically handle source selection and configuration
+            high_mag_dataset = self.dataset(
+                tile_px=tile_px,
+                tile_um=high_mag_um,
+                sources=sources,
+                filters=filters
+            )
+
+            # Create low mag dataset with source_um to find "_from_" directories
+            low_mag_dataset = self.dataset(
+                tile_px=tile_px,
+                tile_um=low_mag_um,
+                source_um=high_mag_um,
+                sources=sources,
+                filters=filters
+            )
+
         log.info(f"High mag dataset: {len(high_mag_dataset.tfrecords())} TFRecords")
         log.info(f"Low mag dataset: {len(low_mag_dataset.tfrecords())} TFRecords")
 
@@ -2193,16 +2282,27 @@ class Project:
         if high_tfrs:
             log.debug(f"Example high mag TFRecord path: {high_tfrs[0]}")
         else:
-            log.warning(f"No high mag TFRecords found! Expected directory: {high_mag_tfr_dir}")
+            log.warning(f"No high mag TFRecords found!")
         if low_tfrs:
             log.debug(f"Example low mag TFRecord path: {low_tfrs[0]}")
         else:
-            log.warning(f"No low mag TFRecords found! Expected directory: {low_mag_tfr_dir}")
-        
+            log.warning(f"No low mag TFRecords found!")
+
+        # Determine TFRecord directories for config
+        # Get the parent directory of the first TFRecord file for each magnification
+        high_mag_tfr_dir_for_config = os.path.dirname(high_tfrs[0]) if high_tfrs else None
+        low_mag_tfr_dir_for_config = os.path.dirname(low_tfrs[0]) if low_tfrs else None
+
         # Use the specialized DualMagnificationFeatures subclass
         from .model.features import DualMagnificationFeatures
-        
+
         dual_features = DualMagnificationFeatures(output_dir)
+
+        # Store the TFRecord directory paths in the dual_features object
+        # so they can be saved in the config
+        dual_features.high_mag_tfr_dir = high_mag_tfr_dir_for_config
+        dual_features.low_mag_tfr_dir = low_mag_tfr_dir_for_config
+
         result = dual_features.extract_and_concatenate(
             high_mag_dataset=high_mag_dataset,
             low_mag_dataset=low_mag_dataset,

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -2074,6 +2074,7 @@ class Project:
         low_mag_tfr_dir: str,
         model_path: str,
         output_dir: str,
+        device = 'cuda',
         *,
         filters: Optional[Dict] = None,
         batch_size: int = 32,
@@ -2098,6 +2099,7 @@ class Project:
             source (str): Dataset source name from the project
             high_mag_tfr_dir (str): Directory containing high magnification TFRecords
             low_mag_tfr_dir (str): Directory containing low magnification TFRecords  
+            device (str): 'cuda' or 'cpu'
             model_path (str): Path to the feature extraction model
             output_dir (str): Directory to save the concatenated feature bags
             filters (dict, optional): Dataset filters to apply
@@ -2184,6 +2186,7 @@ class Project:
         result = dual_features.extract_and_concatenate(
             high_mag_dataset=high_mag_dataset,
             low_mag_dataset=low_mag_dataset,
+            device = device,
             model_path=model_path,
             batch_size=batch_size,
             num_workers=num_workers,

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -19,8 +19,12 @@ import pickle
 import pandas as pd
 import tarfile
 import warnings
+from collections import defaultdict
 from tqdm import tqdm
+from rich.progress import track
 from os.path import basename, exists, join, isdir, dirname
+from pathlib import Path
+import glob
 from multiprocessing.managers import DictProxy
 from contextlib import contextmanager
 from statistics import mean
@@ -31,6 +35,7 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
 import slideflow as sf
 from . import errors, project_utils
 from .util import log, path_to_name, path_to_ext
+from .model.features import DatasetFeatures
 from .dataset import Dataset
 from .model import ModelParams
 from .project_utils import (  # noqa: F401
@@ -1995,6 +2000,195 @@ class Project:
         dataset.generate_feature_bags(model, outdir, **kwargs)
 
         return outdir
+
+    def _get_extraction_csv(self, high_mag_tfr_dir, low_mag_tfr_dir):
+        """
+        Reads two CSVs and returns a small summary dict with:
+        - tile_px
+        - tile_um
+        - num_tiles
+
+        Assumptions:
+        • High-mag CSV is `<high_mag_tfr_dir>/extraction_report.csv`
+        • Low-mag CSV is the first match of `lower_mag_extraction_report_*.csv`
+            (fallback to `<low_mag_tfr_dir>/extraction_report.csv`)
+
+        Returns:
+        {
+            "high": {"csv_path": Path, "tile_px": int|None, "tile_um": float|None, "num_tiles": int},
+            "low":  {"csv_path": Path, "tile_px": int|None, "tile_um": float|None, "num_tiles": int},
+        }
+        """
+        high_dir = Path(high_mag_tfr_dir)
+        low_dir  = Path(low_mag_tfr_dir)
+
+        # Resolve paths
+        high_csv = high_dir / "extraction_report.csv"
+        low_matches = sorted(low_dir.glob("lower_mag_extraction_report_*.csv"))
+        low_csv = low_matches[0] if low_matches else (low_dir / "extraction_report.csv")
+
+        # Read
+        high_df = pd.read_csv(high_csv)
+        low_df  = pd.read_csv(low_csv)
+
+        # Try common column names; keep it simple
+        def pick(df, name_options, cast):
+            for n in name_options:
+                if n in df.columns:
+                    try:
+                        return cast(df[n].iloc[0])
+                    except Exception:
+                        return None
+            return None
+
+        # Pick tile_um without casting - slideflow can handle magnification strings like "40x"
+        def pick_tile_um(df, name_options):
+            for n in name_options:
+                if n in df.columns:
+                    return df[n].iloc[0]  # Return as-is (string or numeric)
+            return None
+
+        px_names = ["tile_px", "target_tile_px", "source_tile_px"]
+        um_names = ["tile_um", "target_tile_um", "source_tile_um"]
+
+        out = {
+            "high": {
+                "csv_path": high_csv,
+                "tile_px": pick(high_df, px_names, int),
+                "tile_um": pick_tile_um(high_df, um_names),
+                "num_tiles": len(high_df),
+            },
+            "low": {
+                "csv_path": low_csv,
+                "tile_px": pick(low_df, px_names, int),
+                "tile_um": pick_tile_um(low_df, um_names),
+                "num_tiles": len(low_df),
+            },
+        }
+        return out
+
+    def extract_dual_magnification_features(
+        self,
+        source: str,
+        high_mag_tfr_dir: str,
+        low_mag_tfr_dir: str,
+        model_path: str,
+        output_dir: str,
+        *,
+        filters: Optional[Dict] = None,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        high_mag_features_path: Optional[str] = None,
+        low_mag_features_path: Optional[str] = None,
+        **kwargs
+    ) -> "DatasetFeatures":
+        """Extract and concatenate features from corresponding high and low magnification tiles.
+        
+        For each high magnification tile, this method finds the corresponding low magnification
+        tile that contains it (based on spatial coordinates), extracts features from both using
+        the same model, concatenates the feature vectors, and creates bags from the concatenated
+        features.
+        
+        Args:
+            source (str): Dataset source name from the project
+            high_mag_tfr_dir (str): Directory containing high magnification TFRecords
+            low_mag_tfr_dir (str): Directory containing low magnification TFRecords  
+            model_path (str): Path to the feature extraction model
+            output_dir (str): Directory to save the concatenated feature bags
+            filters (dict, optional): Dataset filters to apply
+            batch_size (int): Batch size for feature extraction. Defaults to 32.
+            num_workers (int): Number of worker processes. Defaults to 4.
+            high_mag_features_path (str, optional): Path to pre-extracted high mag features 
+                (for concatenate_only mode)
+            low_mag_features_path (str, optional): Path to pre-extracted low mag features 
+                (for concatenate_only mode)
+            **kwargs: Additional arguments passed to feature extraction
+            
+        Returns:
+            DatasetFeatures: Object containing the concatenated feature bags
+            
+        Example:
+            >>> # Extract concatenated features from 40x and 10x tiles
+            >>> features = DatasetFeatures.extract_concatenated_features(
+            ...     high_mag_tfr_dir='project/tfrecords/512px_40x',
+            ...     low_mag_tfr_dir='project/tfrecords/224px_10x_from_40x', 
+            ...     model_path='path/to/model.pt',
+            ...     output_dir='project/concatenated_features'
+            ... )
+        """
+        
+        log.info(f"Starting concatenated feature extraction")
+        log.info(f"  High mag TFRecords: {high_mag_tfr_dir}")
+        log.info(f"  Low mag TFRecords: {low_mag_tfr_dir}")
+        log.info(f"  Model: {model_path}")
+        log.info(f"  Output: {output_dir}")
+        
+        # Validate input directories
+        if not os.path.exists(high_mag_tfr_dir):
+            raise FileNotFoundError(f"High magnification TFRecord directory not found: {high_mag_tfr_dir}")
+        if not os.path.exists(low_mag_tfr_dir):
+            raise FileNotFoundError(f"Low magnification TFRecord directory not found: {low_mag_tfr_dir}")
+        tfrecords_base = os.path.dirname(high_mag_tfr_dir)  # Get parent dir
+        # Create output directory
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Get extraction information from report csvs
+        out = Project._get_extraction_csv(self, high_mag_tfr_dir, low_mag_tfr_dir)
+        
+        # Find all TFRecord files in both directories
+        high_mag_tfrs = glob.glob(os.path.join(high_mag_tfr_dir, "*.tfrecords"))
+        low_mag_tfrs = glob.glob(os.path.join(low_mag_tfr_dir, "*.tfrecords"))
+        
+        if not high_mag_tfrs:
+            raise ValueError(f"No TFRecord files found in high mag directory: {high_mag_tfr_dir}")
+        if not low_mag_tfrs:
+            raise ValueError(f"No TFRecord files found in low mag directory: {low_mag_tfr_dir}")
+            
+        log.info(f"Found {len(high_mag_tfrs)} high mag TFRecords and {len(low_mag_tfrs)} low mag TFRecords")
+        log.debug(f"Found high mag: {out['high']['tile_px']} px at {out['high']['tile_um']} and low mag : {out['low']['tile_px']}px at {out['low']['tile_um']}")
+        # Create datasets using the standard approach with source_um for low mag
+        # High mag dataset (standard approach)
+        high_mag_dataset = Dataset(
+            tfrecords=tfrecords_base,
+            tile_px=out['high']['tile_px'],
+            tile_um=out['high']['tile_um'],
+            annotations=self.annotations,
+            filters=filters
+        )
+        
+        # Low mag dataset with source_um to find "224px_10x_from_40x" directories
+        low_mag_dataset = Dataset(
+            tfrecords=tfrecords_base,
+            tile_px=out['low']['tile_px'],
+            tile_um=out['low']['tile_um'],
+            source_um=out['high']['tile_um'],  # This creates "224px_10x_from_40x" label
+            annotations=self.annotations,
+            filters=filters
+        )
+        
+        log.info(f"High mag dataset: {len(high_mag_dataset.tfrecords())} TFRecords")
+        log.info(f"Low mag dataset: {len(low_mag_dataset.tfrecords())} TFRecords")
+        
+        # Use the specialized DualMagnificationFeatures subclass
+        from .model.features import DualMagnificationFeatures
+        
+        dual_features = DualMagnificationFeatures(output_dir)
+        result = dual_features.extract_and_concatenate(
+            high_mag_dataset=high_mag_dataset,
+            low_mag_dataset=low_mag_dataset,
+            model_path=model_path,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            high_mag_features_path=high_mag_features_path,
+            low_mag_features_path=low_mag_features_path,
+            **kwargs
+        )
+        
+        # Save bags to concatenated subdirectory  
+        log.info(f"Saving concatenated feature bags to {result.concatenated_dir}")
+        result.to_torch(result.concatenated_dir, verbose=True)
+        
+        return result
 
     @auto_dataset
     def generate_heatmaps(

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -2078,16 +2078,21 @@ class Project:
         filters: Optional[Dict] = None,
         batch_size: int = 32,
         num_workers: int = 4,
+        min_tiles: Optional[int] = None,
+        max_tiles: Optional[int] = None,
         high_mag_features_path: Optional[str] = None,
         low_mag_features_path: Optional[str] = None,
         **kwargs
     ) -> "DatasetFeatures":
         """Extract and concatenate features from corresponding high and low magnification tiles.
-        
+
         For each high magnification tile, this method finds the corresponding low magnification
         tile that contains it (based on spatial coordinates), extracts features from both using
-        the same model, concatenates the feature vectors, and creates bags from the concatenated
-        features.
+        the same model, concatenates the feature vectors, and saves them in MIL-ready format.
+
+        The output concatenated features are saved as individual .pt files per slide with
+        accompanying .index files containing coordinate information. These files are directly
+        compatible with MIL training without requiring additional conversion to bags.
         
         Args:
             source (str): Dataset source name from the project
@@ -2098,14 +2103,17 @@ class Project:
             filters (dict, optional): Dataset filters to apply
             batch_size (int): Batch size for feature extraction. Defaults to 32.
             num_workers (int): Number of worker processes. Defaults to 4.
-            high_mag_features_path (str, optional): Path to pre-extracted high mag features 
+            min_tiles (int, optional): Minimum tiles per slide. Slides with fewer tiles are excluded.
+            max_tiles (int, optional): Maximum tiles per slide. Excess tiles are randomly sampled.
+            high_mag_features_path (str, optional): Path to pre-extracted high mag features
                 (for concatenate_only mode)
-            low_mag_features_path (str, optional): Path to pre-extracted low mag features 
+            low_mag_features_path (str, optional): Path to pre-extracted low mag features
                 (for concatenate_only mode)
             **kwargs: Additional arguments passed to feature extraction
             
         Returns:
-            DatasetFeatures: Object containing the concatenated feature bags
+            DatasetFeatures: Object containing MIL-ready concatenated features saved as
+            individual .pt files per slide, directly usable for training without conversion
             
         Example:
             >>> # Extract concatenated features from 40x and 10x tiles
@@ -2179,6 +2187,8 @@ class Project:
             model_path=model_path,
             batch_size=batch_size,
             num_workers=num_workers,
+            min_tiles=min_tiles,
+            max_tiles=max_tiles,
             high_mag_features_path=high_mag_features_path,
             low_mag_features_path=low_mag_features_path,
             **kwargs

--- a/slideflow/project.py
+++ b/slideflow/project.py
@@ -2026,7 +2026,7 @@ class Project:
         high_csv = high_dir / "extraction_report.csv"
         low_matches = sorted(low_dir.glob("lower_mag_extraction_report_*.csv"))
         low_csv = low_matches[0] if low_matches else (low_dir / "extraction_report.csv")
-
+        print(low_csv)
         # Read
         high_df = pd.read_csv(high_csv)
         low_df  = pd.read_csv(low_csv)
@@ -2041,11 +2041,19 @@ class Project:
                         return None
             return None
 
-        # Pick tile_um without casting - slideflow can handle magnification strings like "40x"
+        # Pick tile_um and ensure it's a native Python type (not numpy)
         def pick_tile_um(df, name_options):
             for n in name_options:
                 if n in df.columns:
-                    return df[n].iloc[0]  # Return as-is (string or numeric)
+                    val = df[n].iloc[0]
+                    # Convert pandas/numpy types to native Python types for JSON serialization
+                    if isinstance(val, str):
+                        return val
+                    elif pd.isna(val):
+                        return None
+                    else:
+                        # Convert numeric to native Python int
+                        return int(val)
             return None
 
         px_names = ["tile_px", "target_tile_px", "source_tile_px"]
@@ -2069,7 +2077,6 @@ class Project:
 
     def extract_dual_magnification_features(
         self,
-        source: str,
         high_mag_tfr_dir: str,
         low_mag_tfr_dir: str,
         model_path: str,
@@ -2096,7 +2103,6 @@ class Project:
         compatible with MIL training without requiring additional conversion to bags.
         
         Args:
-            source (str): Dataset source name from the project
             high_mag_tfr_dir (str): Directory containing high magnification TFRecords
             low_mag_tfr_dir (str): Directory containing low magnification TFRecords  
             device (str): 'cuda' or 'cpu'
@@ -2165,7 +2171,7 @@ class Project:
             annotations=self.annotations,
             filters=filters
         )
-        
+
         # Low mag dataset with source_um to find "224px_10x_from_40x" directories
         low_mag_dataset = Dataset(
             tfrecords=tfrecords_base,
@@ -2175,9 +2181,23 @@ class Project:
             annotations=self.annotations,
             filters=filters
         )
-        
+
+        log.info(f"High mag dataset config: tile_px={out['high']['tile_px']}, tile_um={out['high']['tile_um']}")
+        log.info(f"Low mag dataset config: tile_px={out['low']['tile_px']}, tile_um={out['low']['tile_um']}, source_um={out['high']['tile_um']}")
         log.info(f"High mag dataset: {len(high_mag_dataset.tfrecords())} TFRecords")
         log.info(f"Low mag dataset: {len(low_mag_dataset.tfrecords())} TFRecords")
+
+        # Debug: show where datasets are looking for TFRecords
+        high_tfrs = high_mag_dataset.tfrecords()
+        low_tfrs = low_mag_dataset.tfrecords()
+        if high_tfrs:
+            log.debug(f"Example high mag TFRecord path: {high_tfrs[0]}")
+        else:
+            log.warning(f"No high mag TFRecords found! Expected directory: {high_mag_tfr_dir}")
+        if low_tfrs:
+            log.debug(f"Example low mag TFRecord path: {low_tfrs[0]}")
+        else:
+            log.warning(f"No low mag TFRecords found! Expected directory: {low_mag_tfr_dir}")
         
         # Use the specialized DualMagnificationFeatures subclass
         from .model.features import DualMagnificationFeatures

--- a/slideflow/slide/__init__.py
+++ b/slideflow/slide/__init__.py
@@ -7,7 +7,7 @@ import warnings
 import slideflow.slide.qc
 from slideflow.util import SUPPORTED_FORMATS  # noqa F401
 from .report import ExtractionPDF  # noqa F401
-from .report import ExtractionReport, SlideReport
+from .report import ExtractionReport, SlideReport, LowerMagExtractionReport, LowerMagSlideReport
 from .utils import *
 from .backends import tile_worker, wsi_reader, backend_formats
 from .wsi import WSI

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -548,7 +548,6 @@ class LowerMagSlideReport(SlideReport):
             if len(centers_draw) == 0:
                 log.debug(f"DEBUG _draw: {label} centers_draw is empty")
                 return
-            log.debug(f"DEBUG _draw: Drawing {len(centers_draw)} {label} rectangles with box_draw={box_draw}, scale={scale_draw_to_thumb:.4f}")
             half = box_draw / 2.0
             w_th = box_draw * scale_draw_to_thumb
             for i, coord_pair in enumerate(centers_draw):
@@ -564,9 +563,6 @@ class LowerMagSlideReport(SlideReport):
                 y_th = y_draw * scale_draw_to_thumb
                 rect_coords = [x_th, y_th, x_th + w_th, y_th + w_th]
                 draw.rectangle(rect_coords, outline=color, width=width)
-                # Log first few rectangles for debugging
-                if i < 3:
-                    log.debug(f"DEBUG _draw: {label}[{i}] coord=({cx},{cy}) -> rect=[{x_th:.1f},{y_th:.1f},{x_th+w_th:.1f},{y_th+w_th:.1f}]")
 
         source_coords = getattr(self, 'source_thumb_coords', None)
         target_coords = getattr(self, 'target_thumb_coords', None)
@@ -574,15 +570,9 @@ class LowerMagSlideReport(SlideReport):
         # Debug the actual coordinate values received in calc_thumb
         if source_coords is None:
             log.debug(f"DEBUG calc_thumb: source_coords is None for {self.path}")
-        else:
-            log.debug(f"DEBUG calc_thumb: source_coords has {len(source_coords)} coordinates for {self.path}")
 
         if target_coords is None:
             log.debug(f"DEBUG calc_thumb: target_coords is None for {self.path}")
-        else:
-            log.debug(f"DEBUG calc_thumb: target_coords has {len(target_coords)} coordinates for {self.path}")
-            if len(target_coords) > 0:
-                log.debug(f"DEBUG calc_thumb: First target coord: {target_coords[0]}")
         
         # Use black for source tiles, red for target tiles - with thin lines
         _draw(source_coords, s_box_draw, (0, 0, 0), 2, "SOURCE")

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -514,9 +514,12 @@ class LowerMagSlideReport(SlideReport):
         # ----- 4) Draw rectangles (centers are already in DRAW coordinates) -----
         def _draw(centers_draw, box_draw, color, width, label):
             if centers_draw is None:
+                log.debug(f"DEBUG _draw: {label} centers_draw is None")
                 return
             if len(centers_draw) == 0:
+                log.debug(f"DEBUG _draw: {label} centers_draw is empty")
                 return
+            log.debug(f"DEBUG _draw: Drawing {len(centers_draw)} {label} rectangles with box_draw={box_draw}, scale={scale_draw_to_thumb:.4f}")
             half = box_draw / 2.0
             w_th = box_draw * scale_draw_to_thumb
             for i, coord_pair in enumerate(centers_draw):
@@ -532,16 +535,25 @@ class LowerMagSlideReport(SlideReport):
                 y_th = y_draw * scale_draw_to_thumb
                 rect_coords = [x_th, y_th, x_th + w_th, y_th + w_th]
                 draw.rectangle(rect_coords, outline=color, width=width)
+                # Log first few rectangles for debugging
+                if i < 3:
+                    log.debug(f"DEBUG _draw: {label}[{i}] coord=({cx},{cy}) -> rect=[{x_th:.1f},{y_th:.1f},{x_th+w_th:.1f},{y_th+w_th:.1f}]")
 
         source_coords = getattr(self, 'source_thumb_coords', None)
         target_coords = getattr(self, 'target_thumb_coords', None)
-        
+
         # Debug the actual coordinate values received in calc_thumb
         if source_coords is None:
-            log.debug(f"DEBUG: source_coords is None in calc_thumb")
-            
+            log.debug(f"DEBUG calc_thumb: source_coords is None for {self.path}")
+        else:
+            log.debug(f"DEBUG calc_thumb: source_coords has {len(source_coords)} coordinates for {self.path}")
+
         if target_coords is None:
-            log.debug(f"DEBUG: target_coords is None in calc_thumb")
+            log.debug(f"DEBUG calc_thumb: target_coords is None for {self.path}")
+        else:
+            log.debug(f"DEBUG calc_thumb: target_coords has {len(target_coords)} coordinates for {self.path}")
+            if len(target_coords) > 0:
+                log.debug(f"DEBUG calc_thumb: First target coord: {target_coords[0]}")
         
         # Use black for source tiles, red for target tiles - with thin lines
         _draw(source_coords, s_box_draw, (0, 0, 0), 2, "SOURCE")

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -951,7 +951,6 @@ class LowerMagExtractionReport(ExtractionReport):
         # Add lower mag specific content to PDF
         self._add_lower_mag_summary()
         self._add_combination_metrics()
-        self._add_efficiency_charts()
 
     def _add_lower_mag_summary(self) -> None:
         pdf = self.pdf
@@ -1015,35 +1014,3 @@ class LowerMagExtractionReport(ExtractionReport):
             pdf.cell(25, 5, f"{coverage_red:.1f}%", 1, 0, 'C')
             pdf.cell(25, 5, f"{incomplete:.1f}%", 1, 1, 'C')
         pdf.ln(10)
-
-    def _add_efficiency_charts(self) -> None:
-        pdf = self.pdf
-        try:
-            import matplotlib.pyplot as plt
-            effs = [r.combination_efficiency for r in self.reports if r and hasattr(r, 'combination_efficiency') and r.combination_efficiency is not None]
-            covers = [r.spatial_coverage_reduction for r in self.reports if r and hasattr(r, 'spatial_coverage_reduction') and r.spatial_coverage_reduction is not None]
-            if not (effs and covers):
-                return
-            with sf.util.matplotlib_backend('Agg'):
-                fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
-
-                ax1.hist(effs, bins=10, alpha=0.9, edgecolor='black')
-                ax1.set_xlabel('Combination Efficiency (%)')
-                ax1.set_ylabel('Number of Slides')
-                ax1.set_title('Tile Combination Efficiency')
-                ax1.grid(True, alpha=0.3)
-
-                ax2.hist(covers, bins=10, alpha=0.9, edgecolor='black')
-                ax2.set_xlabel('Spatial Coverage Reduction (%)')
-                ax2.set_ylabel('Number of Slides')
-                ax2.set_title('Coverage Reduction')
-                ax2.grid(True, alpha=0.3)
-
-                plt.tight_layout()
-                with tempfile.NamedTemporaryFile(suffix='.png') as temp:
-                    plt.savefig(temp.name, dpi=150, bbox_inches='tight')
-                    pdf.image(temp.name, 10, pdf.y, w=190)
-                    plt.close(fig)
-                pdf.ln(60)
-        except Exception as e:
-            log.error(f"Error creating efficiency charts: {e}")

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -569,7 +569,7 @@ class LowerMagSlideReport(SlideReport):
         
         # Use black for source tiles, red for target tiles - with thin lines
         _draw(source_coords, s_box_draw, (0, 0, 0), 2, "SOURCE")
-        _draw(target_coords, t_box_draw, (255, 0, 0), 2.5, "TARGET_RED") 
+        _draw(target_coords, t_box_draw, (255, 0, 0), 3, "TARGET_RED") 
         
         # Test rectangles removed - coordinate scaling is working correctly
 
@@ -577,12 +577,17 @@ class LowerMagSlideReport(SlideReport):
         self._thumb = thumb
 
         # Debug: Save a test image to verify rectangles are actually drawn
-        import os
-        os.makedirs("data/slides/thumbs", exist_ok=True)
-        debug_path = f"data/slides/thumbs/debug_thumb_{os.path.basename(self.path)}.png"
-        thumb.save(debug_path)
-        sf.util.log.debug(f"DEBUG: Saved thumbnail with overlays to {debug_path}")
-        sf.util.log.debug(f"DEBUG: Thumbnail size: {thumb.size}, mode: {thumb.mode}")
+        try:
+            import os
+            os.makedirs("data/slides/thumbs", exist_ok=True)
+            debug_path = f"data/slides/thumbs/debug_thumb_{os.path.basename(self.path)}.png"
+            thumb.save(debug_path)
+            sf.util.log.debug(f"DEBUG: Saved thumbnail with overlays to {debug_path}")
+            sf.util.log.debug(f"DEBUG: Thumbnail size: {thumb.size}, mode: {thumb.mode}")
+        except Exception as e:
+            sf.util.log.error(f"DEBUG: Failed to save debug thumbnail for {self.path}: {e}")
+            import traceback
+            sf.util.log.error(f"DEBUG: Traceback: {traceback.format_exc()}")
 
     def create_combination_visualization(self) -> Optional[bytes]:
         """Create a visualization showing source→target tile relationships."""

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -444,72 +444,101 @@ class LowerMagSlideReport(SlideReport):
             self._thumb = thumb
             return
 
-        # ----- 2) Compute DRAW→THUMB scale (pure geometry, no hardcodes) -----
-        # We assume all centers passed in are at the DRAW level (your target space).
-        # Map DRAW px -> level-0 px with factor d_draw (level-0 px per DRAW px).
-        # Then map level-0 px -> thumb px by (thumb.width / W0).
-        #
-        # d_draw is derived from either:
-        #   (a) draw-level mpp = tile_um / tile_px        -> d_draw = mpp_draw / base_mpp
-        #   (b) draw magnification "Nx"                   -> d_draw = 10 / (mag_draw * base_mpp)
-        #
-        # We compute both paths and use whatever is available.
+        # ----- 2) Compute coordinate→THUMB scale -----
+        # For LowerMagSlideReport, coordinates are stored in level-0 WSI pixel space,
+        # so we use a simple scale: level-0 pixels → thumbnail pixels.
+        # For regular SlideReport, coordinates may be in a "DRAW" space requiring transformation.
 
-        # base_mpp (µm/px) at level-0
-        try:
-            base_mpp = float(getattr(wsi, 'mpp', 0.0)) or float(getattr(wsi, 'level_mpp', [0.0])[0] or 0.0)
-            if base_mpp <= 0:
-                raise ValueError
-        except Exception:
-            base_mpp = 0.25  # conservative fallback; only affects absolute scale on the thumbnail
+        # Simple scale for level-0 coordinates → thumbnail
+        scale_level0_to_thumb = thumb.width / float(W0)
 
-        # Prefer a physical mpp for the DRAW level, else fall back to magnification strings
-        mpp_draw = None
-        try:
-            # If tile_um is numeric microns and tile_px is the draw-level px edge, we can get mpp_draw directly
-            if isinstance(self.tile_um, (int, float)) and isinstance(self.tile_px, (int, float)) and self.tile_px > 0:
-                mpp_draw = float(self.tile_um) / float(self.tile_px)  # µm per DRAW px
-        except Exception:
-            mpp_draw = None
+        # Check if coordinates are in level-0 space (LowerMagSlideReport) or need transformation
+        # LowerMagSlideReport stores coordinates directly from TFRecords which are level-0 pixels
+        coords_are_level0 = isinstance(self, LowerMagSlideReport)
 
-        if mpp_draw and mpp_draw > 0:
-            d_draw = mpp_draw / base_mpp
+        if coords_are_level0:
+            # Coordinates are already in level-0 WSI pixel space
+            # Just scale directly to thumbnail
+            scale_draw_to_thumb = scale_level0_to_thumb
+            log.debug(f"[calc_thumb] Using level-0 coordinate scale: {scale_draw_to_thumb:.4f} (thumb.width={thumb.width}, W0={W0})")
         else:
-            # Fallback: try to parse a magnification string for the DRAW level
-            def _to_mag(val):
-                try:
-                    return float(sf.util.to_mag(val)) if isinstance(val, str) else float(val)
-                except Exception:
-                    return None
+            # Original logic for regular SlideReport where coordinates may be in DRAW space
+            # base_mpp (µm/px) at level-0
+            try:
+                base_mpp = float(getattr(wsi, 'mpp', 0.0)) or float(getattr(wsi, 'level_mpp', [0.0])[0] or 0.0)
+                if base_mpp <= 0:
+                    raise ValueError
+            except Exception:
+                base_mpp = 0.25  # conservative fallback
 
-            mag_draw = _to_mag(getattr(self, 'tile_um', None))
-            if mag_draw and mag_draw > 0:
-                d_draw = 10.0 / (mag_draw * base_mpp)
+            # Prefer a physical mpp for the DRAW level, else fall back to magnification strings
+            mpp_draw = None
+            try:
+                if isinstance(self.tile_um, (int, float)) and isinstance(self.tile_px, (int, float)) and self.tile_px > 0:
+                    mpp_draw = float(self.tile_um) / float(self.tile_px)  # µm per DRAW px
+            except Exception:
+                mpp_draw = None
+
+            if mpp_draw and mpp_draw > 0:
+                d_draw = mpp_draw / base_mpp
             else:
-                # Last resort: infer draw mag from source mag and mag_ratio if available
-                src_mag = _to_mag(getattr(self, 'source_tile_um', None))
-                ratio  = float(getattr(self, 'mag_ratio', 0) or 0)
-                if src_mag and ratio and ratio > 0:
-                    mag_draw = src_mag / ratio
+                # Fallback: try to parse a magnification string for the DRAW level
+                def _to_mag(val):
+                    try:
+                        return float(sf.util.to_mag(val)) if isinstance(val, str) else float(val)
+                    except Exception:
+                        return None
+
+                mag_draw = _to_mag(getattr(self, 'tile_um', None))
+                if mag_draw and mag_draw > 0:
                     d_draw = 10.0 / (mag_draw * base_mpp)
                 else:
-                    # Absolute fallback: assume draw==level-0 (no extra scaling)
-                    d_draw = 1.0
-                    log.debug("[calc_thumb] Falling back to d_draw=1.0 (no draw-level metadata).")
+                    # Last resort: infer draw mag from source mag and mag_ratio if available
+                    src_mag = _to_mag(getattr(self, 'source_tile_um', None))
+                    ratio  = float(getattr(self, 'mag_ratio', 0) or 0)
+                    if src_mag and ratio and ratio > 0:
+                        mag_draw = src_mag / ratio
+                        d_draw = 10.0 / (mag_draw * base_mpp)
+                    else:
+                        # Absolute fallback: assume draw==level-0 (no extra scaling)
+                        d_draw = 1.0
+                        log.debug("[calc_thumb] Falling back to d_draw=1.0 (no draw-level metadata).")
 
-        scale_draw_to_thumb = d_draw * (thumb.width / float(W0))
+            scale_draw_to_thumb = d_draw * (thumb.width / float(W0))
 
-        # ----- 3) Resolve box sizes at DRAW level (you set these on the report) -----
-        # If not set, fall back to reasonable derivations (still no hardcoded constants).
-        try:
-            s_box_draw = float(getattr(self, 'source_tile_px'))  # e.g., 128 if 40→10
-        except Exception as e:
-            # Derive from report tile_px and mag_ratio if present
-            s_box_draw = float(getattr(self, 'tile_px')) / max(1.0, float(getattr(self, 'mag_ratio', 1)))
-        try:
-            t_box_draw = float(getattr(self, 'target_tile_px'))  # e.g., 512 at draw level
-        except Exception as e:
-            t_box_draw = float(getattr(self, 'tile_px'))
+        # ----- 3) Resolve box sizes -----
+        # For LowerMagSlideReport with level-0 coordinates, calculate actual extraction sizes
+        # using the same method as wsi.thumb() (which uses wsi.full_extract_px)
+
+        if coords_are_level0:
+            # For source tiles: need to create a temporary WSI with source magnification
+            # to get the correct full_extract_px value
+            try:
+                source_wsi = sf.WSI(
+                    self.path,
+                    tile_px=self.tile_px,  # This doesn't matter for full_extract_px calculation
+                    tile_um=getattr(self, 'source_tile_um'),
+                    verbose=False,
+                )
+                s_box_draw = float(source_wsi.full_extract_px)  # Actual extraction size in level-0 pixels
+                log.debug(f"[calc_thumb] Calculated source box size from WSI: {s_box_draw} pixels")
+            except Exception as e:
+                log.error(f"Failed to calculate source box size from WSI: {e}")
+                raise
+
+            # Target box is mag_ratio times the source box
+            t_box_draw = s_box_draw * float(getattr(self, 'mag_ratio'))
+            log.debug(f"[calc_thumb] Box sizes in level-0 pixels: source={s_box_draw:.0f}, target={t_box_draw:.0f}")
+        else:
+            # Original logic for regular SlideReport
+            try:
+                s_box_draw = float(getattr(self, 'source_tile_px'))
+            except Exception as e:
+                s_box_draw = float(getattr(self, 'tile_px')) / max(1.0, float(getattr(self, 'mag_ratio', 1)))
+            try:
+                t_box_draw = float(getattr(self, 'target_tile_px'))
+            except Exception as e:
+                t_box_draw = float(getattr(self, 'tile_px'))
 
         # ----- 4) Draw rectangles (centers are already in DRAW coordinates) -----
         def _draw(centers_draw, box_draw, color, width, label):

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -269,13 +269,6 @@ class LowerMagSlideReport(SlideReport):
         self.source_tile_um = source_tile_um
         self.mag_ratio = int(mag_ratio)
         self.source_thumb_coords = source_thumb_coords
-        
-        # Log received tile sizes for debugging
-        import slideflow as sf
-        sf.util.log.debug(f"LowerMagSlideReport initialized for {path}:")
-        sf.util.log.debug(f"  Target tile_px: {tile_px}px @ {tile_um}")
-        sf.util.log.debug(f"  Source tile_um: {source_tile_um}")
-        sf.util.log.debug(f"  Mag ratio: {mag_ratio}x")
 
     @property
     def combination_efficiency(self) -> Optional[float]:
@@ -331,7 +324,7 @@ class LowerMagSlideReport(SlideReport):
                     
         except Exception as e:
             import slideflow as sf
-            sf.util.log.debug(f"Error finding target TFRecord path: {e}")
+            log.debug(f"Error finding target TFRecord path: {e}")
             
         return None
     
@@ -354,12 +347,10 @@ class LowerMagSlideReport(SlideReport):
             target_tfrecord_path = self._get_target_tfrecord_path()
             if target_tfrecord_path:
                 try:
-                    import slideflow as sf
                     target_coords = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
-                    sf.util.log.debug(f"Using target coordinates from TFRecord: {len(target_coords)} target tiles")
                     return target_coords
                 except Exception as e:
-                    sf.util.log.debug(f"Could not read target TFRecord {target_tfrecord_path}: {e}")
+                    log.debug(f"Could not read target TFRecord {target_tfrecord_path}: {e}")
         
         # First check if we have the combined_grid_coords attribute set directly  
         if hasattr(self, 'combined_grid_coords') and self.combined_grid_coords:
@@ -424,7 +415,7 @@ class LowerMagSlideReport(SlideReport):
         try:
             W0, H0 = wsi.slide.level_dimensions[0]   # level-0 size in px
         except Exception as e:
-            sf.util.log.warning(f"Could not read level-0 dimensions for {self.path}: {e}")
+            log.warning(f"Could not read level-0 dimensions for {self.path}: {e}")
             self._thumb = thumb
             return
 
@@ -479,59 +470,36 @@ class LowerMagSlideReport(SlideReport):
                 else:
                     # Absolute fallback: assume draw==level-0 (no extra scaling)
                     d_draw = 1.0
-                    sf.util.log.debug("[calc_thumb] Falling back to d_draw=1.0 (no draw-level metadata).")
+                    log.debug("[calc_thumb] Falling back to d_draw=1.0 (no draw-level metadata).")
 
         scale_draw_to_thumb = d_draw * (thumb.width / float(W0))
-
-        sf.util.log.debug(
-            f"[calc_thumb] base_mpp={base_mpp:.6f}, mpp_draw={mpp_draw if mpp_draw else 'N/A'}, "
-            f"d_draw={d_draw:.6f}, W0={W0}, thumbW={thumb.width}, "
-            f"scale_draw_to_thumb={scale_draw_to_thumb:.8f}"
-        )
-        sf.util.log.debug(f"DEBUG: Thumb size: {thumb.width}x{thumb.height}")
-        sf.util.log.debug(f"DEBUG: Level-0 dimensions: {W0}x{H0}")
-        sf.util.log.debug(f"DEBUG: Raw scale factor (thumb.width/W0): {thumb.width / float(W0):.8f}")
-        
-        # The coordinates are now properly scaled in dataset.py, no additional mag_ratio correction needed
-        sf.util.log.debug(f"DEBUG: Using original scale without mag_ratio correction: {scale_draw_to_thumb:.8f}")
 
         # ----- 3) Resolve box sizes at DRAW level (you set these on the report) -----
         # If not set, fall back to reasonable derivations (still no hardcoded constants).
         try:
             s_box_draw = float(getattr(self, 'source_tile_px'))  # e.g., 128 if 40→10
-            sf.util.log.debug(f"DEBUG: Got source_tile_px from attribute: {s_box_draw}")
         except Exception as e:
             # Derive from report tile_px and mag_ratio if present
             s_box_draw = float(getattr(self, 'tile_px', 512)) / max(1.0, float(getattr(self, 'mag_ratio', 1)))
-            sf.util.log.debug(f"DEBUG: Derived s_box_draw from tile_px/mag_ratio: {s_box_draw} (tile_px={getattr(self, 'tile_px', 512)}, mag_ratio={getattr(self, 'mag_ratio', 1)})")
         try:
             t_box_draw = float(getattr(self, 'target_tile_px'))  # e.g., 512 at draw level
-            sf.util.log.debug(f"DEBUG: Got target_tile_px from attribute: {t_box_draw}")
         except Exception as e:
             t_box_draw = float(getattr(self, 'tile_px', 512))
-            sf.util.log.debug(f"DEBUG: Derived t_box_draw from tile_px: {t_box_draw}")
 
         # ----- 4) Draw rectangles (centers are already in DRAW coordinates) -----
         def _draw(centers_draw, box_draw, color, width, label):
-            sf.util.log.debug(f"DEBUG: _draw called for {label}")
-            sf.util.log.debug(f"DEBUG: centers_draw: {centers_draw}")
-            sf.util.log.debug(f"DEBUG: box_draw: {box_draw}, color: {color}, width: {width}")
             if centers_draw is None:
-                sf.util.log.debug(f"DEBUG: {label} centers_draw is None - no rectangles will be drawn")
                 return
             if len(centers_draw) == 0:
-                sf.util.log.debug(f"DEBUG: {label} centers_draw is empty - no rectangles will be drawn")
                 return
-            sf.util.log.debug(f"DEBUG: {label} has {len(centers_draw)} coordinates to draw")
             half = box_draw / 2.0
             w_th = box_draw * scale_draw_to_thumb
-            sf.util.log.debug(f"DEBUG: half={half:.2f}, w_th={w_th:.2f}, scale_draw_to_thumb={scale_draw_to_thumb:.8f}")
             for i, coord_pair in enumerate(centers_draw):
                 # Handle both (x, y) tuples and [x, y] arrays
                 if len(coord_pair) == 2:
                     cx, cy = coord_pair[0], coord_pair[1]
                 else:
-                    sf.util.log.error(f"DEBUG: Invalid coordinate format: {coord_pair}")
+                    log.error(f"DEBUG: Invalid coordinate format: {coord_pair}")
                     continue
                 x_draw = float(cx) - half
                 y_draw = float(cy) - half
@@ -539,55 +507,23 @@ class LowerMagSlideReport(SlideReport):
                 y_th = y_draw * scale_draw_to_thumb
                 rect_coords = [x_th, y_th, x_th + w_th, y_th + w_th]
                 draw.rectangle(rect_coords, outline=color, width=width)
-                if i < 5:  # Limit debug output to first 5 rectangles only
-                    sf.util.log.debug(
-                        f"DEBUG: {label}[{i}] center=({cx},{cy}) → draw=({x_draw:.2f},{y_draw:.2f}) → "
-                        f"thumb rect=({x_th:.2f},{y_th:.2f},{x_th+w_th:.2f},{y_th+w_th:.2f}) color={color}"
-                    )
-                elif i == 5:
-                    sf.util.log.debug(f"DEBUG: ... and {len(centers_draw)-5} more rectangles")
 
         source_coords = getattr(self, 'source_thumb_coords', None)
         target_coords = getattr(self, 'target_thumb_coords', None)
         
-        sf.util.log.debug(f"DEBUG: About to draw source and target coordinates")
-        sf.util.log.debug(f"DEBUG: source_thumb_coords type: {type(source_coords)}")
-        sf.util.log.debug(f"DEBUG: target_thumb_coords type: {type(target_coords)}")
-        
         # Debug the actual coordinate values received in calc_thumb
-        if source_coords is not None:
-            sf.util.log.debug(f"DEBUG: source_coords shape: {source_coords.shape if hasattr(source_coords, 'shape') else 'no shape'}")
-            sf.util.log.debug(f"DEBUG: source_coords sample received in calc_thumb: {source_coords[:3] if len(source_coords) > 0 else 'empty'}")
-        else:
-            sf.util.log.debug(f"DEBUG: source_coords is None in calc_thumb")
+        if source_coords is None:
+            log.debug(f"DEBUG: source_coords is None in calc_thumb")
             
-        if target_coords is not None:
-            sf.util.log.debug(f"DEBUG: target_coords shape: {target_coords.shape if hasattr(target_coords, 'shape') else 'no shape'}")  
-            sf.util.log.debug(f"DEBUG: target_coords sample received in calc_thumb: {target_coords[:3] if len(target_coords) > 0 else 'empty'}")
-        else:
-            sf.util.log.debug(f"DEBUG: target_coords is None in calc_thumb")
+        if target_coords is None:
+            log.debug(f"DEBUG: target_coords is None in calc_thumb")
         
         # Use black for source tiles, red for target tiles - with thin lines
         _draw(source_coords, s_box_draw, (0, 0, 0), 2, "SOURCE")
         _draw(target_coords, t_box_draw, (255, 0, 0), 3, "TARGET_RED") 
         
-        # Test rectangles removed - coordinate scaling is working correctly
-
         # ----- 5) Save -----
         self._thumb = thumb
-
-        # Debug: Save a test image to verify rectangles are actually drawn
-        try:
-            import os
-            os.makedirs("data/slides/thumbs", exist_ok=True)
-            debug_path = f"data/slides/thumbs/debug_thumb_{os.path.basename(self.path)}.png"
-            thumb.save(debug_path)
-            sf.util.log.debug(f"DEBUG: Saved thumbnail with overlays to {debug_path}")
-            sf.util.log.debug(f"DEBUG: Thumbnail size: {thumb.size}, mode: {thumb.mode}")
-        except Exception as e:
-            sf.util.log.error(f"DEBUG: Failed to save debug thumbnail for {self.path}: {e}")
-            import traceback
-            sf.util.log.error(f"DEBUG: Traceback: {traceback.format_exc()}")
 
     def create_combination_visualization(self) -> Optional[bytes]:
         """Create a visualization showing source→target tile relationships."""

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -394,8 +394,8 @@ class LowerMagSlideReport(SlideReport):
         try:
             wsi = sf.WSI(
                 self.path,
-                tile_px=getattr(self, 'tile_px', 512),
-                tile_um=getattr(self, 'tile_um', '10x'),
+                tile_px=getattr(self, 'tile_px'),
+                tile_um=getattr(self, 'tile_um'),
                 verbose=False,
             )
         except Exception as e:
@@ -420,7 +420,7 @@ class LowerMagSlideReport(SlideReport):
 
             # Try to generate a basic thumbnail safely; if that fails, create a blank placeholder.
             try:
-                base_thumb = sf.WSI(self.path, tile_px=getattr(self, 'tile_px', 512)).thumb(
+                base_thumb = sf.WSI(self.path, tile_px=getattr(self, 'tile_px', 512), tile_um=getattr(self, 'tile_um')).thumb(
                     coords=None, rois=getattr(self, 'has_rois', False), low_res=True, width=1024, rect_linewidth=1
                 )
                 thumb = Image.fromarray(np.asarray(base_thumb)[:, :, :3])

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -10,11 +10,11 @@ import numpy as np
 import cv2
 
 from fpdf import FPDF, XPos, YPos
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageDraw, UnidentifiedImageError
 from datetime import datetime
 from os.path import join, exists
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING, Tuple
 
 import slideflow as sf
 from slideflow.util import log, path_to_name  # noqa F401
@@ -234,6 +234,447 @@ class SlideReport:
             row_image.save(output, format="JPEG", quality=75)
             return output.getvalue()
 
+# -----------------------------------------------------------------------------
+
+class LowerMagSlideReport(SlideReport):
+    """Report for lower magnification tile extraction (e.g., 40x → 10x)."""
+
+    def __init__(
+        self,
+        images: List[bytes],
+        path: str,
+        tile_px: int,
+        tile_um: Union[int, str],
+        source_tile_um: Union[int, str],
+        mag_ratio: int,
+        *,
+        thumb: Optional[Image.Image] = None,
+        thumb_coords: Optional[np.ndarray] = None,
+        source_thumb_coords: Optional[np.ndarray] = None,
+        data: Optional[Dict[str, Any]] = None,
+        compress: bool = True,
+        ignore_thumb_errors: bool = False
+    ) -> None:
+        super().__init__(
+            images=images,
+            path=path,
+            tile_px=tile_px,
+            tile_um=tile_um,
+            thumb=thumb,
+            thumb_coords=thumb_coords,
+            data=data,
+            compress=compress,
+            ignore_thumb_errors=ignore_thumb_errors
+        )
+        self.source_tile_um = source_tile_um
+        self.mag_ratio = int(mag_ratio)
+        self.source_thumb_coords = source_thumb_coords
+        
+        # Log received tile sizes for debugging
+        import slideflow as sf
+        sf.util.log.debug(f"LowerMagSlideReport initialized for {path}:")
+        sf.util.log.debug(f"  Target tile_px: {tile_px}px @ {tile_um}")
+        sf.util.log.debug(f"  Source tile_um: {source_tile_um}")
+        sf.util.log.debug(f"  Mag ratio: {mag_ratio}x")
+
+    @property
+    def combination_efficiency(self) -> Optional[float]:
+        """% of source tiles successfully combined into target tiles."""
+        total_source = self.data.get('total_source_tiles', 0)
+        used_source = self.data.get('source_tiles_used', 0)
+        if not total_source:
+            return None
+        return (used_source / total_source) * 100.0
+
+    @property
+    def spatial_coverage_reduction(self) -> Optional[float]:
+        """% reduction in number of tiles (spatial coverage)."""
+        total_source = self.data.get('total_source_tiles', 0)
+        num_combined = self.data.get('num_tiles', 0)
+        if not total_source:
+            return None
+        return (1.0 - (num_combined / total_source)) * 100.0
+
+    @property
+    def incomplete_groups_percent(self) -> Optional[float]:
+        """% of tile groups that were incomplete."""
+        incomplete = self.data.get('incomplete_groups', 0)
+        combined = self.data.get('num_tiles', 0)
+        total_groups = incomplete + combined
+        if not total_groups:
+            return None
+        return (incomplete / total_groups) * 100.0
+
+    def _get_target_tfrecord_path(self) -> Optional[str]:
+        """Get the path to the target TFRecord file for this slide."""
+        try:
+            import slideflow as sf
+            from os.path import exists, join
+            
+            # Build target TFRecord path based on slide name and magnifications
+            slide_name = sf.util.path_to_name(self.path)
+            
+            # Construct target directory name: "{target_px}px_{target_mag}_from_{source_mag}"
+            target_px = getattr(self, 'target_tile_px', self.tile_px)  # Default to current tile_px if not set
+            source_mag = getattr(self, 'source_tile_um', '40x')
+            target_mag = getattr(self, 'tile_um', '10x')
+            
+            target_dir_name = f"{target_px}px_{target_mag}_from_{source_mag}"
+            
+            # Look for TFRecord in project structure
+            # Assuming we can get to the project root from self.path
+            project_root = self._find_project_root()
+            if project_root:
+                target_path = join(project_root, 'tfrecords', target_dir_name, f"{slide_name}.tfrecords")
+                if exists(target_path):
+                    return target_path
+                    
+        except Exception as e:
+            import slideflow as sf
+            sf.util.log.debug(f"Error finding target TFRecord path: {e}")
+            
+        return None
+    
+    def _find_project_root(self) -> Optional[str]:
+        """Find the project root directory."""
+        from os.path import dirname, exists, join
+        
+        # Start from slide path and work up to find project root
+        current = dirname(self.path)
+        for _ in range(5):  # Limit search depth
+            if exists(join(current, 'tfrecords')):
+                return current
+            current = dirname(current)
+        return None
+
+    def _extract_target_locations(self) -> List[Tuple[int, int]]:
+        """Return target grid locations as list of (grid_x, grid_y)."""
+        # Try to read target coordinates directly from the target TFRecord
+        if hasattr(self, 'source_tile_um') and hasattr(self, 'tile_um'):
+            target_tfrecord_path = self._get_target_tfrecord_path()
+            if target_tfrecord_path:
+                try:
+                    import slideflow as sf
+                    target_coords = sf.io.get_locations_from_tfrecord(target_tfrecord_path)
+                    sf.util.log.debug(f"Using target coordinates from TFRecord: {len(target_coords)} target tiles")
+                    return target_coords
+                except Exception as e:
+                    sf.util.log.debug(f"Could not read target TFRecord {target_tfrecord_path}: {e}")
+        
+        # First check if we have the combined_grid_coords attribute set directly  
+        if hasattr(self, 'combined_grid_coords') and self.combined_grid_coords:
+            return list(self.combined_grid_coords)
+        
+        # Otherwise look in the data dict
+        locs = self.data.get('locations')
+        if locs is None:
+            return []
+        # If DataFrame, prefer grid_x/grid_y; fall back to loc_x/loc_y if those are grids
+        if isinstance(locs, pd.DataFrame):
+            if {'grid_x', 'grid_y'}.issubset(locs.columns):
+                gx = locs['grid_x'].astype(int).tolist()
+                gy = locs['grid_y'].astype(int).tolist()
+                return list(zip(gx, gy))
+            elif {'loc_x', 'loc_y'}.issubset(locs.columns):
+                # assume loc_* are already grid indices at lower mag
+                gx = locs['loc_x'].astype(int).tolist()
+                gy = locs['loc_y'].astype(int).tolist()
+                return list(zip(gx, gy))
+            else:
+                return []
+        # Else assume iterable of tuples
+        try:
+            out = []
+            for t in locs:
+                if isinstance(t, (tuple, list)) and len(t) >= 2:
+                    out.append((int(t[0]), int(t[1])))
+            return out
+        except Exception:
+            return []
+
+    def calc_thumb(self) -> None:
+        """Draw source (black) and target (red) overlays on the WSI thumbnail.
+        Magnification-agnostic: no hardcoded DS/512/10x. Uses slide metadata + report fields."""
+        import numpy as np
+        from PIL import Image, ImageDraw
+        import slideflow as sf
+
+        # ----- 0) Open WSI (params here don't affect geometry; we map via level-0 size) -----
+        try:
+            wsi = sf.WSI(
+                self.path,
+                tile_px=getattr(self, 'tile_px', 512),
+                tile_um=getattr(self, 'tile_um', '10x'),
+                verbose=False,
+            )
+        except sf.errors.SlideMissingMPPError:
+            wsi = sf.WSI(
+                self.path,
+                tile_px=getattr(self, 'tile_px', 512),
+                tile_um=getattr(self, 'tile_um', '10x'),
+                verbose=False,
+                mpp=1.0,  # fallback; only ratios matter downstream
+            )
+
+        # ----- 1) Build thumbnail & get level-0 geometry -----
+        base_thumb = wsi.thumb(coords=None, rois=self.has_rois, low_res=True, width=1024, rect_linewidth=1)
+        thumb = Image.fromarray(np.asarray(base_thumb)[:, :, :3])
+        draw = ImageDraw.Draw(thumb)
+
+        try:
+            W0, H0 = wsi.slide.level_dimensions[0]   # level-0 size in px
+        except Exception as e:
+            sf.util.log.warning(f"Could not read level-0 dimensions for {self.path}: {e}")
+            self._thumb = thumb
+            return
+
+        # ----- 2) Compute DRAW→THUMB scale (pure geometry, no hardcodes) -----
+        # We assume all centers passed in are at the DRAW level (your target space).
+        # Map DRAW px -> level-0 px with factor d_draw (level-0 px per DRAW px).
+        # Then map level-0 px -> thumb px by (thumb.width / W0).
+        #
+        # d_draw is derived from either:
+        #   (a) draw-level mpp = tile_um / tile_px        -> d_draw = mpp_draw / base_mpp
+        #   (b) draw magnification "Nx"                   -> d_draw = 10 / (mag_draw * base_mpp)
+        #
+        # We compute both paths and use whatever is available.
+
+        # base_mpp (µm/px) at level-0
+        try:
+            base_mpp = float(getattr(wsi, 'mpp', 0.0)) or float(getattr(wsi, 'level_mpp', [0.0])[0] or 0.0)
+            if base_mpp <= 0:
+                raise ValueError
+        except Exception:
+            base_mpp = 0.25  # conservative fallback; only affects absolute scale on the thumbnail
+
+        # Prefer a physical mpp for the DRAW level, else fall back to magnification strings
+        mpp_draw = None
+        try:
+            # If tile_um is numeric microns and tile_px is the draw-level px edge, we can get mpp_draw directly
+            if isinstance(self.tile_um, (int, float)) and isinstance(self.tile_px, (int, float)) and self.tile_px > 0:
+                mpp_draw = float(self.tile_um) / float(self.tile_px)  # µm per DRAW px
+        except Exception:
+            mpp_draw = None
+
+        if mpp_draw and mpp_draw > 0:
+            d_draw = mpp_draw / base_mpp
+        else:
+            # Fallback: try to parse a magnification string for the DRAW level
+            def _to_mag(val):
+                try:
+                    return float(sf.util.to_mag(val)) if isinstance(val, str) else float(val)
+                except Exception:
+                    return None
+
+            mag_draw = _to_mag(getattr(self, 'tile_um', None))
+            if mag_draw and mag_draw > 0:
+                d_draw = 10.0 / (mag_draw * base_mpp)
+            else:
+                # Last resort: infer draw mag from source mag and mag_ratio if available
+                src_mag = _to_mag(getattr(self, 'source_tile_um', None))
+                ratio  = float(getattr(self, 'mag_ratio', 0) or 0)
+                if src_mag and ratio and ratio > 0:
+                    mag_draw = src_mag / ratio
+                    d_draw = 10.0 / (mag_draw * base_mpp)
+                else:
+                    # Absolute fallback: assume draw==level-0 (no extra scaling)
+                    d_draw = 1.0
+                    sf.util.log.debug("[calc_thumb] Falling back to d_draw=1.0 (no draw-level metadata).")
+
+        scale_draw_to_thumb = d_draw * (thumb.width / float(W0))
+
+        sf.util.log.debug(
+            f"[calc_thumb] base_mpp={base_mpp:.6f}, mpp_draw={mpp_draw if mpp_draw else 'N/A'}, "
+            f"d_draw={d_draw:.6f}, W0={W0}, thumbW={thumb.width}, "
+            f"scale_draw_to_thumb={scale_draw_to_thumb:.8f}"
+        )
+        sf.util.log.debug(f"DEBUG: Thumb size: {thumb.width}x{thumb.height}")
+        sf.util.log.debug(f"DEBUG: Level-0 dimensions: {W0}x{H0}")
+        sf.util.log.debug(f"DEBUG: Raw scale factor (thumb.width/W0): {thumb.width / float(W0):.8f}")
+        
+        # The coordinates are now properly scaled in dataset.py, no additional mag_ratio correction needed
+        sf.util.log.debug(f"DEBUG: Using original scale without mag_ratio correction: {scale_draw_to_thumb:.8f}")
+
+        # ----- 3) Resolve box sizes at DRAW level (you set these on the report) -----
+        # If not set, fall back to reasonable derivations (still no hardcoded constants).
+        try:
+            s_box_draw = float(getattr(self, 'source_tile_px'))  # e.g., 128 if 40→10
+            sf.util.log.debug(f"DEBUG: Got source_tile_px from attribute: {s_box_draw}")
+        except Exception as e:
+            # Derive from report tile_px and mag_ratio if present
+            s_box_draw = float(getattr(self, 'tile_px', 512)) / max(1.0, float(getattr(self, 'mag_ratio', 1)))
+            sf.util.log.debug(f"DEBUG: Derived s_box_draw from tile_px/mag_ratio: {s_box_draw} (tile_px={getattr(self, 'tile_px', 512)}, mag_ratio={getattr(self, 'mag_ratio', 1)})")
+        try:
+            t_box_draw = float(getattr(self, 'target_tile_px'))  # e.g., 512 at draw level
+            sf.util.log.debug(f"DEBUG: Got target_tile_px from attribute: {t_box_draw}")
+        except Exception as e:
+            t_box_draw = float(getattr(self, 'tile_px', 512))
+            sf.util.log.debug(f"DEBUG: Derived t_box_draw from tile_px: {t_box_draw}")
+
+        # ----- 4) Draw rectangles (centers are already in DRAW coordinates) -----
+        def _draw(centers_draw, box_draw, color, width, label):
+            sf.util.log.debug(f"DEBUG: _draw called for {label}")
+            sf.util.log.debug(f"DEBUG: centers_draw: {centers_draw}")
+            sf.util.log.debug(f"DEBUG: box_draw: {box_draw}, color: {color}, width: {width}")
+            if centers_draw is None:
+                sf.util.log.debug(f"DEBUG: {label} centers_draw is None - no rectangles will be drawn")
+                return
+            if len(centers_draw) == 0:
+                sf.util.log.debug(f"DEBUG: {label} centers_draw is empty - no rectangles will be drawn")
+                return
+            sf.util.log.debug(f"DEBUG: {label} has {len(centers_draw)} coordinates to draw")
+            half = box_draw / 2.0
+            w_th = box_draw * scale_draw_to_thumb
+            sf.util.log.debug(f"DEBUG: half={half:.2f}, w_th={w_th:.2f}, scale_draw_to_thumb={scale_draw_to_thumb:.8f}")
+            for i, coord_pair in enumerate(centers_draw):
+                # Handle both (x, y) tuples and [x, y] arrays
+                if len(coord_pair) == 2:
+                    cx, cy = coord_pair[0], coord_pair[1]
+                else:
+                    sf.util.log.error(f"DEBUG: Invalid coordinate format: {coord_pair}")
+                    continue
+                x_draw = float(cx) - half
+                y_draw = float(cy) - half
+                x_th = x_draw * scale_draw_to_thumb
+                y_th = y_draw * scale_draw_to_thumb
+                rect_coords = [x_th, y_th, x_th + w_th, y_th + w_th]
+                draw.rectangle(rect_coords, outline=color, width=width)
+                if i < 5:  # Limit debug output to first 5 rectangles only
+                    sf.util.log.debug(
+                        f"DEBUG: {label}[{i}] center=({cx},{cy}) → draw=({x_draw:.2f},{y_draw:.2f}) → "
+                        f"thumb rect=({x_th:.2f},{y_th:.2f},{x_th+w_th:.2f},{y_th+w_th:.2f}) color={color}"
+                    )
+                elif i == 5:
+                    sf.util.log.debug(f"DEBUG: ... and {len(centers_draw)-5} more rectangles")
+
+        source_coords = getattr(self, 'source_thumb_coords', None)
+        target_coords = getattr(self, 'target_thumb_coords', None)
+        
+        sf.util.log.debug(f"DEBUG: About to draw source and target coordinates")
+        sf.util.log.debug(f"DEBUG: source_thumb_coords type: {type(source_coords)}")
+        sf.util.log.debug(f"DEBUG: target_thumb_coords type: {type(target_coords)}")
+        
+        # Debug the actual coordinate values received in calc_thumb
+        if source_coords is not None:
+            sf.util.log.debug(f"DEBUG: source_coords shape: {source_coords.shape if hasattr(source_coords, 'shape') else 'no shape'}")
+            sf.util.log.debug(f"DEBUG: source_coords sample received in calc_thumb: {source_coords[:3] if len(source_coords) > 0 else 'empty'}")
+        else:
+            sf.util.log.debug(f"DEBUG: source_coords is None in calc_thumb")
+            
+        if target_coords is not None:
+            sf.util.log.debug(f"DEBUG: target_coords shape: {target_coords.shape if hasattr(target_coords, 'shape') else 'no shape'}")  
+            sf.util.log.debug(f"DEBUG: target_coords sample received in calc_thumb: {target_coords[:3] if len(target_coords) > 0 else 'empty'}")
+        else:
+            sf.util.log.debug(f"DEBUG: target_coords is None in calc_thumb")
+        
+        # Use black for source tiles, red for target tiles - with thin lines
+        _draw(source_coords, s_box_draw, (0, 0, 0), 2, "SOURCE")
+        _draw(target_coords, t_box_draw, (255, 0, 0), 2.5, "TARGET_RED") 
+        
+        # Test rectangles removed - coordinate scaling is working correctly
+
+        # ----- 5) Save -----
+        self._thumb = thumb
+
+        # Debug: Save a test image to verify rectangles are actually drawn
+        import os
+        os.makedirs("data/slides/thumbs", exist_ok=True)
+        debug_path = f"data/slides/thumbs/debug_thumb_{os.path.basename(self.path)}.png"
+        thumb.save(debug_path)
+        sf.util.log.debug(f"DEBUG: Saved thumbnail with overlays to {debug_path}")
+        sf.util.log.debug(f"DEBUG: Thumbnail size: {thumb.size}, mode: {thumb.mode}")
+
+    def create_combination_visualization(self) -> Optional[bytes]:
+        """Create a visualization showing source→target tile relationships."""
+        target_locations = self._extract_target_locations()
+        if not target_locations:
+            return None
+        try:
+            import matplotlib.pyplot as plt
+            with sf.util.matplotlib_backend('Agg'):
+                fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+
+                # Estimate source locations by upsampling each target grid cell
+                src = []
+                R = self.mag_ratio
+                for tx, ty in target_locations:
+                    for i in range(R):
+                        for j in range(R):
+                            src.append((tx * R + i, ty * R + j))
+
+                if src:
+                    sx, sy = zip(*src)
+                    ax1.scatter(sx, sy, s=2, alpha=0.6)
+                    ax1.set_title(f'Source Tiles ({self.source_tile_um}) — est. {len(src)}')
+                    ax1.set_xlabel('Grid X'); ax1.set_ylabel('Grid Y'); ax1.grid(True, alpha=0.3)
+
+                tx, ty = zip(*target_locations)
+                ax2.scatter(tx, ty, s=8, alpha=0.8)
+                ax2.set_title(f'Combined Tiles ({self.tile_um}) — {len(target_locations)}')
+                ax2.set_xlabel('Grid X'); ax2.set_ylabel('Grid Y'); ax2.grid(True, alpha=0.3)
+
+                plt.tight_layout()
+                with tempfile.NamedTemporaryFile(suffix='.png') as temp:
+                    plt.savefig(temp.name, dpi=150, bbox_inches='tight')
+                    plt.close(fig)
+                    with open(temp.name, 'rb') as f:
+                        return f.read()
+        except Exception as e:
+            log.error(f"Error creating combination visualization for {self.path}: {e}")
+            return None
+
+    def create_before_after_comparison(self) -> Optional[bytes]:
+        """Create before/after example grids by visualizing a split of combined tiles."""
+        if not self.images:
+            return None
+        try:
+            import matplotlib.pyplot as plt
+            n_examples = min(3, len(self.images))
+            with sf.util.matplotlib_backend('Agg'):
+                fig, axes = plt.subplots(2, n_examples, figsize=(4*n_examples, 8))
+                # Normalize axes shape for n_examples==1
+                if n_examples == 1:
+                    axes = np.array([[axes[0]], [axes[1]]])
+
+                for i in range(n_examples):
+                    img = Image.open(io.BytesIO(self.images[i])).convert('RGB')
+                    axes[0, i].imshow(img)
+                    axes[0, i].set_title(f'Combined Tile {i+1} ({self.tile_um})')
+                    axes[0, i].axis('off')
+
+                    img_array = np.array(img)
+                    h, w = img_array.shape[:2]
+                    R = max(self.mag_ratio, 1)
+                    tile_h, tile_w = h // R, w // R
+                    before_grid = np.zeros_like(img_array)
+
+                    for r in range(R):
+                        for c in range(R):
+                            y0, y1 = r * tile_h, (r + 1) * tile_h
+                            x0, x1 = c * tile_w, (c + 1) * tile_w
+                            tile_region = img_array[y0:y1, x0:x1].copy()
+                            # white borders
+                            tile_region[:2, :] = 255
+                            tile_region[-2:, :] = 255
+                            tile_region[:, :2] = 255
+                            tile_region[:, -2:] = 255
+                            before_grid[y0:y1, x0:x1] = tile_region
+
+                    axes[1, i].imshow(before_grid)
+                    axes[1, i].set_title(f'Source Tiles ({self.source_tile_um}) — {R}×{R}')
+                    axes[1, i].axis('off')
+
+                plt.tight_layout()
+                with tempfile.NamedTemporaryFile(suffix='.png') as temp:
+                    plt.savefig(temp.name, dpi=150, bbox_inches='tight')
+                    plt.close(fig)
+                    with open(temp.name, 'rb') as f:
+                        return f.read()
+        except Exception as e:
+            log.error(f"Error creating before/after comparison for {self.path}: {e}")
+            return None
+
+# -----------------------------------------------------------------------------
 
 class ExtractionPDF(FPDF):
     # Length is 220
@@ -544,3 +985,124 @@ class ExtractionReport:
             df = pd.concat([df, ex_df[~ex_df.slide.isin(df.slide.unique())]])
         df.to_csv(filename, index=False)
         return df
+
+# -----------------------------------------------------------------------------
+
+class LowerMagExtractionReport(ExtractionReport):
+    """ExtractionReport variant for lower magnification tile extraction."""
+
+    def __init__(
+        self,
+        reports: List[LowerMagSlideReport],
+        meta: Optional[Any] = None,
+        title: str = 'Lower Magnification Tile Extraction Report',
+        *,
+        pool: Optional[Any] = None
+    ) -> None:
+        # Initialize parent (bb_threshold not really used here but keep signature)
+        super().__init__(
+            reports=reports,
+            meta=meta,
+            bb_threshold=0.05,
+            title=title,
+            pool=pool
+        )
+        # Add lower mag specific content to PDF
+        self._add_lower_mag_summary()
+        self._add_combination_metrics()
+        self._add_efficiency_charts()
+
+    def _add_lower_mag_summary(self) -> None:
+        pdf = self.pdf
+        # Aggregate stats safely
+        total_slides = len([r for r in self.reports if r is not None])
+        total_source_tiles = int(sum((r.data or {}).get('total_source_tiles', 0) for r in self.reports if r is not None))
+        total_combined_tiles = int(sum((r.data or {}).get('num_tiles', 0) for r in self.reports if r is not None))
+        total_discarded = int(sum((r.data or {}).get('discarded_tiles', 0) for r in self.reports if r is not None))
+
+        effs = [r.combination_efficiency for r in self.reports if r is not None and hasattr(r, 'combination_efficiency') and r.combination_efficiency is not None]
+        avg_efficiency = float(np.mean(effs)) if len(effs) else 0.0
+
+        pdf.set_font('Arial', 'B', 12)
+        pdf.cell(0, 10, 'Lower Magnification Extraction Summary', new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        pdf.ln(5)
+
+        pdf.set_font('Arial', '', 10)
+        summary_lines = [
+            f"Total slides processed: {total_slides}",
+            f"Source tiles processed: {total_source_tiles:,}",
+            f"Combined tiles created: {total_combined_tiles:,}",
+            f"Tiles discarded: {total_discarded:,}",
+            f"Average combination efficiency: {avg_efficiency:.1f}%"
+        ]
+        for line in summary_lines:
+            pdf.cell(0, 5, line, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        pdf.ln(10)
+
+    def _add_combination_metrics(self) -> None:
+        pdf = self.pdf
+        pdf.set_font('Arial', 'B', 11)
+        pdf.cell(0, 8, 'Tile Combination Metrics', new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        pdf.ln(3)
+
+        # Table header
+        pdf.set_font('Arial', 'B', 8)
+        pdf.cell(60, 6, 'Slide', 1, 0, 'C')
+        pdf.cell(25, 6, 'Source Tiles', 1, 0, 'C')
+        pdf.cell(25, 6, 'Combined', 1, 0, 'C')
+        pdf.cell(25, 6, 'Efficiency', 1, 0, 'C')
+        pdf.cell(25, 6, 'Coverage Red.', 1, 0, 'C')
+        pdf.cell(25, 6, 'Incomplete', 1, 1, 'C')
+
+        # Rows
+        pdf.set_font('Arial', '', 7)
+        for report in self.reports:
+            if report is None:
+                continue
+            slide_name = path_to_name(report.path)[:40]
+            data = report.data or {}
+            source_tiles = int(data.get('total_source_tiles', 0))
+            combined = int(data.get('num_tiles', 0))
+            efficiency = float(getattr(report, 'combination_efficiency', 0.0) or 0.0)
+            coverage_red = float(getattr(report, 'spatial_coverage_reduction', 0.0) or 0.0)
+            incomplete = float(getattr(report, 'incomplete_groups_percent', 0.0) or 0.0)
+
+            pdf.cell(60, 5, slide_name, 1, 0, 'L')
+            pdf.cell(25, 5, f"{source_tiles}", 1, 0, 'C')
+            pdf.cell(25, 5, f"{combined}", 1, 0, 'C')
+            pdf.cell(25, 5, f"{efficiency:.1f}%", 1, 0, 'C')
+            pdf.cell(25, 5, f"{coverage_red:.1f}%", 1, 0, 'C')
+            pdf.cell(25, 5, f"{incomplete:.1f}%", 1, 1, 'C')
+        pdf.ln(10)
+
+    def _add_efficiency_charts(self) -> None:
+        pdf = self.pdf
+        try:
+            import matplotlib.pyplot as plt
+            effs = [r.combination_efficiency for r in self.reports if r and hasattr(r, 'combination_efficiency') and r.combination_efficiency is not None]
+            covers = [r.spatial_coverage_reduction for r in self.reports if r and hasattr(r, 'spatial_coverage_reduction') and r.spatial_coverage_reduction is not None]
+            if not (effs and covers):
+                return
+            with sf.util.matplotlib_backend('Agg'):
+                fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
+
+                ax1.hist(effs, bins=10, alpha=0.9, edgecolor='black')
+                ax1.set_xlabel('Combination Efficiency (%)')
+                ax1.set_ylabel('Number of Slides')
+                ax1.set_title('Tile Combination Efficiency')
+                ax1.grid(True, alpha=0.3)
+
+                ax2.hist(covers, bins=10, alpha=0.9, edgecolor='black')
+                ax2.set_xlabel('Spatial Coverage Reduction (%)')
+                ax2.set_ylabel('Number of Slides')
+                ax2.set_title('Coverage Reduction')
+                ax2.grid(True, alpha=0.3)
+
+                plt.tight_layout()
+                with tempfile.NamedTemporaryFile(suffix='.png') as temp:
+                    plt.savefig(temp.name, dpi=150, bbox_inches='tight')
+                    pdf.image(temp.name, 10, pdf.y, w=190)
+                    plt.close(fig)
+                pdf.ln(60)
+        except Exception as e:
+            log.error(f"Error creating efficiency charts: {e}")

--- a/slideflow/slide/report.py
+++ b/slideflow/slide/report.py
@@ -309,8 +309,8 @@ class LowerMagSlideReport(SlideReport):
             
             # Construct target directory name: "{target_px}px_{target_mag}_from_{source_mag}"
             target_px = getattr(self, 'target_tile_px', self.tile_px)  # Default to current tile_px if not set
-            source_mag = getattr(self, 'source_tile_um', '40x')
-            target_mag = getattr(self, 'tile_um', '10x')
+            source_mag = getattr(self, 'source_tile_um')
+            target_mag = getattr(self, 'tile_um')
             
             target_dir_name = f"{target_px}px_{target_mag}_from_{source_mag}"
             
@@ -398,14 +398,39 @@ class LowerMagSlideReport(SlideReport):
                 tile_um=getattr(self, 'tile_um', '10x'),
                 verbose=False,
             )
-        except sf.errors.SlideMissingMPPError:
-            wsi = sf.WSI(
-                self.path,
-                tile_px=getattr(self, 'tile_px', 512),
-                tile_um=getattr(self, 'tile_um', '10x'),
-                verbose=False,
-                mpp=1.0,  # fallback; only ratios matter downstream
+        except Exception as e:
+            # If slideflow exposes specific error types, include them; otherwise catch generic Exception.
+            try:
+                SlideLoadError = sf.errors.SlideLoadError
+                SlideMissingMPPError = sf.errors.SlideMissingMPPError
+            except Exception:
+                SlideLoadError = None
+                SlideMissingMPPError = None
+
+            is_slide_error = (
+                (SlideLoadError and isinstance(e, SlideLoadError)) or
+                (SlideMissingMPPError and isinstance(e, SlideMissingMPPError))
             )
+
+            # Log and gracefully skip this slide's overlay drawing.
+            log.warning(f"Skipping thumbnail overlay for {self.path} due to WSI open error: {e}")
+            # Mark as skipped so higher-level reports can count this.
+            self.data = self.data or {}
+            self.data['skipped'] = True
+
+            # Try to generate a basic thumbnail safely; if that fails, create a blank placeholder.
+            try:
+                base_thumb = sf.WSI(self.path, tile_px=getattr(self, 'tile_px', 512)).thumb(
+                    coords=None, rois=getattr(self, 'has_rois', False), low_res=True, width=1024, rect_linewidth=1
+                )
+                thumb = Image.fromarray(np.asarray(base_thumb)[:, :, :3])
+            except Exception as e_thumb:
+                log.debug(f"Couldn't create fallback thumbnail for {self.path}: {e_thumb}; using blank placeholder.")
+                thumb = Image.new('RGB', (1024, 1024), (255, 255, 255))
+
+            # Save placeholder and exit early — don't attempt any overlay drawing.
+            self._thumb = thumb
+            return
 
         # ----- 1) Build thumbnail & get level-0 geometry -----
         base_thumb = wsi.thumb(coords=None, rois=self.has_rois, low_res=True, width=1024, rect_linewidth=1)
@@ -480,11 +505,11 @@ class LowerMagSlideReport(SlideReport):
             s_box_draw = float(getattr(self, 'source_tile_px'))  # e.g., 128 if 40→10
         except Exception as e:
             # Derive from report tile_px and mag_ratio if present
-            s_box_draw = float(getattr(self, 'tile_px', 512)) / max(1.0, float(getattr(self, 'mag_ratio', 1)))
+            s_box_draw = float(getattr(self, 'tile_px')) / max(1.0, float(getattr(self, 'mag_ratio', 1)))
         try:
             t_box_draw = float(getattr(self, 'target_tile_px'))  # e.g., 512 at draw level
         except Exception as e:
-            t_box_draw = float(getattr(self, 'tile_px', 512))
+            t_box_draw = float(getattr(self, 'tile_px'))
 
         # ----- 4) Draw rectangles (centers are already in DRAW coordinates) -----
         def _draw(centers_draw, box_draw, color, width, label):

--- a/slideflow/util/__init__.py
+++ b/slideflow/util/__init__.py
@@ -1553,12 +1553,30 @@ def tfrecord_heatmap(
     )
 
 
-def tile_size_label(tile_px: int, tile_um: Union[str, int]) -> str:
-    """Return the string label of the given tile size."""
+def tile_size_label(tile_px: int, tile_um: Union[str, int], source_um: Optional[Union[str, int]] = None) -> str:
+    """Return the string label of the given tile size.
+    
+    Args:
+        tile_px: Tile size in pixels
+        tile_um: Target magnification/tile size
+        source_um: Optional source magnification for downscaled tiles
+        
+    Returns:
+        String label like "224px_40x" or "224px_10x_from_40x" for downscaled tiles
+    """
     if isinstance(tile_um, str):
-        return f"{tile_px}px_{tile_um.lower()}"
+        base_label = f"{tile_px}px_{tile_um.lower()}"
     else:
-        return f"{tile_px}px_{tile_um}um"
+        base_label = f"{tile_px}px_{tile_um}um"
+    
+    if source_um is not None:
+        if isinstance(source_um, str):
+            source_label = source_um.lower()
+        else:
+            source_label = f"{source_um}um"
+        return f"{base_label}_from_{source_label}"
+    else:
+        return base_label
 
 
 def get_valid_model_dir(root: str) -> List:


### PR DESCRIPTION
# Dual Magnification Tile Extraction and Feature Concatenation

Comprehensive dual magnification tile extraction functionality. Tiles are extracted from existing high-magnification TFRecords, and concatenated features can be created from both magnifications for enhanced MIL training.

## New Features

### Dual Magnification Tile Extraction
- **`extract_lower_mag_tiles_from_tfr()`** - Extract lower magnification tiles by combining adjacent high-mag tiles
- **Integer-only magnifications** - Uses micron values (e.g., 112um) instead of string magnifications (e.g., '20x')
- **Multi-source support** - Process multiple dataset sources separately with organized outputs
- **Spatial tile grouping** - Reconstruction of tile spatial arrangements
- **Custom thumbnails** - Dual-colored overlays showing original and combined tiles
- **Enhanced reporting** - PDF and CSV reports with combination statistics per source

### Feature Concatenation for MIL
- **`DualMagnificationFeatures`** class for handling concatenated features
- **`extract_dual_magnification_features()`** - End-to-end dual-mag feature extraction with two modes:
  - **Mode 1 (Legacy)**: Direct directory specification
  - **Mode 2 (Multi-Source)**: Automatic directory discovery across multiple sources
- **Incremental feature saving** - Memory-efficient processing with resumability
- **MIL training compatibility** - Seamless integration with existing MIL pipeline
- **Traceability** - TFRecord directory paths saved in config for reproducibility

### New Report Classes
- **`LowerMagSlideReport`** - Specialized reports for dual-mag extraction
- **`LowerMagExtractionReport`** - Comprehensive extraction summaries

## Usage

### Step 1: Extract High Magnification Tiles
```python
# Extract tiles at high magnification (e.g., 112um = ~20x at 224px)
dataset = project.dataset(tile_px=224, tile_um=112)
reports = dataset.extract_tiles(save_tfrecords=True)
```

### Step 2: Extract Lower Magnification Tiles from TFRecords
```python
# Extract lower magnification tiles by combining high-mag tiles
# IMPORTANT: tile_um must be an integer (microns), not a string magnification
dataset = project.dataset(tile_px=224, tile_um=112)  # Integer only!

lower_mag_reports = dataset.extract_lower_mag_tiles_from_tfr(
    mag_ratio=4,              # 4x4 grid = 16 tiles combined into 1
    target_tile_px=224,       # Output tile size
    report=True,              # Generate PDF reports
    skip_extracted=True       # Skip already processed slides
)
```

**Multi-Source Example:**
```python
# Process multiple sources - reports/indices created per source
dataset = project.dataset(tile_px=224, tile_um=112, sources=['source1', 'source2'])
lower_mag_reports = dataset.extract_lower_mag_tiles_from_tfr(
    mag_ratio=4,
    target_tile_px=224,
    report=True
)
```

**Results:**
- Lower-mag TFRecords saved to `tfrecords/source1/224px_448um_from_112um/` (and source2, etc.)
- PDF reports generated per source
- Custom thumbnails with dual-colored overlays

### Step 3: Extract Features from Both Magnifications

**Mode 1: Direct Directories (Legacy)**
```python
# Specify exact TFRecord directories
dual_features = project.extract_dual_magnification_features(
    model_path='resnet18',
    output_dir='dual_mag_features',
    high_mag_tfr_dir='tfrecords/source1/224px_112um',
    low_mag_tfr_dir='tfrecords/source1/224px_448um_from_112um',
    min_tiles=5
)
```

**Mode 2: Multi-Source (Recommended)**
```python
# Automatic directory discovery across multiple sources
dual_features = project.extract_dual_magnification_features(
    model_path='resnet18',
    output_dir='dual_mag_features',
    sources=['source1', 'source2'],  # Process multiple sources
    high_mag_um=112,                 # Integer microns only
    low_mag_um=448,                  # Integer microns only
    tile_px=224,                     # Integer pixels
    mag_ratio=4,                     # Optional, inferred from magnifications
    min_tiles=5
)
```

**Results:**
- High-mag features: `dual_mag_features/high_mag_features/`
- Low-mag features: `dual_mag_features/low_mag_features/`
- Concatenated features: `dual_mag_features/concatenated_features/`
- All sources combined in same output directory
- Config file includes TFRecord directory paths for traceability

## Key Changes

### Integer-Only Magnifications
The `extract_lower_mag_tiles_from_tfr()` method now requires `tile_um` to be an integer representing microns, not a string magnification. This ensures consistent behavior across the dual magnification workflow.

### Multi-Source Organization
- **Tile Extraction**: TFRecords are organized by source (e.g., `tfrecords/source1/`, `tfrecords/source2/`)
- **Feature Extraction**: All sources combined into single output directory for MIL training

### Backward Compatibility
Mode 1 (direct directories) maintains full backward compatibility with existing code while Mode 2 provides enhanced multi-source support.
